### PR TITLE
Fixes idea not able to run spek tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testCompile 'org.jetbrains.spek:spek-api:1.1.5'
     testRuntime 'org.jetbrains.spek:spek-junit-platform-engine:1.1.5'
+    testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile 'org.assertj:assertj-core:3.6.2'
 }
 


### PR DESCRIPTION
This should fix IntelliJ IDEA not being able to run Spek tests.

See: [https://github.com/raniejade/spek-idea-plugin#requirements](https://github.com/raniejade/spek-idea-plugin#requirements)

Fixes #27 