### PR TITLE
Fixed issue where you couldn't select `isEqualTo` for nullable java strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ src/main/kotlin/assertk/assertions/any.kt
 ### Fixed
 - Fix typos on a few assertions.
 - Fix bug in array `containsExactly`.
+- Fix issue with isEqualTo and nullable java strings
 
 ## [0.9] - 2017-09-25
 - Initial Release

--- a/src/main/kotlin/assertk/assertions/string.kt
+++ b/src/main/kotlin/assertk/assertions/string.kt
@@ -19,7 +19,7 @@ fun Assert<String>.hasLineCount(lineCount: Int) {
  * @param ignoreCase true to compare ignoring case, the default if false.
  * @see [isNotEqualTo]
  */
-fun Assert<String>.isEqualTo(other: String, ignoreCase: Boolean = false) {
+fun Assert<String?>.isEqualTo(other: String?, ignoreCase: Boolean = false) {
     if (actual.equals(other, ignoreCase)) return
     fail(other, actual)
 }
@@ -29,9 +29,13 @@ fun Assert<String>.isEqualTo(other: String, ignoreCase: Boolean = false) {
  * @param ignoreCase true to compare ignoring case, the default if false.
  * @see [isEqualTo]
  */
-fun Assert<String>.isNotEqualTo(other: String, ignoreCase: Boolean = false) {
+fun Assert<String?>.isNotEqualTo(other: String?, ignoreCase: Boolean = false) {
     if (!actual.equals(other, ignoreCase)) return
-    expected(":${show(other)} not to be equal to:${show(actual)}")
+    if (ignoreCase) {
+        expected(":${show(other)} not to be equal to (ignoring case):${show(actual)}")
+    } else {
+        expected("to not be equal to:${show(actual)}")
+    }
 }
 
 /**

--- a/src/test/java/test/assertk/assertions/JavaNullableString.java
+++ b/src/test/java/test/assertk/assertions/JavaNullableString.java
@@ -1,0 +1,8 @@
+package test.assertk.assertions;
+
+public class JavaNullableString {
+
+    public static String string() {
+        return null;
+    }
+}

--- a/src/test/kotlin/test/assertk/assertions/StringSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/StringSpec.kt
@@ -30,27 +30,35 @@ class StringSpec : Spek({
                     assert("Test").isEqualTo("tesT", false)
                 }.hasMessage("expected:<\"[tesT]\"> but was:<\"[Test]\">")
             }
+
+            it("Given a java nullable string, picks the objects isEqualTo over the string one") {
+                assert(JavaNullableString.string()).isEqualTo(JavaNullableString.string())
+            }
         }
 
         on("isNotEqualTo()") {
             it("Given same strings, test should fail") {
                 Assertions.assertThatThrownBy {
                     assert("test").isNotEqualTo("test")
-                }.hasMessage("expected:<\"test\"> not to be equal to:<\"test\">")
+                }.hasMessage("expected to not be equal to:<\"test\">")
             }
 
             it("Given different strings, test should pass") {
-                    assert("").isNotEqualTo("test")
+                assert("").isNotEqualTo("test")
             }
 
             it("Given same strings with different casing and ignoring case, test should fail") {
                 Assertions.assertThatThrownBy {
                     assert("Test").isNotEqualTo("tesT", true)
-                }.hasMessage("expected:<\"tesT\"> not to be equal to:<\"Test\">")
+                }.hasMessage("expected:<\"tesT\"> not to be equal to (ignoring case):<\"Test\">")
             }
 
             it("Given different strings with different casing and not ignoring case, test should pass") {
-                    assert("Test").isNotEqualTo("tesT", false)
+                assert("Test").isNotEqualTo("tesT", false)
+            }
+
+            it("Given a java nullable string, picks the objects isNotEqualTo over the string one") {
+                assert(JavaNullableString.string()).isNotEqualTo("wrong")
             }
         }
 
@@ -138,7 +146,7 @@ class StringSpec : Spek({
 
         on("matches()") {
             it("Given a string that matches, test should pass") {
-               assert("1234").matches(Regex("\\d\\d\\d\\d"))
+                assert("1234").matches(Regex("\\d\\d\\d\\d"))
             }
 
             it("Given a string that doesn't matche, test should fail") {


### PR DESCRIPTION
Fixes #58

![](http://www.maxistentialism.com/bees/oprahbees.gif)