### PR TITLE
Feature/typesafe isequal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testRuntime 'org.jetbrains.spek:spek-junit-platform-engine:1.1.5'
     testRuntime "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testCompile 'org.assertj:assertj-core:3.6.2'
+    testCompile 'com.google.code.findbugs:jsr305:3.0.0'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ group 'com.willowtreeapps.assertk'
 version '0.10-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.1.50'
+    ext.kotlin_version = '1.2.21'
     ext.junit_platform_version = '1.0.0'
     ext.dokka_version = '0.9.14'
     ext.detekt_version = '1.0.0.RC4-3'
@@ -74,5 +74,11 @@ detekt {
     profile("test") {
         input = "$projectDir/src/test/kotlin"
         config = "$projectDir/detekt-test.yml"
+    }
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        allWarningsAsErrors = true
     }
 }

--- a/src/main/kotlin/assertk/assert.kt
+++ b/src/main/kotlin/assertk/assert.kt
@@ -6,7 +6,7 @@ import assertk.assertions.support.show
  * An assertion. Holds an actual value to assertion on and an optional name.
  * @see [assert]
  */
-class Assert<out T> internal constructor(val actual: T, val name: String?, internal val context: Any?) {
+class Assert<T> internal constructor(val actual: T, val name: String?, internal val context: Any?) {
     /**
      * Asserts on the given value with an optional name.
      *
@@ -21,7 +21,7 @@ class Assert<out T> internal constructor(val actual: T, val name: String?, inter
 /**
  * An assertion on a block of code. Can assert that it either throws and error or returns a value.
  */
-sealed class AssertBlock<out T> {
+sealed class AssertBlock<T> {
     /**
      * Runs the given lambda if the block throws an error, otherwise fails.
      */
@@ -32,7 +32,7 @@ sealed class AssertBlock<out T> {
      */
     abstract fun returnedValue(f: Assert<T>.() -> Unit)
 
-    internal class Value<out T> internal constructor(private val value: T) : AssertBlock<T>() {
+    internal class Value<T> internal constructor(private val value: T) : AssertBlock<T>() {
         override fun thrownError(f: Assert<Throwable>.() -> Unit) = fail("expected exception but was:${show(value)}")
 
         override fun returnedValue(f: Assert<T>.() -> Unit) {
@@ -40,7 +40,7 @@ sealed class AssertBlock<out T> {
         }
     }
 
-    internal class Error<out T> internal constructor(private val error: Throwable) : AssertBlock<T>() {
+    internal class Error<T> internal constructor(private val error: Throwable) : AssertBlock<T>() {
         override fun thrownError(f: Assert<Throwable>.() -> Unit) {
             f(assert(error))
         }

--- a/src/main/kotlin/assertk/assertions/any.kt
+++ b/src/main/kotlin/assertk/assertions/any.kt
@@ -84,8 +84,8 @@ fun <T> Assert<T>.isNotSameAs(expected: Any?) {
  */
 @Deprecated(message = "Use kClass().isEqualTo(kclass) instead.",
         replaceWith = ReplaceWith("kClass().isEqualTo(kclass)"))
-fun <T : Any> Assert<T>.hasClass(kclass: KClass<out T>) {
-    val jclass: Class<out T> = kclass.java
+fun <T : Any> Assert<T>.hasClass(kclass: KClass<T>) {
+    val jclass: Class<T> = kclass.java
     if (jclass == actual.javaClass) return
     expected("to have class:${show(jclass)} but was:${show(actual.javaClass)}")
 }
@@ -98,7 +98,7 @@ fun <T : Any> Assert<T>.hasClass(kclass: KClass<out T>) {
  */
 @Deprecated(message = "Use jClass().isEqualTo(jclass) instead.",
         replaceWith = ReplaceWith("jClass().isEqualTo(jclass)"))
-fun <T : Any> Assert<T>.hasClass(jclass: Class<out T>) {
+fun <T : Any> Assert<T>.hasClass(jclass: Class<T>) {
     if (jclass == actual.javaClass) return
     expected("to have class:${show(jclass)} but was:${show(actual.javaClass)}")
 }
@@ -112,8 +112,8 @@ fun <T : Any> Assert<T>.hasClass(jclass: Class<out T>) {
  */
 @Deprecated(message = "Use kClass().isNotEqualTo(kclass) instead.",
         replaceWith = ReplaceWith("kClass().isNotEqualTo(kclass)"))
-fun <T : Any> Assert<T>.doesNotHaveClass(kclass: KClass<out T>) {
-    val jclass: Class<out T> = kclass.java
+fun <T : Any> Assert<T>.doesNotHaveClass(kclass: KClass<T>) {
+    val jclass: Class<T> = kclass.java
     if (jclass != actual.javaClass) return
     expected("to not have class:${show(jclass)}")
 }
@@ -127,7 +127,7 @@ fun <T : Any> Assert<T>.doesNotHaveClass(kclass: KClass<out T>) {
  */
 @Deprecated(message = "Use jClass().isNotEqualTo(jclass) instead.",
         replaceWith = ReplaceWith("jClass().isNotEqualTo(jclass)"))
-fun <T : Any> Assert<T>.doesNotHaveClass(jclass: Class<out T>) {
+fun <T : Any> Assert<T>.doesNotHaveClass(jclass: Class<T>) {
     if (jclass != actual.javaClass) return
     expected("to not have class:${show(jclass)}")
 }
@@ -138,8 +138,8 @@ fun <T : Any> Assert<T>.doesNotHaveClass(jclass: Class<out T>) {
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
-fun <T : Any> Assert<T>.isInstanceOf(kclass: KClass<out T>) {
-    val jclass: Class<out T> = kclass.java
+fun <T : Any> Assert<T>.isInstanceOf(kclass: KClass<*>) {
+    val jclass: Class<*> = kclass.java
     if (jclass.isInstance(actual)) return
     expected("to be instance of:${show(jclass)} but had class:${show(actual.javaClass)}")
 }
@@ -150,7 +150,7 @@ fun <T : Any> Assert<T>.isInstanceOf(kclass: KClass<out T>) {
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
-fun <T : Any> Assert<T>.isInstanceOf(jclass: Class<out T>) {
+fun <T : Any> Assert<T>.isInstanceOf(jclass: Class<*>) {
     if (jclass.isInstance(actual)) return
     expected("to be instance of:${show(jclass)} but had class:${show(actual.javaClass)}")
 }
@@ -161,8 +161,8 @@ fun <T : Any> Assert<T>.isInstanceOf(jclass: Class<out T>) {
  * @see [isInstanceOf]
  * @see [doesNotHaveClass]
  */
-fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) {
-    val jclass: Class<out T> = kclass.java
+fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<*>) {
+    val jclass: Class<*> = kclass.java
     if (!jclass.isInstance(actual)) return
     expected("to not be instance of:${show(jclass)}")
 }
@@ -173,7 +173,7 @@ fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) {
  * @see [isInstanceOf]
  * @see [doesNotHaveClass]
  */
-fun <T : Any> Assert<T>.isNotInstanceOf(jclass: Class<out T>) {
+fun <T : Any> Assert<T>.isNotInstanceOf(jclass: Class<*>) {
     if (!jclass.isInstance(actual)) return
     expected("to not be instance of:${show(jclass)}")
 }
@@ -237,7 +237,7 @@ fun <T : Any> Assert<T?>.isNull() {
  * }
  * ```
  */
-fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
+fun <T> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
     if (actual != null) {
         assert(actual, name = name).all(f)
     } else {
@@ -254,8 +254,9 @@ fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
  * assert(person).prop("name", { it.name }).isEqualTo("Sue")
  * ```
  */
-fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P)
-        = assert(extract(actual), "${if (this.name != null) this.name + "." else ""}$name")
+fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P): Assert<P> {
+    return assert(extract(actual!!), "${if (this.name != null) this.name + "." else ""}$name")
+}
 
 /**
  * Returns an assert that asserts on the given property.

--- a/src/main/kotlin/assertk/assertions/any.kt
+++ b/src/main/kotlin/assertk/assertions/any.kt
@@ -268,3 +268,16 @@ fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P): Assert<P> {
  * ```
  */
 fun <T, P> Assert<T>.prop(callable: KCallable<P>) = prop(callable.name) { callable.call(it) }
+
+/**
+ * Returns an assert that can handle plateform type ```T!```
+ */
+inline fun <reified T> Assert<T>.Nullable(): Assert<T?> {
+    @Suppress("UNCHECKED_CAST")
+    return this as Assert<T?>
+}
+
+inline fun <reified T : kotlin.Any> Assert<T?>.Nonnull(): Assert<T> {
+    return assert(actual!!, name)
+}
+

--- a/src/main/kotlin/assertk/assertions/any.kt
+++ b/src/main/kotlin/assertk/assertions/any.kt
@@ -34,7 +34,12 @@ fun <T : Any> Assert<T>.hashCodeFun() = prop("hashCode", Any::hashCode)
  * @see [isNotEqualTo]
  * @see [isSameAs]
  */
-fun <T> Assert<T>.isEqualTo(expected: Any?) {
+fun <T> Assert<T>.isEqualTo(expected: T) {
+    if (actual == expected) return
+    fail(expected, actual)
+}
+
+fun <T> Assert<T>.isRelaxedEqualTo(expected: Any?) {
     if (actual == expected) return
     fail(expected, actual)
 }

--- a/src/main/kotlin/assertk/assertions/array.kt
+++ b/src/main/kotlin/assertk/assertions/array.kt
@@ -31,7 +31,7 @@ fun <T> Assert<Array<T>>.isNotEmpty() {
  * @see [isEmpty]
  */
 @JvmName("arrayIsNullOrEmpty")
-fun <T> Assert<Array<T>?>.isNullOrEmpty() {
+fun <T> Assert<Array<T?>?>.isNullOrEmpty() {
     if (actual == null || actual.isEmpty()) return
     expected("to be null or empty but was:${show(actual)}")
 }

--- a/src/main/kotlin/assertk/assertions/charsequence.kt
+++ b/src/main/kotlin/assertk/assertions/charsequence.kt
@@ -35,7 +35,7 @@ fun <T : CharSequence> Assert<T>.isNotEmpty() {
  * @see [isEmpty]
  */
 @JvmName("isCharSequenceNullOrEmpty")
-fun <T : CharSequence?> Assert<T>.isNullOrEmpty() {
+fun <T : CharSequence?> Assert<T?>.isNullOrEmpty() {
     if (actual.isNullOrEmpty()) return
     expected("to be null or empty but was:${show(actual)}")
 }

--- a/src/main/kotlin/assertk/assertions/inputstream.kt
+++ b/src/main/kotlin/assertk/assertions/inputstream.kt
@@ -62,7 +62,7 @@ private fun fillBuffer(stream: InputStream, buffer: ByteArray): Int {
     }
 }
 
-private fun compare(len: Int, actual: ByteArray, expected: ByteArray): Int? {
+private fun firstDifferencePosition(len: Int, actual: ByteArray, expected: ByteArray): Int? {
     return (0 until len).firstOrNull { actual[it] != expected[it] }
 }
 
@@ -83,7 +83,7 @@ private fun doTheStreamHaveTheSameContent(actual: InputStream, expected: InputSt
                 return null
             }
 
-            val pos = compare(actualRead, actualBuffer, otherBuffer)
+            val pos = firstDifferencePosition(actualRead, actualBuffer, otherBuffer)
             if (pos == null) {
                 // the current buffers are equals and we can try the next block
                 size += actualRead
@@ -113,7 +113,7 @@ private fun doTheStreamHaveTheSameContent(actual: InputStream, expected: InputSt
                         " but actual stream size ($actualSize) differs from other stream size ($otherSize)"
             }
 
-            val pos = compare(Math.min(actualRead, otherRead), actualBuffer, otherBuffer)
+            val pos = firstDifferencePosition(Math.min(actualRead, otherRead), actualBuffer, otherBuffer)
             val actualSize = consume(actual) + actualRead + size
             val otherSize = consume(expected) + otherRead + size
 
@@ -131,6 +131,7 @@ private fun doTheStreamHaveTheSameContent(actual: InputStream, expected: InputSt
     // the following throw should be unnecessary, as the only way to leave the while loop is either
     // - somewhere in the while loop an exception is thrown
     // - somewhere in the while loop the method is left by a return statement
+    @Suppress("UNREACHABLE_CODE")
     throw IllegalStateException("unreachable code")
 }
 

--- a/src/main/kotlin/assertk/assertions/string.kt
+++ b/src/main/kotlin/assertk/assertions/string.kt
@@ -19,7 +19,7 @@ fun Assert<String>.hasLineCount(lineCount: Int) {
  * @param ignoreCase true to compare ignoring case, the default if false.
  * @see [isNotEqualTo]
  */
-fun Assert<String?>.isEqualTo(other: String?, ignoreCase: Boolean = false) {
+fun Assert<String>.isEqualTo(other: String, ignoreCase: Boolean = false) {
     if (actual.equals(other, ignoreCase)) return
     fail(other, actual)
 }
@@ -29,7 +29,7 @@ fun Assert<String?>.isEqualTo(other: String?, ignoreCase: Boolean = false) {
  * @param ignoreCase true to compare ignoring case, the default if false.
  * @see [isEqualTo]
  */
-fun Assert<String?>.isNotEqualTo(other: String?, ignoreCase: Boolean = false) {
+fun Assert<String>.isNotEqualTo(other: String, ignoreCase: Boolean = false) {
     if (!actual.equals(other, ignoreCase)) return
     if (ignoreCase) {
         expected(":${show(other)} not to be equal to (ignoring case):${show(actual)}")

--- a/src/main/kotlin/assertk/assertions/throwable.kt
+++ b/src/main/kotlin/assertk/assertions/throwable.kt
@@ -32,7 +32,7 @@ fun <T : Throwable> Assert<T>.stackTrace() = prop("stack trace", { it.stackTrace
         replaceWith = ReplaceWith("message().isEqualTo(message)"))
 fun <T : Throwable> Assert<T>.hasMessage(message: String?) {
     assert(actual.message, "message").isNotNull {
-        it.isEqualTo(message)
+        it.isRelaxedEqualTo(message)
     }
 }
 

--- a/src/main/kotlin/assertk/assertions/throwable.kt
+++ b/src/main/kotlin/assertk/assertions/throwable.kt
@@ -107,7 +107,7 @@ fun <T : Throwable> Assert<T>.hasMessageEndingWith(suffix: String) {
  */
 @Deprecated(message = "Use cause().isNotNull { it.isInstanceOf(kclass) } instead.",
         replaceWith = ReplaceWith("cause().isNotNull { it.isInstanceOf(kclass) }"))
-fun <T : Throwable> Assert<T>.hasCauseInstanceOf(kclass: KClass<out T>) {
+fun <T : Throwable> Assert<T>.hasCauseInstanceOf(kclass: KClass<T>) {
     assert(actual.cause, "cause").isNotNull {
         it.isInstanceOf(kclass)
     }
@@ -120,7 +120,7 @@ fun <T : Throwable> Assert<T>.hasCauseInstanceOf(kclass: KClass<out T>) {
  */
 @Deprecated(message = "Use cause().isNotNull { it.isInstanceOf(jclass) } instead.",
         replaceWith = ReplaceWith("cause().isNotNull { it.isInstanceOf(jclass) }"))
-fun <T : Throwable> Assert<T>.hasCauseInstanceOf(jclass: Class<out T>) {
+fun <T : Throwable> Assert<T>.hasCauseInstanceOf(jclass: Class<T>) {
     assert(actual.cause, "cause").isNotNull {
         it.isInstanceOf(jclass)
     }
@@ -133,7 +133,7 @@ fun <T : Throwable> Assert<T>.hasCauseInstanceOf(jclass: Class<out T>) {
  */
 @Deprecated(message = "Use cause().isNotNull { it.kClass().isEqualTo(kclass) } instead.",
         replaceWith = ReplaceWith("cause().isNotNull { it.kClass().isEqualTo(kclass) }"))
-fun <T : Throwable> Assert<T>.hasCauseWithClass(kclass: KClass<out T>) {
+fun <T : Throwable> Assert<T>.hasCauseWithClass(kclass: KClass<T>) {
     assert(actual.cause, "cause").isNotNull {
         it.kClass().isEqualTo(kclass)
     }
@@ -146,7 +146,7 @@ fun <T : Throwable> Assert<T>.hasCauseWithClass(kclass: KClass<out T>) {
  */
 @Deprecated(message = "Use cause().isNotNull { it.jClass().isEqualTo(jclass) } instead.",
         replaceWith = ReplaceWith("cause().isNotNull { it.jClass().isEqualTo(jclass) }"))
-fun <T : Throwable> Assert<T>.hasCauseWithClass(jclass: Class<out T>) {
+fun <T : Throwable> Assert<T>.hasCauseWithClass(jclass: Class<T>) {
     assert(actual.cause, "cause").isNotNull {
         it.jClass().isEqualTo(jclass)
     }
@@ -169,10 +169,8 @@ fun <T : Throwable> Assert<T>.hasRootCause(cause: Throwable) {
  */
 @Deprecated(message = "Use rootCause().isInstanceOf(kclass) instead.",
         replaceWith = ReplaceWith("rootCause().isInstanceOf(kclass)"))
-fun <T : Throwable> Assert<T>.hasRootCauseInstanceOf(kclass: KClass<out T>) {
-    assert(actual.rootCause(), "root cause").isNotNull {
-        it.isInstanceOf(kclass)
-    }
+fun <T : Throwable> Assert<T>.hasRootCauseInstanceOf(kclass: KClass<T>) {
+    assert(actual.rootCause(), "root cause").isInstanceOf(kclass)
 }
 
 /**
@@ -182,10 +180,8 @@ fun <T : Throwable> Assert<T>.hasRootCauseInstanceOf(kclass: KClass<out T>) {
  */
 @Deprecated(message = "Use rootCause().isInstanceOf(jclass) instead.",
         replaceWith = ReplaceWith("rootCause().isInstanceOf(jclass)"))
-fun <T : Throwable> Assert<T>.hasRootCauseInstanceOf(jclass: Class<out T>) {
-    assert(actual.rootCause(), "root cause").isNotNull {
-        it.isInstanceOf(jclass)
-    }
+fun <T : Throwable> Assert<T>.hasRootCauseInstanceOf(jclass: Class<T>) {
+    assert(actual.rootCause(), "root cause").isInstanceOf(jclass)
 }
 
 /**
@@ -195,8 +191,9 @@ fun <T : Throwable> Assert<T>.hasRootCauseInstanceOf(jclass: Class<out T>) {
  */
 @Deprecated(message = "Use rootCause().isNotNull { it.kClass().isEqualTo(kclass) } instead.",
         replaceWith = ReplaceWith("rootCause().isNotNull { it.kClass().isEqualTo(kclass) }"))
-fun <T : Throwable> Assert<T>.hasRootCauseWithClass(kclass: KClass<out T>) {
-    assert(actual.rootCause(), "root cause").isNotNull {
+fun <T : Throwable> Assert<T>.hasRootCauseWithClass(kclass: KClass<T>) {
+    val assertion: Assert<Throwable?> = assert(actual.rootCause(), "root cause")
+    assertion.isNotNull {
         it.kClass().isEqualTo(kclass)
     }
 }
@@ -208,8 +205,9 @@ fun <T : Throwable> Assert<T>.hasRootCauseWithClass(kclass: KClass<out T>) {
  */
 @Deprecated(message = "Use rootCause().isNotNull { it.jClass().isEqualTo(jclass) } instead.",
         replaceWith = ReplaceWith("rootCause().isNotNull { it.jClass().isEqualTo(jclass) }"))
-fun <T : Throwable> Assert<T>.hasRootCauseWithClass(jclass: Class<out T>) {
-    assert(actual.rootCause(), "root cause").isNotNull {
+fun <T : Throwable> Assert<T>.hasRootCauseWithClass(jclass: Class<T>) {
+    val assertion: Assert<Throwable?> = assert(actual.rootCause(), "root cause")
+    assertion.isNotNull {
         it.jClass().isEqualTo(jclass)
     }
 }
@@ -223,6 +221,6 @@ private fun Throwable.rootCause(): Throwable =
 @Deprecated(message = "Use stackTrace().contains(description) instead.",
         replaceWith = ReplaceWith("stackTrace().contains(description)"))
 fun <T : Throwable> Assert<T>.hasStackTraceContaining(description: String) {
-    assert(actual.stackTrace.map { it.toString() }, "stack trace").contains(description)
+    stackTrace().contains(description)
 }
 

--- a/src/test/java/test/assertk/assertions/JavaNullableString.java
+++ b/src/test/java/test/assertk/assertions/JavaNullableString.java
@@ -1,8 +1,19 @@
 package test.assertk.assertions;
 
+import javax.annotation.Nullable;
+
 public class JavaNullableString {
 
     public static String string() {
         return null;
+    }
+
+    @Nullable
+    public static String stringWithNullableAnnotation() {
+        return null;
+    }
+
+    public static String nonNullableString() {
+        return "nonNullableString";
     }
 }

--- a/src/test/kotlin/test/assertk/assertions/ArraySpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/ArraySpec.kt
@@ -135,46 +135,46 @@ class ArraySpec : Spek({
 
             it("Given an empty arrays, " +
                     "test should pass") {
-                assert(emptyArray<Any?>()).isNullOrEmpty()
+                assert(emptyArray<Any?>()).isEmpty()
             }
 
             it("Given a non-empty array of Ints, " +
                     "test should fail") {
                 Assertions.assertThatThrownBy {
-                    assert(arrayOf(1, 2, 3)).isNullOrEmpty()
-                }.hasMessage("expected to be null or empty but was:<[1, 2, 3]>")
+                    assert(arrayOf(1, 2, 3)).isEmpty()
+                }.hasMessage("expected to be empty but was:<[1, 2, 3]>")
             }
 
             it("Given a non-empty array with a null, " +
                     "test should fail") {
                 Assertions.assertThatThrownBy {
-                    assert(arrayOf<Any?>(null)).isNullOrEmpty()
-                }.hasMessage("expected to be null or empty but was:<[null]>")
+                    assert(arrayOf<Any?>(null)).isEmpty()
+                }.hasMessage("expected to be empty but was:<[null]>")
             }
 
             it("Given two non-empty non-null arrays, " +
                     "test should fail with only one error message per failed assertion") {
                 Assertions.assertThatThrownBy {
                     assertAll {
-                        assert(arrayOf(1, 2, 3)).isNullOrEmpty()
-                        assert(arrayOf(43, true, "awesome!")).isNullOrEmpty()
+                        assert(arrayOf(1, 2, 3)).isEmpty()
+                        assert(arrayOf(43, true, "awesome!")).isEmpty()
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to be null or empty but was:<[1, 2, 3]>\n"
-                        + "- expected to be null or empty but was:<[43, true, \"awesome!\"]>")
+                        + "- expected to be empty but was:<[1, 2, 3]>\n"
+                        + "- expected to be empty but was:<[43, true, \"awesome!\"]>")
             }
 
             it("Given one empty array and two non-empty non-null arrays, " +
                     "test should fail only for the non-empty non-null arrays") {
                 Assertions.assertThatThrownBy {
                     assertAll {
-                        assert(arrayOf(1, 2, 3)).isNullOrEmpty()
-                        assert(arrayOf(43, true, "awesome!")).isNullOrEmpty()
-                        assert(emptyArray<Any?>()).isNullOrEmpty()
+                        assert(arrayOf(1, 2, 3)).isEmpty()
+                        assert(arrayOf(43, true, "awesome!")).isEmpty()
+                        assert(emptyArray<Any?>()).isEmpty()
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to be null or empty but was:<[1, 2, 3]>\n"
-                        + "- expected to be null or empty but was:<[43, true, \"awesome!\"]>")
+                        + "- expected to be empty but was:<[1, 2, 3]>\n"
+                        + "- expected to be empty but was:<[43, true, \"awesome!\"]>")
             }
         }
 

--- a/src/test/kotlin/test/assertk/assertions/CharSequenceSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/CharSequenceSpec.kt
@@ -36,15 +36,15 @@ class CharSequenceSpec : Spek({
 
         on("isNullOrEmpty()") {
             it("Given an empty sequence or null, test should pass") {
-                assert("").isNullOrEmpty()
+                assert("").isEmpty()
                 val test : CharSequence? = null
                 assert(test).isNullOrEmpty()
             }
 
             it("Given a non empty sequence, test should fail") {
                 Assertions.assertThatThrownBy {
-                    assert("test").isNullOrEmpty()
-                }.hasMessage("expected to be null or empty but was:<\"test\">")
+                    assert("test").isEmpty()
+                }.hasMessage("expected to be empty but was:<\"test\">")
             }
         }
 

--- a/src/test/kotlin/test/assertk/assertions/StringSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/StringSpec.kt
@@ -32,6 +32,7 @@ class StringSpec : Spek({
             }
 
             it("Given a java nullable string, picks the objects isEqualTo over the string one") {
+                //TODO not sure to understand this one ?
                 assert(JavaNullableString.string()).isEqualTo(JavaNullableString.string())
             }
         }

--- a/src/test/kotlin/test/assertk/assertions/StringSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/StringSpec.kt
@@ -32,8 +32,24 @@ class StringSpec : Spek({
             }
 
             it("Given a java nullable string, picks the objects isEqualTo over the string one") {
-                //TODO not sure to understand this one ?
-                assert(JavaNullableString.string()).isEqualTo(JavaNullableString.string())
+                val actual: String? = JavaNullableString.string()
+                val other: String? = JavaNullableString.string()
+                assert(actual).isEqualTo(other)
+            }
+
+            it("Given a java nullable string with annotation @Nullable, picks the objects isEqualTo over the string one") {
+                assert(JavaNullableString.stringWithNullableAnnotation())
+                        .isEqualTo(JavaNullableString.stringWithNullableAnnotation())
+            }
+
+            it("Given a java nullable string, picks the string isEqualTo after calling Nullable()") {
+                assert(JavaNullableString.string()).Nullable().isEqualTo(JavaNullableString.string())
+            }
+
+            it("Given a java non nullable string, picks the string isEqualTo after calling Nonnull()") {
+                assert(JavaNullableString.nonNullableString())
+                        .Nonnull()
+                        .isEqualTo(JavaNullableString.nonNullableString())
             }
         }
 

--- a/src/test/kotlin/test/assertk/assertions/ThrowableSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/ThrowableSpec.kt
@@ -232,24 +232,24 @@ class ThrowableSpec : Spek({
 
         on("hasRootCauseWithClass(KClass)") {
             it("should pass a successful test") {
-                assert(subject).rootCause().isNotNull { it.kClass().isEqualTo(TestException::class) }
+                assert(subject).rootCause().kClass().isEqualTo(TestException::class)
             }
 
             it("should fail an unsuccessful test") {
                 Assertions.assertThatThrownBy {
-                    assert(subject).rootCause().isNotNull { it.kClass().isEqualTo(Exception::class) }
+                    assert(subject).rootCause().kClass().isEqualTo(Exception::class)
                 }.hasMessage("expected [rootCause.class]:<class [java.lang.]Exception> but was:<class [$THROWABLE_SPEC\$Test]Exception> ($THROWABLE_SPEC\$TestException: test)")
             }
         }
 
         on("hasRootCauseWithClass(Class)") {
             it("should pass a successful test") {
-                assert(subject).rootCause().isNotNull { it.jClass().isEqualTo(TestException::class.java) }
+                assert(subject).rootCause().jClass().isEqualTo(TestException::class.java)
             }
 
             it("should fail an unsuccessful test") {
                 Assertions.assertThatThrownBy {
-                    assert(subject).rootCause().isNotNull { it.jClass().isEqualTo(Exception::class.java) }
+                    assert(subject).rootCause().jClass().isEqualTo(Exception::class.java)
                 }.hasMessage("expected [rootCause.class]:<[java.lang.]Exception> but was:<[$THROWABLE_SPEC\$Test]Exception> ($THROWABLE_SPEC\$TestException: test)")
             }
         }


### PR DESCRIPTION
Changing isEqualTo to be more user friendly.

actual:
```isEqualTo signature  fun <T> Assert<T>.isEqualTo(expected: Any?)```

proposal:
```isEqualTo signature  fun <T> Assert<T>.isEqualTo(expected: T)```

this require changing ```Assert``` type parameter to be invariant.

As a result there was code checking for nullable value where not needed (after this change the compiler was complaining about that). exemple here [#diff-388e4c1d06e88f02a47d50cfc9407961L172](https://github.com/willowtreeapps/assertk/compare/master...evantill:feature/typesafe-isequal?expand=1#diff-388e4c1d06e88f02a47d50cfc9407961L172)

see https://github.com/willowtreeapps/assertk/issues/72