### PR TITLE
Add extention function to typecast thrownError

### DIFF
--- a/src/commonMain/kotlin/assertk/assert.kt
+++ b/src/commonMain/kotlin/assertk/assert.kt
@@ -297,3 +297,18 @@ fun catch(f: () -> Unit): Throwable? {
         return e
     }
 }
+
+/**
+ * Runs the given lambda if the block throws expected error, otherwise fails.
+ */
+inline fun <reified E : Throwable> AssertBlock<Any>.thrownExpectedError(crossinline f: Assert<E>.() -> Unit) {
+    thrownError {
+        if (this.actual is E) {
+            @Suppress("UNCHECKED_CAST")
+            f.invoke(this as Assert<E>)
+        }
+        else {
+            fail("expected Throwable to be of type ${show(E::class)} but actual was ${show(actual::class)}")
+        }
+    }
+}

--- a/src/commonTest/kotlin/test/assertk/AssertBlockTest.kt
+++ b/src/commonTest/kotlin/test/assertk/AssertBlockTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNegative
 import assertk.assertions.message
 import assertk.assertions.support.show
+import assertk.thrownExpectedError
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -75,6 +76,28 @@ class AssertBlockTest {
         }
 
         assertEquals("expected to not throw an exception but threw:${show(Exception("test"))}", error.message!!.lineSequence().first())
+    }
+    //endregion
+
+    //region throwsExpectedException
+    @Test fun throwsExpectedException_passes() {
+        assert { throw IllegalStateException("you illegal!") }
+        .thrownExpectedError<IllegalStateException> {
+            message().isEqualTo("you illegal!")
+        }
+    }
+
+    @Test fun throwsExpectedException_fails() {
+        val error = assertFails {
+            assert { throw IllegalStateException("you illegal!") }
+                .thrownExpectedError<IllegalArgumentException> {
+                    message().isEqualTo("you illegal!")
+                }
+        }
+        assertEquals(
+            "expected Throwable to be of type <class ${exceptionPackageName}IllegalArgumentException> but actual was <class ${exceptionPackageName}IllegalStateException>",
+            error.message
+        )
     }
     //endregion
 }

--- a/src/commonTest/kotlin/test/assertk/AssertBlockTest.kt
+++ b/src/commonTest/kotlin/test/assertk/AssertBlockTest.kt
@@ -81,7 +81,7 @@ class AssertBlockTest {
 
     //region throwsExpectedException
     @Test fun throwsExpectedException_passes() {
-        assert { throw IllegalStateException("you illegal!") }
+        assertThat { throw IllegalStateException("you illegal!") }
         .thrownExpectedError<IllegalStateException> {
             message().isEqualTo("you illegal!")
         }
@@ -89,7 +89,7 @@ class AssertBlockTest {
 
     @Test fun throwsExpectedException_fails() {
         val error = assertFails {
-            assert { throw IllegalStateException("you illegal!") }
+            assertThat { throw IllegalStateException("you illegal!") }
                 .thrownExpectedError<IllegalArgumentException> {
                     message().isEqualTo("you illegal!")
                 }


### PR DESCRIPTION
Useful when you only want to work with expected error type