### PR TITLE
Pass context instead of parent assertion.

### DIFF
--- a/src/main/kotlin/assertk/assert.kt
+++ b/src/main/kotlin/assertk/assert.kt
@@ -6,7 +6,7 @@ import assertk.assertions.support.show
  * An assertion. Holds an actual value to assertion on and an optional name.
  * @see [assert]
  */
-class Assert<out T> internal constructor(val actual: T, val name: String? = null, val parent: Assert<*>? = null) {
+class Assert<out T> internal constructor(val actual: T, val name: String?, internal val context: Any?) {
     /**
      * Asserts on the given value with an optional name.
      *
@@ -14,14 +14,9 @@ class Assert<out T> internal constructor(val actual: T, val name: String? = null
      * assert(true, name = "true").isTrue()
      * ```
      */
-    fun <T> assert(actual: T, name: String? = this.name, parent: Assert<*>? = this)
-            : Assert<T> = Assert(actual, name, parent)
+    fun <R> assert(actual: R, name: String? = this.name)
+            : Assert<R> = Assert(actual, name, if (context != null || this.actual === actual) context else this.actual)
 }
-
-/**
- * The root actual value for an assertion. It will follow up parent assertions until it finds the top one.
- */
-fun <T> Assert<T>.rootActual(): Any? = if (parent != null) parent.rootActual() else actual
 
 /**
  * An assertion on a block of code. Can assert that it either throws and error or returns a value.
@@ -61,7 +56,7 @@ sealed class AssertBlock<out T> {
  * assert(true, name = "true").isTrue()
  * ```
  */
-fun <T> assert(actual: T, name: String? = null): Assert<T> = Assert(actual, name)
+fun <T> assert(actual: T, name: String? = null): Assert<T> = Assert(actual, name, null)
 
 /**
  * Asserts on the given value with an optional name. All assertions in the given lambda are run.

--- a/src/main/kotlin/assertk/assertions/any.kt
+++ b/src/main/kotlin/assertk/assertions/any.kt
@@ -239,8 +239,7 @@ fun <T : Any> Assert<T?>.isNull() {
  */
 fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
     if (actual != null) {
-        // Skip self in parent chain because reporting actual T vs T? isn't very useful.
-        assert(actual, name = name, parent = parent).all(f)
+        assert(actual, name = name).all(f)
     } else {
         expected("to not be null")
     }

--- a/src/main/kotlin/assertk/assertions/support/support.kt
+++ b/src/main/kotlin/assertk/assertions/support/support.kt
@@ -2,7 +2,6 @@ package assertk.assertions.support
 
 import assertk.Assert
 import assertk.fail
-import assertk.rootActual
 
 /**
  * Shows the primary value in a failure message.
@@ -51,7 +50,7 @@ fun <T> Assert<T>.fail(expected: Any?, actual: Any?) {
  */
 fun <T> Assert<T>.expected(message: String) {
     val maybeSpace = if (message.startsWith(":")) "" else " "
-    val maybeInstance = if (parent != null) " ${show(rootActual(), "()")}" else ""
+    val maybeInstance = if (context != null) " ${show(context, "()")}" else ""
     fail("expected${formatName(name)}$maybeSpace$message$maybeInstance")
 }
 

--- a/src/test/kotlin/test/assertk/assertions/ThrowableSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/ThrowableSpec.kt
@@ -181,7 +181,7 @@ class ThrowableSpec : Spek({
                 val causeless = TestException("test")
                 Assertions.assertThatThrownBy {
                     assert(causeless).rootCause().isEqualTo(rootCause)
-                }.hasMessage("expected [rootCause]:<...Spec\$TestException: [rootCause]> but was:<...Spec\$TestException: [test]> ($THROWABLE_SPEC\$TestException: test)")
+                }.hasMessage("expected [rootCause]:<...Spec\$TestException: [rootCause]> but was:<...Spec\$TestException: [test]>")
             }
 
             it("should fail an unsuccessful test on wrong cause class") {


### PR DESCRIPTION
Also make the prop internal so it's not part of the public api.
It's a bit simpiler to implement.