### PR TITLE
Add assertion to compare only given properties

### DIFF
--- a/src/main/kotlin/assertk/assertions/any.kt
+++ b/src/main/kotlin/assertk/assertions/any.kt
@@ -7,6 +7,9 @@ import assertk.assertions.support.fail
 import assertk.assertions.support.show
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.full.staticProperties
 
 /**
  * Returns an assert on the kotlin class of the value.
@@ -267,3 +270,19 @@ fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P)
  * ```
  */
 fun <T, P> Assert<T>.prop(callable: KCallable<P>) = prop(callable.name) { callable.call(it) }
+
+/**
+ * Returns an assert that compares only the given properties on the calling class
+ * @param other Other value to compare to
+ * @param properties properties of the type with which to compare
+ *
+ * ```
+ * assert(person).isEqualToComparingOnlyGivenProperties(other, Person::name, Person::age)
+ * ```
+ */
+fun <T> Assert<T>.isEqualToComparingOnlyGivenProperties(other: T, vararg properties: KProperty1<T, Any>) {
+    properties.forEach {
+        assert(it.get(actual), "${if (this.name != null) this.name + "." else ""}${it.name}")
+                .isEqualTo(it.get(other))
+    }
+}

--- a/src/main/kotlin/assertk/assertions/any.kt
+++ b/src/main/kotlin/assertk/assertions/any.kt
@@ -277,10 +277,10 @@ fun <T, P> Assert<T>.prop(callable: KCallable<P>) = prop(callable.name) { callab
  * @param properties properties of the type with which to compare
  *
  * ```
- * assert(person).isEqualToComparingOnlyGivenProperties(other, Person::name, Person::age)
+ * assert(person).isEqualToWithGivenProperties(other, Person::name, Person::age)
  * ```
  */
-fun <T> Assert<T>.isEqualToComparingOnlyGivenProperties(other: T, vararg properties: KProperty1<T, Any>) {
+fun <T> Assert<T>.isEqualToWithGivenProperties(other: T, vararg properties: KProperty1<T, Any>) {
     properties.forEach {
         assert(it.get(actual), "${if (this.name != null) this.name + "." else ""}${it.name}")
                 .isEqualTo(it.get(other))

--- a/src/test/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/src/test/kotlin/test/assertk/assertions/AnyTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RemoveRedundantBackticks")
+
 package test.assertk.assertions
 
 import assertk.assert
@@ -257,6 +259,28 @@ class AnyTest {
                 assertEquals("expected [str] to be empty but was:<\"test\"> (test)", error.message)
             }
         }
+
+        @Nested inner class `isEqualToComparingOnlyGivenProperties(object, props)` {
+
+            private val testObject = BasicObject("test", 99, 3.14)
+
+            @Test fun `regular equals fail` () {
+                assertFails {
+                    assert(subject).isEqualTo(testObject)
+                }
+            }
+
+            @Test fun `extract prop passes`() {
+                assert(subject).isEqualToComparingOnlyGivenProperties(testObject, BasicObject::str, BasicObject::double)
+            }
+
+            @Test fun `extract prop includes name in failure message`() {
+                val error = assertFails {
+                    assert(subject).isEqualToComparingOnlyGivenProperties(testObject, BasicObject::int)
+                }
+                assertEquals("expected [int]:<[99]> but was:<[42]> (test)", error.message)
+            }
+        }
     }
 
     @Nested inner class `nullable object` {
@@ -312,9 +336,9 @@ class AnyTest {
 
 open class TestObject
 
-class BasicObject(val str: String) : TestObject() {
+class BasicObject(val str: String, val int: Int = 42, val double: Double = 3.14) : TestObject() {
     override fun toString(): String = str
-    override fun equals(other: Any?): Boolean = (other is BasicObject) && (str == other.str)
+    override fun equals(other: Any?): Boolean = (other is BasicObject) && (str == other.str && int == other.int && double == other.double)
     override fun hashCode(): Int = 42
 }
 

--- a/src/test/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/src/test/kotlin/test/assertk/assertions/AnyTest.kt
@@ -260,7 +260,7 @@ class AnyTest {
             }
         }
 
-        @Nested inner class `isEqualToComparingOnlyGivenProperties(object, props)` {
+        @Nested inner class `isEqualToWithGivenProperties(object, props)` {
 
             private val testObject = BasicObject("test", 99, 3.14)
 
@@ -271,12 +271,12 @@ class AnyTest {
             }
 
             @Test fun `extract prop passes`() {
-                assert(subject).isEqualToComparingOnlyGivenProperties(testObject, BasicObject::str, BasicObject::double)
+                assert(subject).isEqualToWithGivenProperties(testObject, BasicObject::str, BasicObject::double)
             }
 
             @Test fun `extract prop includes name in failure message`() {
                 val error = assertFails {
-                    assert(subject).isEqualToComparingOnlyGivenProperties(testObject, BasicObject::int)
+                    assert(subject).isEqualToWithGivenProperties(testObject, BasicObject::int)
                 }
                 assertEquals("expected [int]:<[99]> but was:<[42]> (test)", error.message)
             }


### PR DESCRIPTION
Add `isEqualToComparingOnlyGivenProperties` to make comparisons on given properties of an object. 
This aims to be a typesafe version of assertj's [`isEqualToComparingOnlyGivenFields`](http://joel-costigliola.github.io/assertj/assertj-core-features-highlight.html#field-by-field-only)
