### PR TITLE
Change all, and assertAll to take a list of assertion lambdas

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assertions/any.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/any.kt
@@ -122,12 +122,17 @@ fun <T : Any> Assert<T?>.isNull() {
  * }
  * ```
  */
-fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
+fun <T : Any> Assert<T?>.isNotNull(): Assert<T> {
     if (actual != null) {
-        assert(actual, name = name).all(f)
+        return assert(actual, name = name)
     } else {
         expected("to not be null")
     }
+}
+
+@Deprecated(message = "Use isNotNull() instead", replaceWith = ReplaceWith("isNotNull().let(f)"))
+fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit) {
+    isNotNull().apply(f)
 }
 
 /**
@@ -139,8 +144,8 @@ fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
  * assert(person).prop("name", { it.name }).isEqualTo("Sue")
  * ```
  */
-fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P)
-        = assert(extract(actual), "${if (this.name != null) this.name + "." else ""}$name")
+fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P) =
+    assert(extract(actual), "${if (this.name != null) this.name + "." else ""}$name")
 
 
 /**
@@ -184,15 +189,30 @@ fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) {
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
-fun <T : Any, S: T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: (Assert<S>) -> Unit = {}) {
+fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>): Assert<S> {
     if (kclass.isInstance(actual)) {
         @Suppress("UNCHECKED_CAST")
-        assert(actual as S, name = name).all(f)
+        return assert(actual as S, name = name)
     } else {
         expected("to be instance of:${show(kclass)} but had class:${show(actual::class)}")
     }
 }
 
+/**
+ * Asserts the value is an instance of the expected kotlin class. Both `assert("test").isInstanceOf(String::class)` and
+ * `assert("test").isInstanceOf(Any::class)` is successful.
+ * @see [isNotInstanceOf]
+ * @see [hasClass]
+ */
+@Deprecated(message = "Use isInstanceOf(kclass) instead.", replaceWith = ReplaceWith("isInstanceOf(kclass).let(f)"))
+fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: (Assert<S>) -> Unit) {
+    if (kclass.isInstance(actual)) {
+        @Suppress("UNCHECKED_CAST")
+        assert(actual as S, name = name).all(listOf(f))
+    } else {
+        expected("to be instance of:${show(kclass)} but had class:${show(actual::class)}")
+    }
+}
 
 /**
  * Returns an assert that compares only the given properties on the calling class

--- a/assertk-common/src/main/kotlin/assertk/assertions/array.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/array.kt
@@ -137,15 +137,27 @@ fun <T> Assert<Array<T>>.containsAll(vararg elements: Any?) {
  * Returns an assert that assertion on the value at the given index in the array.
  *
  * ```
- * assert(arrayOf(0, 1, 2)).index(1) { it.isPositive() }
+ * assert(arrayOf(0, 1, 2)).index(1).isPositive()
  * ```
  */
-fun <T> Assert<Array<T>>.index(index: Int, f: (Assert<T>) -> Unit) {
+fun <T> Assert<Array<T>>.index(index: Int): Assert<T> {
     if (index in 0 until actual.size) {
-        f(assert(actual[index], "${name ?: ""}${show(index, "[]")}"))
+        return assert(actual[index], "${name ?: ""}${show(index, "[]")}")
     } else {
         expected("index to be in range:[0-${actual.size}) but was:${show(index)}")
     }
+}
+
+/**
+ * Returns an assert that assertion on the value at the given index in the array.
+ *
+ * ```
+ * assert(arrayOf(0, 1, 2)).index(1) { it.isPositive() }
+ * ```
+ */
+@Deprecated(message = "Use index(index) instead.", replaceWith = ReplaceWith("index(index).let(f)"))
+fun <T> Assert<Array<T>>.index(index: Int, f: (Assert<T>) -> Unit) {
+    index(index).apply(f)
 }
 
 /**
@@ -174,15 +186,11 @@ fun <T> Assert<Array<T>>.containsExactly(vararg elements: Any?) {
  *
  * ```
  * assert(arrayOf("one", "two")).each {
- *   it.hasLength(3)
+ *   hasLength(3)
  * }
  * ```
  */
 @PlatformName("arrayEach")
 fun <T> Assert<Array<T>>.each(f: (Assert<T>) -> Unit) {
-    assertAll {
-        actual.forEachIndexed { index, item ->
-            f(assert(item, "${name ?: ""}${show(index, "[]")}"))
-        }
-    }
+    assertAll(actual.mapIndexed { index, item -> { f(assert(item, "${name ?: ""}${show(index, "[]")}")) } })
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
@@ -33,9 +33,5 @@ fun <T : Iterable<*>> Assert<T>.doesNotContain(element: Any?) {
  * ```
  */
 fun <E, T : Iterable<E>> Assert<T>.each(f: (Assert<E>) -> Unit) {
-    assertAll {
-        actual.forEachIndexed { index, item ->
-            f(assert(item, "${name ?: ""}${show(index, "[]")}"))
-        }
-    }
+    assertAll(actual.mapIndexed { index, item -> { f(assert(item, "${name ?: ""}${show(index, "[]")}")) } })
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/list.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/list.kt
@@ -9,9 +9,25 @@ import assertk.assertions.support.show
  * Returns an assert that assertion on the value at the given index in the list.
  *
  * ```
+ * assert(listOf(0, 1, 2)).index(1).isPositive()
+ * ```
+ */
+fun <T> Assert<List<T>>.index(index: Int): Assert<T> {
+    if (index in 0 until actual.size) {
+        return assert(actual[index], "${name ?: ""}${show(index, "[]")}")
+    } else {
+        expected("index to be in range:[0-${actual.size}) but was:${show(index)}")
+    }
+}
+
+/**
+ * Returns an assert that assertion on the value at the given index in the list.
+ *
+ * ```
  * assert(listOf(0, 1, 2)).index(1) { it.isPositive() }
  * ```
  */
+@Deprecated(message = "Use index(index) instead.", replaceWith = ReplaceWith("index(index).let(f)"))
 fun <T> Assert<List<T>>.index(index: Int, f: (Assert<T>) -> Unit) {
     if (index in 0 until actual.size) {
         f(assert(actual[index], "${name ?: ""}${show(index, "[]")}"))

--- a/assertk-common/src/main/kotlin/assertk/assertions/map.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/map.kt
@@ -150,6 +150,22 @@ fun <K, V> Assert<Map<K, V>>.containsOnly(vararg elements: Pair<K, V>) {
  * assert(mapOf("key" to "value")).key("key") { it.isEqualTo("value") }
  * ```
  */
+fun <K, V> Assert<Map<K, V>>.key(key: K): Assert<V> {
+    if (key in actual) {
+        return assert(actual.getValue(key), "${name ?: ""}${show(key, "[]")}")
+    } else {
+        expected("to have key:${show(key)}")
+    }
+}
+
+/**
+ * Returns an assert that asserts on the value at the given key in the map.
+ *
+ * ```
+ * assert(mapOf("key" to "value")).key("key") { it.isEqualTo("value") }
+ * ```
+ */
+@Deprecated(message = "Use key(key) instead.", replaceWith = ReplaceWith("key(key).let(f)"))
 fun <K, V> Assert<Map<K, V>>.key(key: K, f: (Assert<V>) -> Unit) {
     if (key in actual) {
         f(assert(actual.getValue(key), "${name ?: ""}${show(key, "[]")}"))

--- a/assertk-common/src/main/kotlin/assertk/assertions/support/support.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/support/support.kt
@@ -66,7 +66,7 @@ fun <T> Assert<T>.fail(expected: Any?, actual: Any?) {
  *
  * -> "expected to be: <1> but was <2>"
  */
-fun <T> Assert<T>.expected(message: String, expected: Any? = null, actual: Any? = null) {
+fun <T> Assert<T>.expected(message: String, expected: Any? = null, actual: Any? = null): Nothing {
     val maybeSpace = if (message.startsWith(":")) "" else " "
     val maybeInstance = if (context != null) " ${show(context, "()")}" else ""
     fail(

--- a/assertk-common/src/main/kotlin/assertk/assertions/throwable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/throwable.kt
@@ -31,10 +31,11 @@ fun <T : Throwable> Assert<T>.hasMessage(message: String?) {
  * @see [hasNoCause]
  */
 fun <T : Throwable> Assert<T>.hasCause(cause: Throwable) {
-    cause().isNotNull {
-        it.kClass().isEqualTo(cause::class)
-        it.hasMessage(cause.message)
-    }
+    cause().isNotNull().all({
+        kClass().isEqualTo(cause::class)
+    }, {
+        hasMessage(cause.message)
+    })
 }
 
 /**
@@ -49,10 +50,11 @@ fun <T : Throwable> Assert<T>.hasNoCause() {
  * Asserts the throwable is similar to the expected root cause, checking the type and message.
  */
 fun <T : Throwable> Assert<T>.hasRootCause(cause: Throwable) {
-    rootCause().all {
+    rootCause().all({
         kClass().isEqualTo(cause::class)
+    }, {
         hasMessage(cause.message)
-    }
+    })
 }
 
 /**
@@ -64,9 +66,7 @@ fun <T : Throwable> Assert<T>.hasRootCause(cause: Throwable) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasMessageStartingWith(prefix: String) {
-    assert(actual.message, "message").isNotNull {
-        it.startsWith(prefix)
-    }
+    assert(actual.message, "message").isNotNull().startsWith(prefix)
 }
 
 /**
@@ -78,9 +78,7 @@ fun <T : Throwable> Assert<T>.hasMessageStartingWith(prefix: String) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasMessageContaining(string: String) {
-    assert(actual.message, "message").isNotNull {
-        it.contains(string)
-    }
+    assert(actual.message, "message").isNotNull().contains(string)
 }
 
 /**
@@ -92,9 +90,7 @@ fun <T : Throwable> Assert<T>.hasMessageContaining(string: String) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasMessageMatching(regex: Regex) {
-    assert(actual.message, "message").isNotNull {
-        it.matches(regex)
-    }
+    assert(actual.message, "message").isNotNull().matches(regex)
 }
 
 /**
@@ -106,9 +102,7 @@ fun <T : Throwable> Assert<T>.hasMessageMatching(regex: Regex) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasMessageEndingWith(suffix: String) {
-    assert(actual.message, "message").isNotNull {
-        it.endsWith(suffix)
-    }
+    assert(actual.message, "message").isNotNull().endsWith(suffix)
 }
 
 /**
@@ -122,9 +116,7 @@ fun <T : Throwable> Assert<T>.hasMessageEndingWith(suffix: String) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasCauseWithClass(kclass: KClass<out T>) {
-    assert(actual.cause, "cause").isNotNull {
-        it.kClass().isEqualTo(kclass)
-    }
+    assert(actual.cause, "cause").isNotNull().kClass().isEqualTo(kclass)
 }
 
 /**
@@ -138,9 +130,7 @@ fun <T : Throwable> Assert<T>.hasCauseWithClass(kclass: KClass<out T>) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasRootCauseWithClass(kclass: KClass<out T>) {
-    assert(actual.rootCause(), "root cause").isNotNull {
-        it.kClass().isEqualTo(kclass)
-    }
+    assert(actual.rootCause(), "root cause").isNotNull().kClass().isEqualTo(kclass)
 }
 
 /**
@@ -154,9 +144,7 @@ fun <T : Throwable> Assert<T>.hasRootCauseWithClass(kclass: KClass<out T>) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasCauseInstanceOf(kclass: KClass<out T>) {
-    assert(actual.cause, "cause").isNotNull {
-        it.isInstanceOf(kclass)
-    }
+    assert(actual.cause, "cause").isNotNull().isInstanceOf(kclass)
 }
 
 /**
@@ -170,9 +158,7 @@ fun <T : Throwable> Assert<T>.hasCauseInstanceOf(kclass: KClass<out T>) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasRootCauseInstanceOf(kclass: KClass<out T>) {
-    assert(actual.rootCause(), "root cause").isNotNull {
-        it.isInstanceOf(kclass)
-    }
+    assert(actual.rootCause(), "root cause").isNotNull().isInstanceOf(kclass)
 }
 
 private fun Throwable.rootCause(): Throwable = this.cause?.rootCause() ?: this

--- a/assertk-common/src/template/assertk/assertions/primativeArray.kt
+++ b/assertk-common/src/template/assertk/assertions/primativeArray.kt
@@ -140,10 +140,27 @@ fun Assert<$T>.containsAll(vararg elements: $E) {
  * Returns an assert that assertion on the value at the given index in the $T.
  *
  * ```
- * assert($NOf(0, 1, 2)).index(1) { it.isPositive() }
+ * assert($NOf(0, 1, 2)).index(1).isPositive()
  * ```
  */
 @PlatformName("$NIndex")
+fun Assert<$T>.index(index: Int): Assert<$E> {
+    if (index in 0 until actual.size) {
+        return assert(actual[index], "${name ?: ""}${show(index, "[]")}")
+    } else {
+        expected("index to be in range:[0-${actual.size}) but was:${show(index)}")
+    }
+}
+
+/**
+ * Returns an assert that assertion on the value at the given index in the $T.
+ *
+ * ```
+ * assert($NOf(0, 1, 2)).index(1) { it.isPositive() }
+ * ```
+ */
+@PlatformName("$NIndexF")
+@Deprecated("Use index(index) instead.", replaceWith = ReplaceWith("index(index).let(f)"))
 fun Assert<$T>.index(index: Int, f: (Assert<$E>) -> Unit) {
     if (index in 0 until actual.size) {
         f(assert(actual[index], "${name ?: ""}${show(index, "[]")}"))
@@ -184,9 +201,5 @@ fun Assert<$T>.containsExactly(vararg elements: $E) {
  */
 @PlatformName("$NEach")
 fun Assert<$T>.each(f: (Assert<$E>) -> Unit) {
-    assertAll {
-        actual.forEachIndexed { index, item ->
-            f(assert(item, "${name ?: ""}${show(index, "[]")}"))
-        }
-    }
+    assertAll(actual.mapIndexed { index, item -> { f(assert(item, "${name ?: ""}${show(index, "[]")}")) } })
 }

--- a/assertk-common/src/test/kotlin/test/assertk/AssertAllTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/AssertAllTest.kt
@@ -113,5 +113,14 @@ class AssertAllTest {
             error.message
         )
     }
+
+    @Test fun assertAll_single_failure_is_assertion_error() {
+        val error = assertFails {
+            assertAll(listOf({
+                throw Exception()
+            }))
+        }
+        assertEquals(AssertionError::class, error::class)
+    }
     //endregion
 }

--- a/assertk-common/src/test/kotlin/test/assertk/TableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/TableTest.kt
@@ -28,8 +28,8 @@ class TableTest {
                 .row(1, 1)
                 .row(2, 3)
                 .forAll { a, b ->
-                    assert(a).isEqualTo(b)
                     invokeCount += 1
+                    assert(a).isEqualTo(b)
                 }
         }
 
@@ -50,8 +50,8 @@ class TableTest {
                 .row(1, 2)
                 .row(2, 3)
                 .forAll { a, b ->
-                    assert(a).isEqualTo(b)
                     invokeCount += 1
+                    assert(a).isEqualTo(b)
                 }
         }
 

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
@@ -195,20 +195,20 @@ class AnyTest {
     }
 
     @Test fun isNotNull_non_null_and_equal_object_passes() {
-        assert(nullableSubject).isNotNull { it.isEqualTo(subject) }
+        assert(nullableSubject).isNotNull().isEqualTo(subject)
     }
 
     @Test fun isNotNull_non_null_and_non_equal_object_fails() {
         val unequal = BasicObject("not test")
         val error = assertFails {
-            assert(nullableSubject).isNotNull { it.isEqualTo(unequal) }
+            assert(nullableSubject).isNotNull().isEqualTo(unequal)
         }
         assertEquals("expected:<[not ]test> but was:<[]test>", error.message)
     }
 
     @Test fun isNotNull_null_and_equal_object_fails() {
         val error = assertFails {
-            assert(null as String?).isNotNull { it.isEqualTo(null) }
+            assert(null as String?).isNotNull().isEqualTo(null)
         }
         assertEquals("expected to not be null", error.message)
     }
@@ -258,18 +258,15 @@ class AnyTest {
 
     @Test fun isInstanceOf_kclass_run_block_when_passes() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(BasicObject::class) {
-                it.prop("str", BasicObject::str).isEqualTo("wrong")
-            }
+            assert(subject as TestObject).isInstanceOf(BasicObject::class)
+                .prop("str", BasicObject::str).isEqualTo("wrong")
         }
         assertEquals("expected [str]:<\"[wrong]\"> but was:<\"[test]\"> (test)", error.message)
     }
 
     @Test fun isInstanceOf_kclass_doesnt_run_block_when_fails() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(DifferentObject::class) {
-                it.isNull()
-            }
+            assert(subject as TestObject).isInstanceOf(DifferentObject::class).isNull()
         }
         assertEquals(
             "expected to be instance of:<${DifferentObject::class}> but had class:<${BasicObject::class}>",

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
@@ -242,12 +242,12 @@ class ArrayTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert(arrayOf("one", "two"), name = "subject").index(0) { it.isEqualTo("one") }
+        assert(arrayOf("one", "two"), name = "subject").index(0).isEqualTo("one")
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(arrayOf("one", "two"), name = "subject").index(0) { it.isEqualTo("wrong") }
+            assert(arrayOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
         }
         assertEquals(
             "expected [subject[0]]:<\"[wrong]\"> but was:<\"[one]\"> ([\"one\", \"two\"])",
@@ -257,7 +257,7 @@ class ArrayTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert(arrayOf("one", "two"), name = "subject").index(-1) { it.isEqualTo(listOf("one")) }
+            assert(arrayOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ListTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ListTest.kt
@@ -75,12 +75,12 @@ class ListTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert(listOf("one", "two"), name = "subject").index(0) { it.isEqualTo("one") }
+        assert(listOf("one", "two"), name = "subject").index(0).isEqualTo("one")
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(listOf("one", "two"), name = "subject").index(0) { it.isEqualTo("wrong") }
+            assert(listOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
         }
         assertEquals(
             "expected [subject[0]]:<\"[wrong]\"> but was:<\"[one]\"> ([\"one\", \"two\"])",
@@ -90,7 +90,7 @@ class ListTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert(listOf("one", "two"), name = "subject").index(-1) { it.isEqualTo(listOf("one")) }
+            assert(listOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
@@ -156,19 +156,19 @@ class MapTest {
 
     //region key
     @Test fun index_successful_assertion_passes() {
-        assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one") { it.isEqualTo(1) }
+        assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one").isEqualTo(1)
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one") { it.isEqualTo(2) }
+            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one").isEqualTo(2)
         }
         assertEquals("expected [subject[\"one\"]]:<[2]> but was:<[1]> ({\"one\"=1, \"two\"=2})", error.message)
     }
 
     @Test fun index_missing_key_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("wrong") { it.isEqualTo(1) }
+            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("wrong").isEqualTo(1)
         }
         assertEquals("expected [subject] to have key:<\"wrong\">", error.message)
     }

--- a/assertk-js/src/main/kotlin/assertk/failure.kt
+++ b/assertk-js/src/main/kotlin/assertk/failure.kt
@@ -4,3 +4,7 @@ package assertk
 internal actual inline fun failWithNotInStacktrace(error: AssertionError): Nothing {
     throw error
 }
+
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun throwIfFatal(e: Throwable) {
+}

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/throwable.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/throwable.kt
@@ -20,9 +20,7 @@ fun <T : Throwable> Assert<T>.stackTrace() = prop("stack trace", { it.stackTrace
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasCauseInstanceOf(jclass: Class<out T>) {
-    cause().isNotNull {
-        it.isInstanceOf(jclass)
-    }
+    cause().isNotNull().isInstanceOf(jclass)
 }
 
 /**
@@ -36,9 +34,7 @@ fun <T : Throwable> Assert<T>.hasCauseInstanceOf(jclass: Class<out T>) {
     level = DeprecationLevel.ERROR
 )
 fun <T : Throwable> Assert<T>.hasCauseWithClass(jclass: Class<out T>) {
-    cause().isNotNull {
-        it.jClass().isEqualTo(jclass)
-    }
+    cause().isNotNull().jClass().isEqualTo(jclass)
 }
 
 /**

--- a/assertk-jvm/src/main/kotlin/assertk/failure.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/failure.kt
@@ -11,3 +11,10 @@ internal actual inline fun failWithNotInStacktrace(error: AssertionError): Nothi
     (error as java.lang.Throwable).stackTrace = filtered
     throw error
 }
+
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun throwIfFatal(e: Throwable) {
+    if (e is OutOfMemoryError) {
+        throw e
+    }
+}

--- a/assertk-jvm/src/test/kotlin/test/assertk/JavaAssertAllTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/JavaAssertAllTest.kt
@@ -1,0 +1,18 @@
+package test.assertk
+
+import assertk.assertAll
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class JavaAssertAllTest {
+    @Test fun assertAll_propagates_out_of_memory_error() {
+        val error = assertFails {
+            assertAll(listOf({
+                throw OutOfMemoryError()
+            }))
+        }
+
+        assertEquals<Class<*>>(OutOfMemoryError::class.java, error.javaClass)
+    }
+}

--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -37,18 +37,15 @@ class JavaAnyTest {
 
     @Test fun isInstanceOf_jclass_run_block_when_passes() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(BasicObject::class.java) {
-                it.prop("str", BasicObject::str).isEqualTo("wrong")
-            }
+            assert(subject as TestObject).isInstanceOf(BasicObject::class.java)
+                .prop("str", BasicObject::str).isEqualTo("wrong")
         }
         assertEquals("expected [str]:<\"[wrong]\"> but was:<\"[test]\"> (test)", error.message)
     }
 
     @Test fun isInstanceOf_jclass_doesnt_run_block_when_fails() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(DifferentObject::class.java) {
-                it.isNull()
-            }
+            assert(subject as TestObject).isInstanceOf(DifferentObject::class.java).isNull()
         }
         assertEquals(
             "expected to be instance of:<$p\$DifferentObject> but had class:<$p\$BasicObject>",


### PR DESCRIPTION
Removed the concept of 'soft assertions' that don't throw, instead all
assertions throw, and `all` and `assertAll` loop through lambda with a
try/catch. This removes the foot-gun of an assertion maybe running the
rest of the body when it fails, an allows props like `index` and `key`
to return a result and fail with an exception instead of having to take
a lambda.

This has been done in a way to not cause existing code to fail to
compile. Instead, you may not see all exceptions thrown. Deprecated
functions have been kept to guide migration.