### PR TITLE
Add `it` in docs to ensure correct package usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The first is to wrap in a `catch` block to store the result, then assert on that
 ```kotlin
 val exception = catch { throw Exception("error") }
 assert(exception).isNotNull {
-    hasMessage("wrong")
+    it.hasMessage("wrong")
 }
 // -> expected [message] to be:<["wrong"]> but was:<["error"]>
 ```


### PR DESCRIPTION
Correcting the README to show that you need to  use `it.hasMessage(String)` 

If you do not then the IDE will continuously attempt to automatically add the following import
`import org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage` which may confuse some people