### PR TITLE
Change all assert lambdas to take an implicit receiver

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assertions/any.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/any.kt
@@ -122,7 +122,7 @@ fun <T : Any> Assert<T?>.isNull() {
  * }
  * ```
  */
-fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
+fun <T : Any> Assert<T?>.isNotNull(f: Assert<T>.() -> Unit = {}) {
     if (actual != null) {
         assert(actual, name = name).all(f)
     } else {
@@ -136,7 +136,7 @@ fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
  * @param extract The function to extract the property value out of the value of the current assert.
  *
  * ```
- * assert(person).prop("name", { it.name }).isEqualTo("Sue")
+ * assert(person).prop("name") { it.name }.isEqualTo("Sue")
  * ```
  */
 fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P)
@@ -184,7 +184,7 @@ fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) {
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
-fun <T : Any, S: T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: (Assert<S>) -> Unit = {}) {
+fun <T : Any, S: T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: Assert<S>.() -> Unit = {}) {
     if (kclass.isInstance(actual)) {
         @Suppress("UNCHECKED_CAST")
         assert(actual as S, name = name).all(f)

--- a/assertk-common/src/main/kotlin/assertk/assertions/array.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/array.kt
@@ -137,10 +137,10 @@ fun <T> Assert<Array<T>>.containsAll(vararg elements: Any?) {
  * Returns an assert that assertion on the value at the given index in the array.
  *
  * ```
- * assert(arrayOf(0, 1, 2)).index(1) { it.isPositive() }
+ * assert(arrayOf(0, 1, 2)).index(1) { isPositive() }
  * ```
  */
-fun <T> Assert<Array<T>>.index(index: Int, f: (Assert<T>) -> Unit) {
+fun <T> Assert<Array<T>>.index(index: Int, f: Assert<T>.() -> Unit) {
     if (index in 0 until actual.size) {
         f(assert(actual[index], "${name ?: ""}${show(index, "[]")}"))
     } else {
@@ -174,12 +174,12 @@ fun <T> Assert<Array<T>>.containsExactly(vararg elements: Any?) {
  *
  * ```
  * assert(arrayOf("one", "two")).each {
- *   it.hasLength(3)
+ *   hasLength(3)
  * }
  * ```
  */
 @PlatformName("arrayEach")
-fun <T> Assert<Array<T>>.each(f: (Assert<T>) -> Unit) {
+fun <T> Assert<Array<T>>.each(f: Assert<T>.() -> Unit) {
     assertAll {
         actual.forEachIndexed { index, item ->
             f(assert(item, "${name ?: ""}${show(index, "[]")}"))

--- a/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
@@ -28,11 +28,11 @@ fun <T : Iterable<*>> Assert<T>.doesNotContain(element: Any?) {
  *
  * ```
  * assert(listOf("one", "two")).each {
- *   it.hasLength(3)
+ *   hasLength(3)
  * }
  * ```
  */
-fun <E, T : Iterable<E>> Assert<T>.each(f: (Assert<E>) -> Unit) {
+fun <E, T : Iterable<E>> Assert<T>.each(f: Assert<E>.() -> Unit) {
     assertAll {
         actual.forEachIndexed { index, item ->
             f(assert(item, "${name ?: ""}${show(index, "[]")}"))

--- a/assertk-common/src/main/kotlin/assertk/assertions/list.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/list.kt
@@ -9,10 +9,10 @@ import assertk.assertions.support.show
  * Returns an assert that assertion on the value at the given index in the list.
  *
  * ```
- * assert(listOf(0, 1, 2)).index(1) { it.isPositive() }
+ * assert(listOf(0, 1, 2)).index(1) { isPositive() }
  * ```
  */
-fun <T> Assert<List<T>>.index(index: Int, f: (Assert<T>) -> Unit) {
+fun <T> Assert<List<T>>.index(index: Int, f: Assert<T>.() -> Unit) {
     if (index in 0 until actual.size) {
         f(assert(actual[index], "${name ?: ""}${show(index, "[]")}"))
     } else {

--- a/assertk-common/src/main/kotlin/assertk/assertions/map.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/map.kt
@@ -147,10 +147,10 @@ fun <K, V> Assert<Map<K, V>>.containsOnly(vararg elements: Pair<K, V>) {
  * Returns an assert that asserts on the value at the given key in the map.
  *
  * ```
- * assert(mapOf("key" to "value")).key("key") { it.isEqualTo("value") }
+ * assert(mapOf("key" to "value")).key("key") { isEqualTo("value") }
  * ```
  */
-fun <K, V> Assert<Map<K, V>>.key(key: K, f: (Assert<V>) -> Unit) {
+fun <K, V> Assert<Map<K, V>>.key(key: K, f: Assert<V>.() -> Unit) {
     if (key in actual) {
         f(assert(actual.getValue(key), "${name ?: ""}${show(key, "[]")}"))
     } else {

--- a/assertk-common/src/main/kotlin/assertk/assertions/throwable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/throwable.kt
@@ -32,8 +32,8 @@ fun <T : Throwable> Assert<T>.hasMessage(message: String?) {
  */
 fun <T : Throwable> Assert<T>.hasCause(cause: Throwable) {
     cause().isNotNull {
-        it.kClass().isEqualTo(cause::class)
-        it.hasMessage(cause.message)
+        kClass().isEqualTo(cause::class)
+        hasMessage(cause.message)
     }
 }
 
@@ -59,56 +59,48 @@ fun <T : Throwable> Assert<T>.hasRootCause(cause: Throwable) {
  * Asserts the throwable has a message starting with the expected string.
  */
 @Deprecated(
-    message = "Use message().isNotNull { it.startsWith(prefix) } instead.",
-    replaceWith = ReplaceWith("message().isNotNull { it.startsWith(prefix) }"),
+    message = "Use message().isNotNull { startsWith(prefix) } instead.",
+    replaceWith = ReplaceWith("message().isNotNull { startsWith(prefix) }"),
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasMessageStartingWith(prefix: String) {
-    assert(actual.message, "message").isNotNull {
-        it.startsWith(prefix)
-    }
+    assert(actual.message, "message").isNotNull { startsWith(prefix) }
 }
 
 /**
  * Asserts the throwable has a message containing the expected string.
  */
 @Deprecated(
-    message = "Use message().isNotNull { it.contains(string) } instead.",
-    replaceWith = ReplaceWith("message().isNotNull { it.contains(string) }"),
+    message = "Use message().isNotNull { contains(string) } instead.",
+    replaceWith = ReplaceWith("message().isNotNull { contains(string) }"),
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasMessageContaining(string: String) {
-    assert(actual.message, "message").isNotNull {
-        it.contains(string)
-    }
+    assert(actual.message, "message").isNotNull { contains(string) }
 }
 
 /**
  * Asserts the throwable has a messaging matching the expected regular expression.
  */
 @Deprecated(
-    message = "Use message().isNotNull { it.matches(regex) } instead.",
-    replaceWith = ReplaceWith("message().isNotNull { it.matches(regex) }"),
+    message = "Use message().isNotNull { matches(regex) } instead.",
+    replaceWith = ReplaceWith("message().isNotNull { matches(regex) }"),
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasMessageMatching(regex: Regex) {
-    assert(actual.message, "message").isNotNull {
-        it.matches(regex)
-    }
+    assert(actual.message, "message").isNotNull { matches(regex) }
 }
 
 /**
  * Asserts the throwable has a message ending with the expected string.
  */
 @Deprecated(
-    message = "Use message().isNotNull { it.endsWith(suffix) } instead.",
-    replaceWith = ReplaceWith("message().isNotNull { it.endsWith(suffix) }"),
+    message = "Use message().isNotNull { endsWith(suffix) } instead.",
+    replaceWith = ReplaceWith("message().isNotNull { endsWith(suffix) }"),
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasMessageEndingWith(suffix: String) {
-    assert(actual.message, "message").isNotNull {
-        it.endsWith(suffix)
-    }
+    assert(actual.message, "message").isNotNull { endsWith(suffix) }
 }
 
 /**
@@ -117,14 +109,12 @@ fun <T : Throwable> Assert<T>.hasMessageEndingWith(suffix: String) {
  * @see [hasRootCauseWithClass]
  */
 @Deprecated(
-    message = "Use cause().isNotNull { it.kClass().isEqualTo(kclass) } instead.",
-    replaceWith = ReplaceWith("cause().isNotNull { it.kClass().isEqualTo(kclass) }"),
+    message = "Use cause().isNotNull { kClass().isEqualTo(kclass) } instead.",
+    replaceWith = ReplaceWith("cause().isNotNull { kClass().isEqualTo(kclass) }"),
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasCauseWithClass(kclass: KClass<out T>) {
-    assert(actual.cause, "cause").isNotNull {
-        it.kClass().isEqualTo(kclass)
-    }
+    assert(actual.cause, "cause").isNotNull { kClass().isEqualTo(kclass) }
 }
 
 /**
@@ -133,14 +123,12 @@ fun <T : Throwable> Assert<T>.hasCauseWithClass(kclass: KClass<out T>) {
  * @see [hasCauseWithClass]
  */
 @Deprecated(
-    message = "Use rootCause().isNotNull { it.kClass().isEqualTo(kclass) } instead.",
-    replaceWith = ReplaceWith("rootCause().isNotNull { it.kClass().isEqualTo(kclass) }"),
+    message = "Use rootCause().isNotNull { kClass().isEqualTo(kclass) } instead.",
+    replaceWith = ReplaceWith("rootCause().isNotNull { kClass().isEqualTo(kclass) }"),
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasRootCauseWithClass(kclass: KClass<out T>) {
-    assert(actual.rootCause(), "root cause").isNotNull {
-        it.kClass().isEqualTo(kclass)
-    }
+    assert(actual.rootCause(), "root cause").isNotNull { kClass().isEqualTo(kclass) }
 }
 
 /**
@@ -149,14 +137,12 @@ fun <T : Throwable> Assert<T>.hasRootCauseWithClass(kclass: KClass<out T>) {
  * @see [hasRootCauseInstanceOf]
  */
 @Deprecated(
-    message = "Use cause().isNotNull { it.isInstanceOf(kclass) } instead.",
-    replaceWith = ReplaceWith("cause().isNotNull { it.isInstanceOf(kclass) }"),
+    message = "Use cause().isNotNull { isInstanceOf(kclass) } instead.",
+    replaceWith = ReplaceWith("cause().isNotNull { isInstanceOf(kclass) }"),
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasCauseInstanceOf(kclass: KClass<out T>) {
-    assert(actual.cause, "cause").isNotNull {
-        it.isInstanceOf(kclass)
-    }
+    assert(actual.cause, "cause").isNotNull { isInstanceOf(kclass) }
 }
 
 /**
@@ -170,9 +156,7 @@ fun <T : Throwable> Assert<T>.hasCauseInstanceOf(kclass: KClass<out T>) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasRootCauseInstanceOf(kclass: KClass<out T>) {
-    assert(actual.rootCause(), "root cause").isNotNull {
-        it.isInstanceOf(kclass)
-    }
+    assert(actual.rootCause(), "root cause").isNotNull { isInstanceOf(kclass) }
 }
 
 private fun Throwable.rootCause(): Throwable = this.cause?.rootCause() ?: this

--- a/assertk-common/src/template/assertk/assertions/primativeArray.kt
+++ b/assertk-common/src/template/assertk/assertions/primativeArray.kt
@@ -140,11 +140,11 @@ fun Assert<$T>.containsAll(vararg elements: $E) {
  * Returns an assert that assertion on the value at the given index in the $T.
  *
  * ```
- * assert($NOf(0, 1, 2)).index(1) { it.isPositive() }
+ * assert($NOf(0, 1, 2)).index(1) { isPositive() }
  * ```
  */
 @PlatformName("$NIndex")
-fun Assert<$T>.index(index: Int, f: (Assert<$E>) -> Unit) {
+fun Assert<$T>.index(index: Int, f: Assert<$E>.() -> Unit) {
     if (index in 0 until actual.size) {
         f(assert(actual[index], "${name ?: ""}${show(index, "[]")}"))
     } else {
@@ -178,12 +178,12 @@ fun Assert<$T>.containsExactly(vararg elements: $E) {
  *
  * ```
  * assert($NOf("one", "two")).each {
- *   it.hasLength(3)
+ *   hasLength(3)
  * }
  * ```
  */
 @PlatformName("$NEach")
-fun Assert<$T>.each(f: (Assert<$E>) -> Unit) {
+fun Assert<$T>.each(f: Assert<$E>.() -> Unit) {
     assertAll {
         actual.forEachIndexed { index, item ->
             f(assert(item, "${name ?: ""}${show(index, "[]")}"))

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
@@ -195,20 +195,20 @@ class AnyTest {
     }
 
     @Test fun isNotNull_non_null_and_equal_object_passes() {
-        assert(nullableSubject).isNotNull { it.isEqualTo(subject) }
+        assert(nullableSubject).isNotNull { isEqualTo(subject) }
     }
 
     @Test fun isNotNull_non_null_and_non_equal_object_fails() {
         val unequal = BasicObject("not test")
         val error = assertFails {
-            assert(nullableSubject).isNotNull { it.isEqualTo(unequal) }
+            assert(nullableSubject).isNotNull { isEqualTo(unequal) }
         }
         assertEquals("expected:<[not ]test> but was:<[]test>", error.message)
     }
 
     @Test fun isNotNull_null_and_equal_object_fails() {
         val error = assertFails {
-            assert(null as String?).isNotNull { it.isEqualTo(null) }
+            assert(null as String?).isNotNull { isEqualTo(null) }
         }
         assertEquals("expected to not be null", error.message)
     }
@@ -259,7 +259,7 @@ class AnyTest {
     @Test fun isInstanceOf_kclass_run_block_when_passes() {
         val error = assertFails {
             assert(subject as TestObject).isInstanceOf(BasicObject::class) {
-                it.prop("str", BasicObject::str).isEqualTo("wrong")
+                prop("str", BasicObject::str).isEqualTo("wrong")
             }
         }
         assertEquals("expected [str]:<\"[wrong]\"> but was:<\"[test]\"> (test)", error.message)
@@ -268,7 +268,7 @@ class AnyTest {
     @Test fun isInstanceOf_kclass_doesnt_run_block_when_fails() {
         val error = assertFails {
             assert(subject as TestObject).isInstanceOf(DifferentObject::class) {
-                it.isNull()
+                isNull()
             }
         }
         assertEquals(

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
@@ -220,16 +220,16 @@ class ArrayTest {
 
     //region each
     @Test fun each_empty_list_passes() {
-        assert(emptyArray<Int>()).each { it.isEqualTo(1) }
+        assert(emptyArray<Int>()).each { isEqualTo(1) }
     }
 
     @Test fun each_content_passes() {
-        assert(arrayOf(1, 2)).each { it.isGreaterThan(0) }
+        assert(arrayOf(1, 2)).each { isGreaterThan(0) }
     }
 
     @Test fun each_non_matching_content_fails() {
         val error = assertFails {
-            assert(arrayOf(1, 2, 3)).each { it.isLessThan(2) }
+            assert(arrayOf(1, 2, 3)).each { isLessThan(2) }
         }
         assertEquals(
             """The following assertions failed (2 failures)
@@ -242,12 +242,12 @@ class ArrayTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert(arrayOf("one", "two"), name = "subject").index(0) { it.isEqualTo("one") }
+        assert(arrayOf("one", "two"), name = "subject").index(0) { isEqualTo("one") }
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(arrayOf("one", "two"), name = "subject").index(0) { it.isEqualTo("wrong") }
+            assert(arrayOf("one", "two"), name = "subject").index(0) { isEqualTo("wrong") }
         }
         assertEquals(
             "expected [subject[0]]:<\"[wrong]\"> but was:<\"[one]\"> ([\"one\", \"two\"])",
@@ -257,7 +257,7 @@ class ArrayTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert(arrayOf("one", "two"), name = "subject").index(-1) { it.isEqualTo(listOf("one")) }
+            assert(arrayOf("one", "two"), name = "subject").index(-1) { isEqualTo(listOf("one")) }
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
@@ -35,16 +35,16 @@ class IterableTest {
 
     //region each
     @Test fun each_empty_list_passes() {
-        assert(emptyList<Int>() as Iterable<Int>).each { it.isEqualTo(1) }
+        assert(emptyList<Int>() as Iterable<Int>).each { isEqualTo(1) }
     }
 
     @Test fun each_content_passes() {
-        assert(listOf(1, 2) as Iterable<Int>).each { it.isGreaterThan(0) }
+        assert(listOf(1, 2) as Iterable<Int>).each { isGreaterThan(0) }
     }
 
     @Test fun each_non_matching_content_fails() {
         val error = assertFails {
-            assert(listOf(1, 2, 3) as Iterable<Int>).each { it.isLessThan(2) }
+            assert(listOf(1, 2, 3) as Iterable<Int>).each { isLessThan(2) }
         }
         assertEquals(
             """The following assertions failed (2 failures)

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ListTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ListTest.kt
@@ -75,12 +75,12 @@ class ListTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert(listOf("one", "two"), name = "subject").index(0) { it.isEqualTo("one") }
+        assert(listOf("one", "two"), name = "subject").index(0) { isEqualTo("one") }
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(listOf("one", "two"), name = "subject").index(0) { it.isEqualTo("wrong") }
+            assert(listOf("one", "two"), name = "subject").index(0) { isEqualTo("wrong") }
         }
         assertEquals(
             "expected [subject[0]]:<\"[wrong]\"> but was:<\"[one]\"> ([\"one\", \"two\"])",
@@ -90,7 +90,7 @@ class ListTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert(listOf("one", "two"), name = "subject").index(-1) { it.isEqualTo(listOf("one")) }
+            assert(listOf("one", "two"), name = "subject").index(-1) { isEqualTo(listOf("one")) }
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
@@ -156,19 +156,19 @@ class MapTest {
 
     //region key
     @Test fun index_successful_assertion_passes() {
-        assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one") { it.isEqualTo(1) }
+        assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one") { isEqualTo(1) }
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one") { it.isEqualTo(2) }
+            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one") { isEqualTo(2) }
         }
         assertEquals("expected [subject[\"one\"]]:<[2]> but was:<[1]> ({\"one\"=1, \"two\"=2})", error.message)
     }
 
     @Test fun index_missing_key_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("wrong") { it.isEqualTo(1) }
+            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("wrong") { isEqualTo(1) }
         }
         assertEquals("expected [subject] to have key:<\"wrong\">", error.message)
     }

--- a/assertk-common/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
+++ b/assertk-common/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
@@ -223,16 +223,16 @@ class $TTest {
 
     //region each
     @Test fun each_empty_list_passes() {
-        assert($NOf()).each { it.isEqualTo(1) }
+        assert($NOf()).each { isEqualTo(1) }
     }
 
     @Test fun each_content_passes() {
-        assert($NOf(1.to$E(), 2.to$E())).each { it.isGreaterThan(0.to$E()) }
+        assert($NOf(1.to$E(), 2.to$E())).each { isGreaterThan(0.to$E()) }
     }
 
     @Test fun each_non_matching_content_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E(), 3.to$E())).each { it.isLessThan(2.to$E()) }
+            assert($NOf(1.to$E(), 2.to$E(), 3.to$E())).each { isLessThan(2.to$E()) }
         }
         assertEquals(
             """The following assertions failed (2 failures)
@@ -245,12 +245,12 @@ class $TTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0) { it.isEqualTo(1.to$E()) }
+        assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0) { isEqualTo(1.to$E()) }
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0) { it.isGreaterThan(2.to$E()) }
+            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0) { isGreaterThan(2.to$E()) }
         }
         assertEquals(
             "expected [subject[0]] to be greater than:<${show(2.to$E(), "")}> but was:<${show(1.to$E(), "")}> ([${show(1.to$E(), "")}, ${show(2.to$E(), "")}])",
@@ -260,7 +260,7 @@ class $TTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1) { it.isEqualTo(listOf(1.to$E())) }
+            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1) { isEqualTo(listOf(1.to$E())) }
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-js/package-lock.json
+++ b/assertk-js/package-lock.json
@@ -12,7 +12,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -59,12 +59,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "growl": {
@@ -87,8 +87,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -101,7 +101,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -144,7 +144,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "path-is-absolute": {
@@ -157,7 +157,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "2.0.0"
       }
     },
     "wrappy": {

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/any.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/any.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.full.memberProperties
 /**
  * Returns an assert on the java class of the value.
  */
-fun <T : Any> Assert<T>.jClass() = prop("class", { it::class.java })
+fun <T : Any> Assert<T>.jClass() = prop("class") { it::class.java }
 
 
 /**
@@ -45,7 +45,7 @@ fun <T : Any> Assert<T>.doesNotHaveClass(jclass: Class<out T>) {
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
-fun <T : Any, S : T> Assert<T>.isInstanceOf(jclass: Class<S>, f: (Assert<S>) -> Unit = {}) {
+fun <T : Any, S : T> Assert<T>.isInstanceOf(jclass: Class<S>, f: Assert<S>.() -> Unit = {}) {
     if (jclass.isInstance(actual)) {
         @Suppress("UNCHECKED_CAST")
         assert(actual as S, name = name).all(f)

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/file.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/file.kt
@@ -29,7 +29,7 @@ fun Assert<File>.extension() = prop("extension", File::extension)
 /**
  * Returns an assert on the file's contents as text.
  */
-fun Assert<File>.text(charset: Charset = Charsets.UTF_8) = prop("text", { it.readText(charset) })
+fun Assert<File>.text(charset: Charset = Charsets.UTF_8) = prop("text") { it.readText(charset) }
 
 /**
  * Returns an assert on the file's contents as bytes.

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/throwable.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/throwable.kt
@@ -7,7 +7,7 @@ import assertk.Assert
 /**
  * Returns an assert on the throwable's stack trace.
  */
-fun <T : Throwable> Assert<T>.stackTrace() = prop("stack trace", { it.stackTrace.map { it.toString() } })
+fun <T : Throwable> Assert<T>.stackTrace() = prop("stack trace") { it.stackTrace.map(Any::toString) }
 
 /**
  * Asserts the throwable's cause is an instance of the expected java class.
@@ -15,14 +15,12 @@ fun <T : Throwable> Assert<T>.stackTrace() = prop("stack trace", { it.stackTrace
  * @see [hasRootCauseInstanceOf]
  */
 @Deprecated(
-    message = "Use cause().isNotNull { it.isInstanceOf(jclass) } instead.",
-    replaceWith = ReplaceWith("cause().isNotNull { it.isInstanceOf(jclass) }"),
+    message = "Use cause().isNotNull { isInstanceOf(jclass) } instead.",
+    replaceWith = ReplaceWith("cause().isNotNull { isInstanceOf(jclass) }"),
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasCauseInstanceOf(jclass: Class<out T>) {
-    cause().isNotNull {
-        it.isInstanceOf(jclass)
-    }
+    cause().isNotNull { isInstanceOf(jclass) }
 }
 
 /**
@@ -31,14 +29,12 @@ fun <T : Throwable> Assert<T>.hasCauseInstanceOf(jclass: Class<out T>) {
  * @see [hasRootCauseWithClass]
  */
 @Deprecated(
-    message = "Use cause().isNotNull { it.jClass().isEqualTo(jclass) } instead.",
-    replaceWith = ReplaceWith("cause().isNotNull { it.jClass().isEqualTo(jclass) }"),
+    message = "Use cause().isNotNull { jClass().isEqualTo(jclass) } instead.",
+    replaceWith = ReplaceWith("cause().isNotNull { jClass().isEqualTo(jclass) }"),
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasCauseWithClass(jclass: Class<out T>) {
-    cause().isNotNull {
-        it.jClass().isEqualTo(jclass)
-    }
+    cause().isNotNull { jClass().isEqualTo(jclass) }
 }
 
 /**

--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -38,7 +38,7 @@ class JavaAnyTest {
     @Test fun isInstanceOf_jclass_run_block_when_passes() {
         val error = assertFails {
             assert(subject as TestObject).isInstanceOf(BasicObject::class.java) {
-                it.prop("str", BasicObject::str).isEqualTo("wrong")
+                prop("str", BasicObject::str).isEqualTo("wrong")
             }
         }
         assertEquals("expected [str]:<\"[wrong]\"> but was:<\"[test]\"> (test)", error.message)
@@ -46,9 +46,7 @@ class JavaAnyTest {
 
     @Test fun isInstanceOf_jclass_doesnt_run_block_when_fails() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(DifferentObject::class.java) {
-                it.isNull()
-            }
+            assert(subject as TestObject).isInstanceOf(DifferentObject::class.java) { isNull() }
         }
         assertEquals(
             "expected to be instance of:<$p\$DifferentObject> but had class:<$p\$BasicObject>",


### PR DESCRIPTION
ex:
```kotlin
assert(foo).isNotNull { it.isEqualTo("bar") }
```
is now
```kotlin
assert(foo).isNotNull { isEqualTo("bar") }
```

It's not very useful to give these receivers an explicit name and there
is now a warning when `it` is nested.

Unfortunately this is a breaking change with no automated migration
path. We are not yet 1.0 though.