### PR TITLE
Support primative array types through simple templating system

### DIFF
--- a/assertk-common/build.gradle
+++ b/assertk-common/build.gradle
@@ -6,4 +6,21 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-test-common"
 }
 
+task compileTemplates(type: TemplateTask) {
+    inputDir = file('src/template')
+    outputDir = file("$buildDir/generated/template")
+}
+
+task testTemplates(type: TemplateTask) {
+    inputDir = file('src/testTemplate')
+    outputDir = file("$buildDir/generated/testTemplate")
+}
+
+sourceSets {
+    main.kotlin.srcDirs += "$buildDir/generated/template"
+    test.kotlin.srcDirs += "$buildDir/generated/testTemplate"
+}
+
+compileKotlinCommon.dependsOn(compileTemplates, testTemplates)
+
 apply from: '../publish.gradle'

--- a/assertk-common/src/main/kotlin/assertk/assertions/support/support.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/support/support.kt
@@ -9,7 +9,11 @@ import assertk.fail
  * @param wrap What characters to wrap around the value. This should be a pair of characters where the first is at the
  * beginning and the second is at the end. For example, "()" will show (value). The default is "<>".
  */
-fun show(value: Any?, wrap: String = "<>"): String = "${wrap[0]}${display(value)}${wrap[1]}"
+fun show(value: Any?, wrap: String = "<>"): String =
+    "${prefix(wrap)}${display(value)}${suffix(wrap)}"
+
+private fun prefix(wrap: String): String = if (wrap.length > 0) wrap[0].toString() else ""
+private fun suffix(wrap: String): String = if (wrap.length > 1) wrap[1].toString() else ""
 
 internal fun display(value: Any?): String {
     return when (value) {
@@ -20,22 +24,22 @@ internal fun display(value: Any?): String {
         is Array<*> -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is Collection<*> -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is Map<*, *> -> value.entries.joinToString(
-                prefix = "{",
-                postfix = "}",
-                transform = { (k, v) -> "${display(k)}=${display(v)}" })
+            prefix = "{",
+            postfix = "}",
+            transform = { (k, v) -> "${display(k)}=${display(v)}" })
         is BooleanArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is CharArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is IntArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is DoubleArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is LongArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is ShortArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is ByteArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is FloatArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         else -> displayPlatformSpecific(value)
     }
 }
 
-expect
-@Suppress("UndocumentedPublicFunction")
-internal fun displayPlatformSpecific(value: Any?): String
+internal expect fun displayPlatformSpecific(value: Any?): String
 
 /**
  * Fails an assert with the given expected and actual values.

--- a/assertk-common/src/template/assertk/assertions/primativeArray.kt
+++ b/assertk-common/src/template/assertk/assertions/primativeArray.kt
@@ -1,0 +1,166 @@
+package assertk.assertions
+
+import assertk.Assert
+import assertk.PlatformName
+import assertk.assertAll
+import assertk.assertions.support.ListDiffer
+import assertk.assertions.support.expected
+import assertk.assertions.support.show
+
+$T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArray:Short, LongArray:longArray:Long, FloatArray:floatArray:Float, DoubleArray:doubleArray:Double, CharArray:charArray:Char
+
+/**
+ * Returns an assert on the $T's size.
+ */
+@PlatformName("$NSize")
+fun Assert<$T>.size() = prop("size", $T::size)
+
+/**
+ * Asserts the $T is empty.
+ * @see [isNotEmpty]
+ * @see [isNullOrEmpty]
+ */
+@PlatformName("$NIsEmpty")
+fun Assert<$T>.isEmpty() {
+    if (actual.isEmpty()) return
+    expected("to be empty but was:${show(actual)}")
+}
+
+/**
+ * Asserts the $T is not empty.
+ * @see [isEmpty]
+ */
+@PlatformName("$NIsNotEmpty")
+fun Assert<$T>.isNotEmpty() {
+    if (actual.isNotEmpty()) return
+    expected("to not be empty")
+}
+
+/**
+ * Asserts the $T is null or empty.
+ * @see [isEmpty]
+ */
+@PlatformName("$NIsNullOrEmpty")
+fun Assert<$T?>.isNullOrEmpty() {
+    if (actual == null || actual.isEmpty()) return
+    expected("to be null or empty but was:${show(actual)}")
+}
+
+/**
+ * Asserts the $T has the expected size.
+ */
+@PlatformName("$NHasSize")
+fun Assert<$T>.hasSize(size: Int) {
+    assert(actual.size, "size").isEqualTo(size)
+}
+
+/**
+ * Asserts the $T has the same size as the expected array.
+ */
+@PlatformName("$NHasSameSizeAs")
+fun Assert<$T>.hasSameSizeAs(other: $T) {
+    val actualSize = actual.size
+    val otherSize = other.size
+    if (actualSize == otherSize) return
+    expected("to have same size as:${show(other)} ($otherSize) but was size:($actualSize)")
+}
+
+/**
+ * Asserts the $T contains the expected element, using `in`.
+ * @see [doesNotContain]
+ */
+@PlatformName("$NContains")
+fun Assert<$T>.contains(element: $E) {
+    if (element in actual) return
+    expected("to contain:${show(element)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the $T does not contain the expected element, using `!in`.
+ * @see [contains]
+ */
+@PlatformName("$NDoesNotContain")
+fun Assert<$T>.doesNotContain(element: $E) {
+    if (element !in actual) return
+    expected("to not contain:${show(element)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the $T does not contain any of the expected elements.
+ * @see [containsAll]
+ */
+fun Assert<$T>.containsNone(vararg elements: $E) {
+    if (elements.none { it in actual }) {
+        return
+    }
+
+    val notExpected = elements.filter { it in actual }
+    expected("to contain none of:${show(elements)} some elements were not expected:${show(notExpected)}")
+}
+
+/**
+ * Asserts the $T contains all the expected elements, in any order. The array may also contain
+ * additional elements.
+ * @see [containsExactly]
+ */
+@PlatformName("$NContainsAll")
+fun Assert<$T>.containsAll(vararg elements: $E) {
+    if (elements.all { actual.contains(it) }) return
+    val notFound = elements.filterNot { it in actual }
+    expected("to contain all:${show(elements)} some elements were not found:${show(notFound)}")
+}
+
+/**
+ * Returns an assert that assertion on the value at the given index in the $T.
+ *
+ * ```
+ * assert($NOf(0, 1, 2)).index(1) { it.isPositive() }
+ * ```
+ */
+@PlatformName("$NIndex")
+fun Assert<$T>.index(index: Int, f: (Assert<$E>) -> Unit) {
+    if (index in 0 until actual.size) {
+        f(assert(actual[index], "${name ?: ""}${show(index, "[]")}"))
+    } else {
+        expected("index to be in range:[0-${actual.size}) but was:${show(index)}")
+    }
+}
+
+/**
+ * Asserts the $T contains exactly the expected elements. They must be in the same order and
+ * there must not be any extra elements.
+ * @see [containsAll]
+ */
+@PlatformName("$NContainsExactly")
+fun Assert<$T>.containsExactly(vararg elements: $E) {
+    if (actual.contentEquals(elements)) return
+
+    val diff = ListDiffer.diff(elements.asList(), actual.asList())
+        .filterNot { it is ListDiffer.Edit.Eq }
+
+    expected(diff.joinToString(prefix = "to contain exactly:\n", separator = "\n") { edit ->
+        when (edit) {
+            is ListDiffer.Edit.Del -> " at index:${edit.oldIndex} expected:${show(edit.oldValue)}"
+            is ListDiffer.Edit.Ins -> " at index:${edit.newIndex} unexpected:${show(edit.newValue)}"
+            else -> throw IllegalStateException()
+        }
+    })
+}
+
+/**
+ * Asserts on each item in the $T. The given lambda will be run for each item.
+ *
+ * ```
+ * assert($NOf("one", "two")).each {
+ *   it.hasLength(3)
+ * }
+ * ```
+ */
+@PlatformName("$NEach")
+fun Assert<$T>.each(f: (Assert<$E>) -> Unit) {
+    assertAll {
+        actual.forEachIndexed { index, item ->
+            f(assert(item, "${name ?: ""}${show(index, "[]")}"))
+        }
+    }
+}

--- a/assertk-common/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
+++ b/assertk-common/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
@@ -1,0 +1,242 @@
+package test.assertk.assertions
+
+import assertk.assert
+import assertk.assertions.*
+import assertk.assertions.support.show
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+$T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArray:Short, LongArray:longArray:Long, FloatArray:floatArray:Float, DoubleArray:doubleArray:Double, CharArray:charArray:Char
+
+class $TTest {
+    //region isEmpty
+    @Test fun isEmpty_empty_passes() {
+        assert($NOf()).isEmpty()
+    }
+
+    @Test fun isEmpty_non_empty_fails() {
+        val error = assertFails {
+            assert($NOf(0.to$E())).isEmpty()
+        }
+        assertEquals("expected to be empty but was:<[${show(0.to$E(), "")}]>", error.message)
+    }
+    //endregion
+
+    //region isNotEmpty
+    @Test fun isNotEmpty_non_empty_passes() {
+        assert($NOf(0.to$E())).isNotEmpty()
+    }
+
+    @Test fun isNotEmpty_empty_fails() {
+        val error = assertFails {
+            assert($NOf()).isNotEmpty()
+        }
+        assertEquals("expected to not be empty", error.message)
+    }
+    //endregion
+
+    //region isNullOrEmpty
+    @Test fun isNullOrEmpty_null_passes() {
+        assert(null as $T?).isNullOrEmpty()
+    }
+
+    @Test fun isNullOrEmpty_empty_passes() {
+        assert($NOf()).isNullOrEmpty()
+    }
+
+    @Test fun isNullOrEmpty_non_empty_fails() {
+        val error = assertFails {
+            assert($NOf(0.to$E())).isNullOrEmpty()
+        }
+        assertEquals("expected to be null or empty but was:<[${show(0.to$E(), "")}]>", error.message)
+    }
+    //endregion
+
+    //region hasSize
+    @Test fun hasSize_correct_size_passes() {
+        assert($NOf()).hasSize(0)
+    }
+
+    @Test fun hasSize_wrong_size_fails() {
+        val error = assertFails {
+            assert($NOf()).hasSize(1)
+        }
+        assertEquals("expected [size]:<[1]> but was:<[0]> ([])", error.message)
+    }
+    //endregion
+
+    //region hasSameSizeAs
+    @Test fun hasSameSizeAs_equal_sizes_passes() {
+        assert($NOf()).hasSameSizeAs($NOf())
+    }
+
+    @Test fun hasSameSizeAs_non_equal_sizes_fails() {
+        val error = assertFails {
+            assert($NOf()).hasSameSizeAs($NOf(0.to$E()))
+        }
+        assertEquals("expected to have same size as:<[${show(0.to$E(), "")}]> (1) but was size:(0)", error.message)
+    }
+    //endregion
+
+    //region contains
+    @Test fun contains_element_present_passes() {
+        assert($NOf(1.to$E(), 2.to$E())).contains(2.to$E())
+    }
+
+    @Test fun contains_element_missing_fails() {
+        val error = assertFails {
+            assert($NOf()).contains(1.to$E())
+        }
+        assertEquals("expected to contain:<${show(1.to$E(), "")}> but was:<[]>", error.message)
+    }
+    //endregion
+
+    //region doesNotContain
+    @Test fun doesNotContain_element_missing_passes() {
+        assert($NOf()).doesNotContain(1.to$E())
+    }
+
+    @Test fun doesNotContain_element_present_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 2.to$E())).doesNotContain(2.to$E())
+        }
+        assertEquals("expected to not contain:<${show(2.to$E(), "")}> but was:<[${show(1.to$E(), "")}, ${show(2.to$E(), "")}]>", error.message)
+    }
+    //endregion
+
+    //region containsNone
+    @Test fun containsNone_missing_elements_passes() {
+        assert($NOf()).containsNone(1.to$E())
+    }
+
+    @Test fun containsNone_present_element_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 2.to$E())).containsNone(2.to$E(), 3.to$E())
+        }
+        assertEquals("expected to contain none of:<[${show(2.to$E(), "")}, ${show(3.to$E(), "")}]> some elements were not expected:<[${show(2.to$E(), "")}]>", error.message)
+    }
+    //region
+
+    //region containsAll
+    @Test fun containsAll_all_elements_passes() {
+        assert($NOf(1.to$E(), 2.to$E())).containsAll(2.to$E(), 1.to$E())
+    }
+
+    @Test fun containsAll_some_elements_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E())).containsAll(1.to$E(), 2.to$E())
+        }
+        assertEquals("expected to contain all:<[${show(1.to$E(), "")}, ${show(2.to$E(), "")}]> some elements were not found:<[${show(2.to$E(), "")}]>", error.message)
+    }
+    //endregion
+
+    //region containsExactly
+    @Test fun containsExactly_all_elements_in_same_order_passes() {
+        assert($NOf(1.to$E(), 2.to$E())).containsExactly(1.to$E(), 2.to$E())
+    }
+
+    @Test fun containsExactly_all_elements_in_different_order_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 2.to$E())).containsExactly(2.to$E(), 1.to$E())
+        }
+        assertEquals(
+            """expected to contain exactly:
+                | at index:0 expected:<${show(2.to$E(), "")}>
+                | at index:1 unexpected:<${show(2.to$E(), "")}>
+            """.trimMargin(), error.message
+        )
+    }
+
+    @Test fun containsExactly_missing_element_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 2.to$E())).containsExactly(3.to$E())
+        }
+        assertEquals(
+            """expected to contain exactly:
+                | at index:0 expected:<${show(3.to$E(), "")}>
+                | at index:0 unexpected:<${show(1.to$E(), "")}>
+                | at index:1 unexpected:<${show(2.to$E(), "")}>
+            """.trimMargin(), error.message
+        )
+    }
+
+    @Test fun containsExactly_extra_element_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 2.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
+        }
+        assertEquals(
+            """expected to contain exactly:
+                | at index:2 expected:<${show(3.to$E(), "")}>
+            """.trimMargin(), error.message
+        )
+    }
+
+    @Test fun containsExactly_missing_element_in_middle_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 3.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
+        }
+        assertEquals(
+            """expected to contain exactly:
+                | at index:1 expected:<${show(2.to$E(), "")}>
+            """.trimMargin(), error.message
+        )
+    }
+
+    @Test fun containsExactly_extra_element_in_middle_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsExactly(1.to$E(), 3.to$E())
+        }
+        assertEquals(
+            """expected to contain exactly:
+                | at index:1 unexpected:<${show(2.to$E(), "")}>
+            """.trimMargin(), error.message
+        )
+    }
+    //endregion
+
+    //region each
+    @Test fun each_empty_list_passes() {
+        assert($NOf()).each { it.isEqualTo(1) }
+    }
+
+    @Test fun each_content_passes() {
+        assert($NOf(1.to$E(), 2.to$E())).each { it.isGreaterThan(0.to$E()) }
+    }
+
+    @Test fun each_non_matching_content_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 2.to$E(), 3.to$E())).each { it.isLessThan(2.to$E()) }
+        }
+        assertEquals(
+            """The following 2 assertions failed:
+                |- expected [[1]] to be less than:<${show(2.to$E(), "")}> but was:<${show(2.to$E(), "")}> ([${show(1.to$E(), "")}, ${show(2.to$E(), "")}, ${show(3.to$E(), "")}])
+                |- expected [[2]] to be less than:<${show(2.to$E(), "")}> but was:<${show(3.to$E(), "")}> ([${show(1.to$E(), "")}, ${show(2.to$E(), "")}, ${show(3.to$E(), "")}])
+            """.trimMargin(), error.message
+        )
+    }
+    //endregion
+
+    //region index
+    @Test fun index_successful_assertion_passes() {
+        assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0) { it.isEqualTo(1.to$E()) }
+    }
+
+    @Test fun index_unsuccessful_assertion_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0) { it.isGreaterThan(2.to$E()) }
+        }
+        assertEquals(
+            "expected [subject[0]] to be greater than:<${show(2.to$E(), "")}> but was:<${show(1.to$E(), "")}> ([${show(1.to$E(), "")}, ${show(2.to$E(), "")}])",
+            error.message
+        )
+    }
+
+    @Test fun index_out_of_range_fails() {
+        val error = assertFails {
+            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1) { it.isEqualTo(listOf(1.to$E())) }
+        }
+        assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
+    }
+    //endregion
+}

--- a/assertk-js/src/main/kotlin/assertk/assertions/support/support.kt
+++ b/assertk-js/src/main/kotlin/assertk/assertions/support/support.kt
@@ -1,7 +1,7 @@
 package assertk.assertions.support
 
-actual
-@Suppress("UndocumentedPublicFunction")
-internal fun displayPlatformSpecific(value: Any?): String {
+internal actual fun displayPlatformSpecific(value: Any?): String {
+    "".toList().joinToString(transform = { it.toByte().toString()})
     return value.toString()
+
 }

--- a/assertk-js/src/main/kotlin/assertk/failure.kt
+++ b/assertk-js/src/main/kotlin/assertk/failure.kt
@@ -1,7 +1,5 @@
 package assertk
 
-actual
-@Suppress("NOTHING_TO_INLINE", "UndocumentedPublicFunction")
-internal inline fun failWithNotInStacktrace(error: AssertionError): Nothing {
+internal actual inline fun failWithNotInStacktrace(error: AssertionError): Nothing {
     throw error
 }

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/support/support.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/support/support.kt
@@ -1,15 +1,11 @@
 @file:JvmName("SupportJVMKt")
 package assertk.assertions.support
 
-actual
-@Suppress("UndocumentedPublicFunction")
-internal fun displayPlatformSpecific(value: Any?): String {
+internal actual fun displayPlatformSpecific(value: Any?): String {
     return when (value) {
         is Byte -> "0x%02X".format(value)
         is Float -> "${value}f"
         is Regex -> "/$value/"
-        is ByteArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
-        is FloatArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is Class<*> -> value.name
         else -> value.toString()
     }

--- a/assertk-jvm/src/main/kotlin/assertk/failure.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/failure.kt
@@ -2,9 +2,7 @@
 
 package assertk
 
-actual
-@Suppress("NOTHING_TO_INLINE", "UndocumentedPublicFunction")
-internal inline fun failWithNotInStacktrace(error: AssertionError): Nothing {
+internal actual inline fun failWithNotInStacktrace(error: AssertionError): Nothing {
     val filtered = error.stackTrace
             .dropWhile { it.className.startsWith("assertk") }
             .toTypedArray()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+    ext.kotlin_version = '1.2.41'
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+apply plugin: 'kotlin'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile gradleApi()
+    compile "org.jetbrains.kotlin:kotlin-stdlib"
+}

--- a/buildSrc/src/main/kotlin/TemplateTask.kt
+++ b/buildSrc/src/main/kotlin/TemplateTask.kt
@@ -1,0 +1,104 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Generates multiple copies of kotlin code from a template, with simple text replacement. ex:
+ * ```
+ * package test
+ *
+ * $T = String, Int
+ *
+ * fun foo(arg: $T) {
+ * }
+ * ```
+ *
+ * will generate
+ *
+ * ```
+ * package test
+ *
+ * fun foo(arg: String) {
+ * }
+ *
+ * fun foo(arg: Int) {
+ * }
+ * ```
+ *
+ * Note that anything above replacement declaration (`$T = ...`) is placed once and everything after is placed n times.
+ *
+ * You can specify multiple 'groups' of replacements by seperating them with a ':'. This is useful for generics
+ * replacements when the type is known.
+ *
+ * ```
+ * package test
+ *
+ * $T:$E = ByteArray:Byte, CharArray:Char
+ *
+ * fun foo(one: $T, two: $E) {
+ * }
+ * ```
+ *
+ * will generate
+ *
+ * ```
+ * package test
+ *
+ * fun foo(one: ByteArray, two: Byte) {
+ * }
+ *
+ * fun foo(one: CharArray, two: Char) {
+ * }
+ * ```
+ */
+open class TemplateTask : DefaultTask() {
+    @InputDirectory
+    lateinit var inputDir: File
+    @OutputDirectory
+    lateinit var outputDir: File
+
+    @TaskAction
+    fun run() {
+        outputDir.deleteRecursively()
+        inputDir.walkTopDown().filter { it.isFile && it.extension == "kt" }.forEach { template ->
+            val outputFile = outputDir.resolve(template.relativeTo(inputDir))
+            outputFile.parentFile.mkdirs()
+            val lines = template.readLines()
+            val tokenLineIndex = lines.indexOfFirst { it.startsWith("$") }
+            val tokenLine = lines[tokenLineIndex]
+            val tokens = tokenLine.substringBefore('=').split(':').cleanup()
+            val replacements = tokenLine.substringAfter('=')
+                .split(',')
+                .cleanup()
+                .map { it.split(':').cleanup() }
+
+            outputFile.bufferedWriter().use { out ->
+                for (lineIndex in 0 until tokenLineIndex) {
+                    out.write(lines[lineIndex])
+                    out.write("\n")
+                }
+
+                for (replacementIndex in 0 until replacements.size) {
+                    for (lineIndex in tokenLineIndex + 1 until lines.size) {
+                        var line = lines[lineIndex]
+                        if (lineIndex == tokenLineIndex + 1 && line.isBlank()) {
+                            continue
+                        }
+                        for (tokenIndex in 0 until tokens.size) {
+                            val token = tokens[tokenIndex]
+                            val replacement = replacements[replacementIndex][tokenIndex]
+                            line = line.replace(token, replacement)
+                        }
+                        out.write(line)
+                        out.write("\n")
+                    }
+                    out.write("\n")
+                }
+            }
+        }
+    }
+}
+
+private fun List<String>.cleanup(): List<String> = map { it.trim() }.filter { it.isNotEmpty() }


### PR DESCRIPTION
See buildSrc/src/main/kotlin/TemplateTask.kt for details.

Fixes #79