### PR TITLE
Use `@DslMarker` to delimit assertion DSL to prevent confusing code

### DIFF
--- a/src/main/kotlin/assertk/assert.kt
+++ b/src/main/kotlin/assertk/assert.kt
@@ -3,9 +3,16 @@ package assertk
 import assertk.assertions.support.show
 
 /**
+ * Marks the assertion DSL.
+ */
+@DslMarker
+annotation class AssertkDsl
+
+/**
  * An assertion. Holds an actual value to assertion on and an optional name.
  * @see [assert]
  */
+@AssertkDsl
 class Assert<out T> internal constructor(val actual: T, val name: String?, internal val context: Any?) {
     /**
      * Asserts on the given value with an optional name.


### PR DESCRIPTION
Previously, the following code is possible:

```kotlin
assert("hello").all {
  isInstanceOf(String::class)
  toStringFun().isEqualTo("hello")
  prop(String::length).all {
    length().isEqualTo(5)
    isGreaterThan(4)
  }
}
```

This could lead to confusing code of "which block am I making the assertion on?"
With the addition of `@DslMarker`, that code will generate a compiler error like:

> 'fun <T : CharSequence> Assert<String>.length(): Assert<Int>' can't be called in this context by implicit receiver. Use the explicit one if necessary

If users want to continue doing this, they will need to be explicit with the receiver.

```kotlin
assert("hello").all string@ {
  isInstanceOf(String::class)
  toStringFun().isEqualTo("hello")
  prop(String::length).all {
    this@string.length().isEqualTo(5)
    isGreaterThan(4)
  }
}
```

I'm not sure if we need it anywhere else asside from the `Assert` type.