### PR TITLE
Error messages could be better for collections with lots of items

### DIFF
--- a/src/main/kotlin/assertk/assertions/collection.kt
+++ b/src/main/kotlin/assertk/assertions/collection.kt
@@ -70,9 +70,13 @@ fun <T : Collection<*>> Assert<T>.containsNone(vararg elements: Any?) {
  * @see [containsExactly]
  */
 fun <T : Collection<*>> Assert<T>.containsAll(vararg elements: Any?) {
-    if (!actual.containsAll(elements.toList())) {
-        expected("to contain all:${show(elements)} but was:${show(actual)}")
+    if (actual.containsAll(elements.toList())) {
+        return
     }
+
+    val notFound = elements.filterNot { it in actual }
+    expected("to contain all:${show(elements)} but was:${show(actual)}" +
+            " some elements were not found:${show(notFound)}")
 }
 
 /**

--- a/src/main/kotlin/assertk/assertions/collection.kt
+++ b/src/main/kotlin/assertk/assertions/collection.kt
@@ -1,7 +1,6 @@
 package assertk.assertions
 
 import assertk.Assert
-import assertk.assert
 import assertk.assertions.support.expected
 import assertk.assertions.support.show
 
@@ -82,18 +81,30 @@ fun <T : Collection<*>> Assert<T>.containsAll(vararg elements: Any?) {
  * @see [containsAll]
  */
 fun <T : Collection<*>> Assert<T>.containsExactly(vararg elements: Any?) {
-    if (actual.size == elements.size) {
-        val itr = actual.iterator()
-        var i = 0
+    val notExpected = actual.toMutableList()
+    val notFound = mutableListOf<Any?>()
 
-        while (itr.hasNext()) {
-            if (itr.next() != elements[i]) {
-                expected("to contain exactly:${show(elements)} but was:${show(actual)}")
-                break
-            }
-            i += 1
+    for (element in elements) {
+        if (element in notExpected) {
+            notExpected.removeAt(notExpected.indexOfFirst { it == element })
+        } else {
+            notFound += element
         }
+    }
+
+    if (notExpected.isEmpty() && notFound.isEmpty()) {
+        return
+    }
+
+    if (notExpected.isEmpty()) {
+        expected("to contain exactly:${show(elements)} but was:${show(actual)}" +
+                " some elements were not found:${show(notFound)}")
+    } else if (notFound.isEmpty()) {
+        expected("to contain exactly:${show(elements)} but was:${show(actual)}" +
+                " some elements were not expected:${show(notExpected)}")
     } else {
-        expected("to contain exactly:${show(elements)} but was:${show(actual)}")
+        expected("to contain exactly:${show(elements)} but was:${show(actual)}" +
+                " some elements were not found:${show(notFound)}" +
+                " some elements were not expected:${show(notExpected)}")
     }
 }

--- a/src/main/kotlin/assertk/assertions/collection.kt
+++ b/src/main/kotlin/assertk/assertions/collection.kt
@@ -54,13 +54,13 @@ fun <T : Collection<*>> Assert<T>.hasSameSizeAs(other: Collection<*>) {
  * @see [containsAll]
  */
 fun <T : Collection<*>> Assert<T>.containsNone(vararg elements: Any?) {
-    val elementsItr = elements.iterator()
-    while (elementsItr.hasNext()) {
-        if (actual.contains(elementsItr.next())) {
-            expected("to contain none of:${show(elements)} but was:${show(actual)}")
-            break
-        }
+    if (elements.none { it in actual }) {
+        return
     }
+
+    val notExpected = elements.filter { it in actual }
+    expected("to contain none of:${show(elements)} but was:${show(actual)}" +
+            " some elements were not expected:${show(notExpected)}")
 }
 
 /**

--- a/src/main/kotlin/assertk/assertions/collection.kt
+++ b/src/main/kotlin/assertk/assertions/collection.kt
@@ -81,7 +81,13 @@ fun <T : Collection<*>> Assert<T>.containsAll(vararg elements: Any?) {
  * @see [containsAll]
  */
 fun <T : Collection<*>> Assert<T>.containsExactly(vararg elements: Any?) {
-    val notExpected = actual.toMutableList()
+    val actualAsList = actual.toList()
+    if (actualAsList == elements.toList()) {
+        return
+    }
+
+    val firstDifferingIndex = (elements zip actualAsList).indexOfFirst { it.first != it.second }
+    val notExpected = actualAsList.toMutableList()
     val notFound = mutableListOf<Any?>()
 
     for (element in elements) {
@@ -92,19 +98,19 @@ fun <T : Collection<*>> Assert<T>.containsExactly(vararg elements: Any?) {
         }
     }
 
-    if (notExpected.isEmpty() && notFound.isEmpty()) {
-        return
-    }
-
-    if (notExpected.isEmpty()) {
+    if (!notExpected.isEmpty() && !notFound.isEmpty()) {
+        expected("to contain exactly:${show(elements)} but was:${show(actual)}" +
+                " some elements were not found:${show(notFound)}" +
+                " some elements were not expected:${show(notExpected)}")
+    } else if (!notFound.isEmpty()) {
         expected("to contain exactly:${show(elements)} but was:${show(actual)}" +
                 " some elements were not found:${show(notFound)}")
-    } else if (notFound.isEmpty()) {
+    } else if (!notExpected.isEmpty()) {
         expected("to contain exactly:${show(elements)} but was:${show(actual)}" +
                 " some elements were not expected:${show(notExpected)}")
     } else {
         expected("to contain exactly:${show(elements)} but was:${show(actual)}" +
-                " some elements were not found:${show(notFound)}" +
-                " some elements were not expected:${show(notExpected)}")
+                " first difference at index $firstDifferingIndex" +
+                " expected:${show(elements[firstDifferingIndex])} but was:${show(actualAsList[firstDifferingIndex])}")
     }
 }

--- a/src/test/kotlin/test/assertk/assertions/CollectionSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/CollectionSpec.kt
@@ -408,28 +408,32 @@ class CollectionSpec : Spek({
                     "test should fail when not containing all elements expected regardless of order") {
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, 2, 3)).containsAll(4, 3, 1, 2)
-                }.hasMessage("expected to contain all:<[4, 3, 1, 2]> but was:<[1, 2, 3]>")
+                }.hasMessage("expected to contain all:<[4, 3, 1, 2]> but was:<[1, 2, 3]>" +
+                                " some elements were not found:<[4]>")
             }
 
             it("Given a list of multiple elements with less elements given than expected, " +
                     "test should fail when not containing all elements expected regardless of order") {
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, 2, 4, 5)).containsAll(2, 1, 3)
-                }.hasMessage("expected to contain all:<[2, 1, 3]> but was:<[1, 2, 4, 5]>")
+                }.hasMessage("expected to contain all:<[2, 1, 3]> but was:<[1, 2, 4, 5]>" +
+                                " some elements were not found:<[3]>")
             }
 
             it("Given an empty list, " +
                     "test should fail when expecting anything") {
                 Assertions.assertThatThrownBy {
                     assert(emptyList<Any?>()).containsAll(1, 2, 3)
-                }.hasMessage("expected to contain all:<[1, 2, 3]> but was:<[]>")
+                }.hasMessage("expected to contain all:<[1, 2, 3]> but was:<[]>" +
+                                " some elements were not found:<[1, 2, 3]>")
             }
 
             it("Given a list of multiple types, " +
                     "test should fail when not containing all elements expected regardless of order") {
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, "is", "awesome!")).containsAll("this", 4, "awesome!")
-                }.hasMessage("expected to contain all:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>")
+                }.hasMessage("expected to contain all:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>" +
+                                " some elements were not found:<[\"this\", 4]>")
             }
 
             it("Given multiple assertions which should fail, " +
@@ -440,8 +444,10 @@ class CollectionSpec : Spek({
                         assert(listOf(1, "is", "awesome!")).containsAll("this", 4, "awesome!")
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to contain all:<[5, 6, 7]> but was:<[1, 2, 3]>\n"
-                        + "- expected to contain all:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>")
+                        + "- expected to contain all:<[5, 6, 7]> but was:<[1, 2, 3]>"
+                        + " some elements were not found:<[5, 6, 7]>\n"
+                        + "- expected to contain all:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>"
+                        + " some elements were not found:<[\"this\", 4]>")
             }
 
             it("Given multiple assertions which should fail and some that should pass, " +
@@ -454,8 +460,10 @@ class CollectionSpec : Spek({
                         assert(listOf(1, 1.09, "awesome!", true)).containsAll(1, 1.09, "awesome!", true) // should pass
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to contain all:<[5, 6, 7]> but was:<[1, 2, 3]>\n"
-                        + "- expected to contain all:<[\"this\", 4, \"awesome!\"]> but was:<[\"this\", \"is\", \"awesome!\"]>")
+                        + "- expected to contain all:<[5, 6, 7]> but was:<[1, 2, 3]>"
+                        + " some elements were not found:<[5, 6, 7]>\n"
+                        + "- expected to contain all:<[\"this\", 4, \"awesome!\"]> but was:<[\"this\", \"is\", \"awesome!\"]>"
+                        + " some elements were not found:<[4]>")
             }
         }
 

--- a/src/test/kotlin/test/assertk/assertions/CollectionSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/CollectionSpec.kt
@@ -479,28 +479,33 @@ class CollectionSpec : Spek({
                     "test should fail when not containing all elements expected exactly in order") {
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, 2, 3)).containsExactly(1, 2, 3, 4)
-                }.hasMessage("expected to contain exactly:<[1, 2, 3, 4]> but was:<[1, 2, 3]>")
+                }.hasMessage("expected to contain exactly:<[1, 2, 3, 4]> but was:<[1, 2, 3]>" +
+                                " some elements were not found:<[4]>")
             }
 
             it("Given a list of multiple elements with more elements given than expected, " +
                     "test should fail when not containing all elements expected exactly in order") {
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, 2, 3, 4)).containsExactly(1, 2, 3)
-                }.hasMessage("expected to contain exactly:<[1, 2, 3]> but was:<[1, 2, 3, 4]>")
+                }.hasMessage("expected to contain exactly:<[1, 2, 3]> but was:<[1, 2, 3, 4]>" +
+                                " some elements were not expected:<[4]>")
             }
 
             it("Given an empty list, " +
                     "test should fail when expecting anything") {
                 Assertions.assertThatThrownBy {
                     assert(emptyList<Any?>()).containsExactly(1, 2, 3)
-                }.hasMessage("expected to contain exactly:<[1, 2, 3]> but was:<[]>")
+                }.hasMessage("expected to contain exactly:<[1, 2, 3]> but was:<[]>" +
+                                " some elements were not found:<[1, 2, 3]>")
             }
 
             it("Given a list of multiple types, " +
                     "test should fail when not containing all elements expected exactly in order") {
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, "is", "awesome!")).containsExactly("this", 4, "awesome!")
-                }.hasMessage("expected to contain exactly:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>")
+                }.hasMessage("expected to contain exactly:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>" +
+                                " some elements were not found:<[\"this\", 4]>" +
+                                " some elements were not expected:<[1, \"is\"]>")
             }
 
             it("Given multiple assertions which should fail, " +
@@ -511,8 +516,12 @@ class CollectionSpec : Spek({
                         assert(listOf(1, "is", "awesome!")).containsExactly("this", 4, "awesome!") // should fail
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to contain exactly:<[5, 6, 7]> but was:<[1, 2, 3]>\n"
-                        + "- expected to contain exactly:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>")
+                        + "- expected to contain exactly:<[5, 6, 7]> but was:<[1, 2, 3]>"
+                        + " some elements were not found:<[5, 6, 7]>"
+                        + " some elements were not expected:<[1, 2, 3]>\n"
+                        + "- expected to contain exactly:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>"
+                        + " some elements were not found:<[\"this\", 4]>"
+                        + " some elements were not expected:<[1, \"is\"]>")
             }
 
             it("Given multiple assertions which should fail and some that should pass, " +
@@ -525,8 +534,20 @@ class CollectionSpec : Spek({
                         assert(listOf(1, "is", "awesome!")).containsExactly("this", 4, "awesome!") // should fail
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to contain exactly:<[5, 6, 7]> but was:<[1, 2, 3]>\n"
-                        + "- expected to contain exactly:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>")
+                                + "- expected to contain exactly:<[5, 6, 7]> but was:<[1, 2, 3]>"
+                                + " some elements were not found:<[5, 6, 7]>"
+                                + " some elements were not expected:<[1, 2, 3]>\n"
+                                + "- expected to contain exactly:<[\"this\", 4, \"awesome!\"]> but was:<[1, \"is\", \"awesome!\"]>"
+                                + " some elements were not found:<[\"this\", 4]>"
+                                + " some elements were not expected:<[1, \"is\"]>")
+            }
+
+            it("Given the same element multiple times, difference reporting should still work") {
+                Assertions.assertThatThrownBy {
+                    assert(listOf(1, 1, 3)).containsExactly(1, 3, 3)
+                }.hasMessage("expected to contain exactly:<[1, 3, 3]> but was:<[1, 1, 3]>"
+                        + " some elements were not found:<[3]>"
+                        + " some elements were not expected:<[1]>")
             }
         }
     }

--- a/src/test/kotlin/test/assertk/assertions/CollectionSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/CollectionSpec.kt
@@ -546,9 +546,19 @@ class CollectionSpec : Spek({
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, 1, 3)).containsExactly(1, 3, 3)
                 }.hasMessage("expected to contain exactly:<[1, 3, 3]> but was:<[1, 1, 3]>"
-                        + " some elements were not found:<[3]>"
-                        + " some elements were not expected:<[1]>")
+                                + " some elements were not found:<[3]>"
+                                + " some elements were not expected:<[1]>")
             }
+
+
+            it("Given the same elements in a different order, difference reporting should still work") {
+                Assertions.assertThatThrownBy {
+                    assert(listOf(1, 2, 1, 3)).containsExactly(1, 1, 2, 3)
+                }.hasMessage("expected to contain exactly:<[1, 1, 2, 3]> but was:<[1, 2, 1, 3]>"
+                                + " first difference at index 1"
+                                + " expected:<1> but was:<2>")
+            }
+
         }
     }
 })

--- a/src/test/kotlin/test/assertk/assertions/CollectionSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/CollectionSpec.kt
@@ -344,21 +344,24 @@ class CollectionSpec : Spek({
                     "test should fail if the list contains any of the elements that are expected") {
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, 2, 3)).containsNone(4, 5, 6, 1)
-                }.hasMessage("expected to contain none of:<[4, 5, 6, 1]> but was:<[1, 2, 3]>")
+                }.hasMessage("expected to contain none of:<[4, 5, 6, 1]> but was:<[1, 2, 3]>" +
+                                " some elements were not expected:<[1]>")
             }
 
             it("Given a list with less elements passed in than the number of elements expected, " +
                     "test should fail if the list contains any of the elements that are expected") {
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, 2, 3, 4)).containsNone(8, 0, 4)
-                }.hasMessage("expected to contain none of:<[8, 0, 4]> but was:<[1, 2, 3, 4]>")
+                }.hasMessage("expected to contain none of:<[8, 0, 4]> but was:<[1, 2, 3, 4]>" +
+                                " some elements were not expected:<[4]>")
             }
 
             it("Given a list of multiple types containing more elements passed in than the number of elements expected, " +
                     "test should fail if the list contains any of the elements that are expected") {
                 Assertions.assertThatThrownBy {
                     assert(listOf(1, 1.09, "awesome!", true)).containsNone(true, 43, "potato")
-                }.hasMessage("expected to contain none of:<[true, 43, \"potato\"]> but was:<[1, 1.09, \"awesome!\", true]>")
+                }.hasMessage("expected to contain none of:<[true, 43, \"potato\"]> but was:<[1, 1.09, \"awesome!\", true]>" +
+                                " some elements were not expected:<[true]>")
             }
 
             it("Given multiple assertions which should fail, " +
@@ -369,8 +372,10 @@ class CollectionSpec : Spek({
                         assert(listOf("this", "is", "awesome!")).containsNone(true, 4, "awesome!")
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to contain none of:<[5, 6, 7, 1]> but was:<[1, 2, 3]>\n"
-                        + "- expected to contain none of:<[true, 4, \"awesome!\"]> but was:<[\"this\", \"is\", \"awesome!\"]>")
+                        + "- expected to contain none of:<[5, 6, 7, 1]> but was:<[1, 2, 3]>"
+                        + " some elements were not expected:<[1]>\n"
+                        + "- expected to contain none of:<[true, 4, \"awesome!\"]> but was:<[\"this\", \"is\", \"awesome!\"]>"
+                        + " some elements were not expected:<[\"awesome!\"]>")
             }
 
             it("Given multiple assertions which should fail and some that should pass, " +
@@ -383,8 +388,10 @@ class CollectionSpec : Spek({
                         assert(listOf(1, 2, 3, 4)).containsNone(5, 6, 7) // Should pass
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to contain none of:<[5, 6, 7, 1]> but was:<[1, 2, 3]>\n"
-                        + "- expected to contain none of:<[true, 4, \"awesome!\"]> but was:<[\"this\", \"is\", \"awesome!\"]>")
+                        + "- expected to contain none of:<[5, 6, 7, 1]> but was:<[1, 2, 3]>"
+                        + " some elements were not expected:<[1]>\n"
+                        + "- expected to contain none of:<[true, 4, \"awesome!\"]> but was:<[\"this\", \"is\", \"awesome!\"]>"
+                        + " some elements were not expected:<[\"awesome!\"]>")
             }
         }
 


### PR DESCRIPTION
Fixes #5 by adding additional info to the expectation messages about items that are missing/superfluous/different for the following collection asserts:

- containsAll
- containsNone
- containsExactly

added some tests to cover corner cases for the new implementation of containsExactly