### PR TITLE
Add support for more types in `show` and add tests to verify the beha…

### DIFF
--- a/src/main/kotlin/assertk/assertions/support/support.kt
+++ b/src/main/kotlin/assertk/assertions/support/support.kt
@@ -15,6 +15,10 @@ private fun display(value: Any?): String {
     return when (value) {
         null -> "null"
         is String -> "\"$value\""
+        is Char -> "'$value'"
+        is Byte -> "0x%02X".format(value)
+        is Long -> "${value}L"
+        is Float -> "${value}f"
         is Class<*> -> value.name
         is Array<*> -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is Collection<*> -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
@@ -22,6 +26,14 @@ private fun display(value: Any?): String {
                 prefix = "{",
                 postfix = "}",
                 transform = { (k, v) -> "${display(k)}=${display(v)}" })
+        is BooleanArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is ByteArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is CharArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is DoubleArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is FloatArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is IntArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is LongArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is ShortArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is Regex -> "/$value/"
         else -> value.toString()
     }

--- a/src/test/kotlin/test/assertk/assertions/MapSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/MapSpec.kt
@@ -135,21 +135,21 @@ class MapSpec : Spek({
                     "test should fail when not containing all entries expected regardless of order") {
                 Assertions.assertThatThrownBy {
                     assertk.assert(mapOf(1 to 'i', 2 to 'j', 3 to 'k')).containsAll(4 to 'a', 1 to 'i')
-                }.hasMessage("expected to contain:<{4=a, 1=i}> but was:<{1=i, 2=j, 3=k}>")
+                }.hasMessage("expected to contain:<{4='a', 1='i'}> but was:<{1='i', 2='j', 3='k'}>")
             }
 
             it("Given a map of multiple entries with less entries given than expected, " +
                     "test should fail when not containing all entries expected regardless of order") {
                 Assertions.assertThatThrownBy {
                     assertk.assert(mapOf(1 to 'i', 3 to 'k')).containsAll(3 to 'k', 1 to 'i', 2 to 'j')
-                }.hasMessage("expected to contain:<{3=k, 1=i, 2=j}> but was:<{1=i, 3=k}>")
+                }.hasMessage("expected to contain:<{3='k', 1='i', 2='j'}> but was:<{1='i', 3='k'}>")
             }
 
             it("Given an empty map, " +
                     "test should fail when expecting anything") {
                 Assertions.assertThatThrownBy {
                     assertk.assert(emptyMap<Any?, Any?>()).containsAll(1 to 'x')
-                }.hasMessage("expected to contain:<{1=x}> but was:<{}>")
+                }.hasMessage("expected to contain:<{1='x'}> but was:<{}>")
             }
 
             it("Given two failing assertions, " +
@@ -160,7 +160,7 @@ class MapSpec : Spek({
                         assertk.assert(emptyMap<Any?, Any?>()).containsAll(1 to 0)
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to contain:<{1=y}> but was:<{1=x}>\n"
+                        + "- expected to contain:<{1='y'}> but was:<{1='x'}>\n"
                         + "- expected to contain:<{1=0}> but was:<{}>")
             }
 
@@ -173,7 +173,7 @@ class MapSpec : Spek({
                         assertk.assert(emptyMap<Any?, Any?>()).containsAll(1 to 0)
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to contain:<{1=y}> but was:<{1=x}>\n"
+                        + "- expected to contain:<{1='y'}> but was:<{1='x'}>\n"
                         + "- expected to contain:<{1=0}> but was:<{}>")
             }
         }
@@ -198,14 +198,14 @@ class MapSpec : Spek({
                     "test should fail") {
                 Assertions.assertThatThrownBy {
                     assertk.assert(mapOf(1 to 'x', 2 to 'y')).hasSameSizeAs(mapOf(1 to 'x'))
-                }.hasMessage("expected to have same size as:<{1=x}> (1) but was size:(2)")
+                }.hasMessage("expected to have same size as:<{1='x'}> (1) but was size:(2)")
             }
 
             it("Given an empty map and a map with 1 entry, " +
                     "test should fail") {
                 Assertions.assertThatThrownBy {
                     assertk.assert(emptyMap<Any?, Any?>()).hasSameSizeAs(mapOf(1 to 'x'))
-                }.hasMessage("expected to have same size as:<{1=x}> (1) but was size:(0)")
+                }.hasMessage("expected to have same size as:<{1='x'}> (1) but was size:(0)")
             }
 
             it("Given two failing assertions, " +
@@ -216,8 +216,8 @@ class MapSpec : Spek({
                         assertk.assert(emptyMap<Any?, Any?>()).hasSameSizeAs(mapOf(1 to 'x'))
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to have same size as:<{1=x}> (1) but was size:(2)\n"
-                        + "- expected to have same size as:<{1=x}> (1) but was size:(0)")
+                        + "- expected to have same size as:<{1='x'}> (1) but was size:(2)\n"
+                        + "- expected to have same size as:<{1='x'}> (1) but was size:(0)")
             }
 
             it("Given one passing and two failing assertions, " +
@@ -229,8 +229,8 @@ class MapSpec : Spek({
                         assertk.assert(emptyMap<Any?, Any?>()).hasSameSizeAs(mapOf(1 to 'x'))
                     }
                 }.hasMessage("The following 2 assertions failed:\n"
-                        + "- expected to have same size as:<{1=x}> (1) but was size:(2)\n"
-                        + "- expected to have same size as:<{1=x}> (1) but was size:(0)")
+                        + "- expected to have same size as:<{1='x'}> (1) but was size:(2)\n"
+                        + "- expected to have same size as:<{1='x'}> (1) but was size:(0)")
             }
         }
     }

--- a/src/test/kotlin/test/assertk/assertions/support/SupportSpec.kt
+++ b/src/test/kotlin/test/assertk/assertions/support/SupportSpec.kt
@@ -1,0 +1,124 @@
+package test.assertk.assertions.support
+
+import assertk.assertions.support.show
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.on
+
+private class Dummy(private val i: Int) {
+  override fun toString(): String = "Dummy=$i"
+}
+
+class SupportSpec : Spek({
+  val anonymous = object : Any() {}
+
+  describe("show") {
+    on("null") {
+      assertThat(show(null)).isEqualTo("<null>")
+    }
+    on("boolean") {
+      assertThat(show(true)).isEqualTo("<true>")
+    }
+    on("byte") {
+      assertThat(show(15.toByte())).isEqualTo("<0x0F>")
+    }
+    on("char") {
+      assertThat(show('c')).isEqualTo("<'c'>")
+    }
+    on("double") {
+      assertThat(show(1.234567890123)).isEqualTo("<1.234567890123>")
+    }
+    on("float") {
+      assertThat(show(1.2345f)).isEqualTo("<1.2345f>")
+    }
+    on("int") {
+      assertThat(show(42)).isEqualTo("<42>")
+    }
+    on("long") {
+      assertThat(show(42L)).isEqualTo("<42L>")
+    }
+    on("short") {
+      assertThat(show(42.toShort())).isEqualTo("<42>")
+    }
+    on("string") {
+      assertThat(show("value")).isEqualTo("<\"value\">")
+    }
+    group("class") {
+      on("predefined") {
+        assertThat(show(Dummy::class)).isEqualTo("<class test.assertk.assertions.support.Dummy>")
+      }
+      on("anonymous") {
+        assertThat(show(anonymous::class)).isEqualTo("<class test.assertk.assertions.support.SupportSpec\$1\$anonymous\$1>")
+      }
+    }
+    group("java class") {
+      // TODO: mkobit: figure if these are needed for multi-platform support
+      on("predefined") {
+        assertThat(show(Dummy::class.java)).isEqualTo("<test.assertk.assertions.support.Dummy>")
+      }
+      on("anonymous") {
+        assertThat(show(anonymous::class.java)).isEqualTo("<test.assertk.assertions.support.SupportSpec\$1\$anonymous\$1>")
+      }
+    }
+    group("array") {
+      on("generic array") {
+        val array = arrayOf(Dummy(0), Dummy(1))
+        assertThat(show(array)).isEqualTo("<[Dummy=0, Dummy=1]>")
+      }
+      on("boolean array") {
+        assertThat(show(booleanArrayOf(false, true))).isEqualTo("<[false, true]>")
+      }
+      on("byte array") {
+        assertThat(show(byteArrayOf(10, 15))).isEqualTo("<[0x0A, 0x0F]>")
+      }
+      on("char array") {
+        assertThat(show(charArrayOf('a', 'b'))).isEqualTo("<['a', 'b']>")
+      }
+      on("double array") {
+        assertThat(show(doubleArrayOf(1.2345, 6.789))).isEqualTo("<[1.2345, 6.789]>")
+      }
+      on("float array") {
+        assertThat(show(floatArrayOf(1.2345f, 6.789f))).isEqualTo("<[1.2345f, 6.789f]>")
+      }
+      on("int array") {
+        assertThat(show(intArrayOf(42, 8))).isEqualTo("<[42, 8]>")
+      }
+      on("long array") {
+        assertThat(show(longArrayOf(42L, 8L))).isEqualTo("<[42L, 8L]>")
+      }
+      on("short array") {
+        assertThat(show(shortArrayOf(42, -1))).isEqualTo("<[42, -1]>")
+      }
+    }
+    group("collection") {
+      on("list") {
+        assertThat(show(listOf(1, 2, 3))).isEqualTo("<[1, 2, 3]>")
+      }
+      on("nested list") {
+        assertThat(show(listOf(
+            listOf(1, 2, 3),
+            listOf(4, 5, 6)
+        ))).isEqualTo("<[[1, 2, 3], [4, 5, 6]]>")
+      }
+      on("set") {
+        assertThat(show(setOf(1,2,3))).isEqualTo("<[1, 2, 3]>")
+      }
+    }
+    on("map") {
+      assertThat(show(mapOf(1 to 5, 2 to 6))).isEqualTo("<{1=5, 2=6}>")
+    }
+    on("regex") {
+      assertThat(show(Regex("^abcd$"))).isEqualTo("</^abcd$/>")
+    }
+    on("other type") {
+      val other = object : Any() {
+        override fun toString(): String = "different"
+      }
+      assertThat(show(other)).isEqualTo("<different>")
+    }
+    on("different wrapper") {
+      assertThat(show(42, "##")).isEqualTo("#42#")
+    }
+  }
+})


### PR DESCRIPTION
…vior

-----

#### Notes

* I just picked output formats for `Byte`, `Long`, `Float` to sort of disambiguate them. I know I've ran into problems before trying to compare things in JVM land like `Long` and `Integer` and being confused why my assertions error messages say they are the same thing in the string output. I believe AssertJ 
* I left the `Class<*>` alone for now, but think it might be useful to change how the classes are output anyways, and I think that will need to be touched if multiplatform support is coming
* unfortunately all of the primitive array type need to be special cased

Side note, I saw `AnyTest.kt` was recently written using JUnit Jupiter instead of Spek, but the Reame says use `Spek`. After using spek my vote is definitrely for just using JUnit Jupiter engine.