### PR TITLE
Changed lambdas for `assert()`, `thrownError()`, `returnedValue()` an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ run even if the first one fails.
 ```kotlin
 val string = "Test"
 assert(string) {
-    it.startsWith("L")
-    it.hasLength(3)
+    startsWith("L")
+    hasLength(3)
 }
 // -> The following 2 assertions failed:
 //    - expected to start with:<"L"> but was:<"Test">
@@ -96,7 +96,7 @@ The first is to wrap in a `catch` block to store the result, then assert on that
 ```kotlin
 val exception = catch { throw Exception("error") }
 assert(exception).isNotNull {
-    it.hasMessage("wrong")
+    hasMessage("wrong")
 }
 // -> expected [message] to be:<["wrong"]> but was:<["error"]>
 ```
@@ -106,16 +106,16 @@ Your other option is to use an `assert` with a single lambda arg to capture the 
 ```kotlin
 assert {
     throw Exception("error")
-}.throwsError {
-    it.hasMessage("wrong")
+}.thrownError {
+    hasMessage("wrong")
 }
 // -> expected [message] to be:<["wrong"]> but was:<["error"]>
 ```
 
 This method also allows you to assert on return values.
 ```kotlin
-assert { 1 + 1 }.returnsValue {
-    it.isNegative()
+assert { 1 + 1 }.returnedValue {
+    isNegative()
 }
 // -> expected to be negative but was:<2>
 ```

--- a/src/main/kotlin/assertk/assert.kt
+++ b/src/main/kotlin/assertk/assert.kt
@@ -5,29 +5,29 @@ import assertk.assertions.support.show
 class Assert<out T> internal constructor(val name: String? = null, val actual: T)
 
 sealed class AssertBlock<out T> {
-    abstract fun throwsError(f: (Assert<Throwable>) -> Unit)
-    abstract fun returnsValue(f: (Assert<T>) -> Unit)
+    abstract fun thrownError(f: Assert<Throwable>.() -> Unit)
+    abstract fun returnedValue(f: Assert<T>.() -> Unit)
 
     class Value<out T> internal constructor(private val value: T) : AssertBlock<T>() {
-        override fun throwsError(f: (Assert<Throwable>) -> Unit) = fail("expected exception but was:${show(value)}")
+        override fun thrownError(f: Assert<Throwable>.() -> Unit) = fail("expected exception but was:${show(value)}")
 
-        override fun returnsValue(f: (Assert<T>) -> Unit) {
+        override fun returnedValue(f: Assert<T>.() -> Unit) {
             f(Assert(actual = value))
         }
     }
 
     class Error<out T> internal constructor(private val error: Throwable) : AssertBlock<T>() {
-        override fun throwsError(f: (Assert<Throwable>) -> Unit) {
+        override fun thrownError(f: Assert<Throwable>.() -> Unit) {
             f(Assert(actual = error))
         }
 
-        override fun returnsValue(f: (Assert<T>) -> Unit) = fail("expected value but threw:${show(error)}")
+        override fun returnedValue(f: Assert<T>.() -> Unit) = fail("expected value but threw:${show(error)}")
     }
 }
 
 fun <T> assert(actual: T, name: String? = null): Assert<T> = Assert(name, actual)
 
-fun <T> assert(actual: T, name: String? = null, f: (Assert<T>) -> Unit) {
+fun <T> assert(actual: T, name: String? = null, f: Assert<T>.() -> Unit) {
     FailureContext.run(SoftFailure()) {
         f(Assert(name, actual))
     }

--- a/src/test/kotlin/test/assertk/AssertBlockSpec.kt
+++ b/src/test/kotlin/test/assertk/AssertBlockSpec.kt
@@ -19,23 +19,23 @@ class AssertBlockSpec : Spek({
         }
 
         it("should pass a successful returns value assertion") {
-            subject.returnsValue {
-                it.isEqualTo(2)
+            subject.returnedValue {
+                isEqualTo(2)
             }
         }
 
         it("should fail an unsuccessful return value assertion") {
             Assertions.assertThatThrownBy {
-                subject.returnsValue {
-                    it.isNegative()
+                subject.returnedValue {
+                    isNegative()
                 }
             }.hasMessage("expected to be negative but was:<2>")
         }
 
         it("should fail a throws error assertion") {
             Assertions.assertThatThrownBy {
-                subject.throwsError {
-                    it.hasMessage("error")
+                subject.thrownError {
+                    hasMessage("error")
                 }
             }.hasMessage("expected exception but was:<2>")
         }
@@ -47,23 +47,23 @@ class AssertBlockSpec : Spek({
         }
 
         it("should pass a successful throws error assertion") {
-            subject.throwsError {
-                it.hasMessage("test")
+            subject.thrownError {
+                hasMessage("test")
             }
         }
 
         it("should fail a unsuccessful throws error assertion") {
             Assertions.assertThatThrownBy {
-                subject.throwsError {
-                    it.hasMessage("wrong")
+                subject.thrownError {
+                    hasMessage("wrong")
                 }
             }.hasMessage("expected [message]:<\"[wrong]\"> but was:<\"[test]\">")
         }
 
         it("should fail a returns value assertion") {
             Assertions.assertThatThrownBy {
-                subject.returnsValue {
-                    it.isPositive()
+                subject.returnedValue {
+                    isPositive()
                 }
             }.hasMessage("expected value but threw:<java.lang.Exception: test>")
         }

--- a/src/test/kotlin/test/assertk/AssertMultipleSpec.kt
+++ b/src/test/kotlin/test/assertk/AssertMultipleSpec.kt
@@ -16,16 +16,16 @@ class AssertMultipleSpec : Spek({
 
         it("should pass multiple successful assertions") {
             assert(subject) {
-                it.isInstanceOf(BasicObject::class)
-                it.hasToString("BasicObject(arg1=test, arg2=1)")
+                isInstanceOf(BasicObject::class)
+                hasToString("BasicObject(arg1=test, arg2=1)")
             }
         }
 
         it("should fail the first assertion") {
             Assertions.assertThatThrownBy {
                 assert<Any>(subject) {
-                    it.isInstanceOf(String::class)
-                    it.hasToString("BasicObject(arg1=test, arg2=1)")
+                    isInstanceOf(String::class)
+                    hasToString("BasicObject(arg1=test, arg2=1)")
                 }
             }.hasMessage("expected to be instance of:<java.lang.String> but had class:<test.assertk.AssertMultiple\$BasicObject>")
         }
@@ -33,8 +33,8 @@ class AssertMultipleSpec : Spek({
         it("should fail the second assertion") {
             Assertions.assertThatThrownBy {
                 assert(subject) {
-                    it.isInstanceOf(BasicObject::class)
-                    it.hasToString("wrong")
+                    isInstanceOf(BasicObject::class)
+                    hasToString("wrong")
                 }
             }.hasMessage("expected toString() to be:<\"wrong\"> but was:<\"BasicObject(arg1=test, arg2=1)\">")
         }
@@ -42,8 +42,8 @@ class AssertMultipleSpec : Spek({
         it("should fail both assertions") {
             Assertions.assertThatThrownBy {
                 assert<Any>(subject) {
-                    it.isInstanceOf(String::class)
-                    it.hasToString("wrong")
+                    isInstanceOf(String::class)
+                    hasToString("wrong")
                 }
             }.hasMessage("""The following 2 assertions failed:
 - expected to be instance of:<java.lang.String> but had class:<test.assertk.AssertMultiple${"$"}BasicObject>


### PR DESCRIPTION
…d isNotNull()

Changed the arg from a lambda arg to `this` to make the assertions
read better. For example, it's now

```
assert(string) {
    startsWith("L")
    hasLength(3)
}
```

Also changed `throwsError` to `thrownError` and `returnsValue` to
`returnedValue` since the will read better as nouns instead of verbs.

```
assert {
    throw Exception("error")
}.thrownError {
    hasMessage("error")
}
```