### PR TITLE
Change assertion message for containsAll on Map

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assertions/map.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/map.kt
@@ -84,7 +84,8 @@ fun <K, V> Assert<Map<K, V>>.contains(element: Pair<K, V>) {
 @PlatformName("mapContainsAll")
 fun <K, V> Assert<Map<K, V>>.containsAll(vararg elements: Pair<K, V>) {
     if (elements.all { (k, v) -> actual[k] == v }) return
-    expected("to contain all:${show(elements.toMap())} but was:${show(actual)}")
+    val notFound = elements.filterNot { (k, v) -> actual[k] == v }
+    expected("to contain all:${show(elements.toMap())} but was:${show(actual)}. Missing elements: ${show(notFound.toMap())}")
 }
 
 /**

--- a/assertk-common/src/main/kotlin/assertk/assertions/map.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/map.kt
@@ -84,8 +84,7 @@ fun <K, V> Assert<Map<K, V>>.contains(element: Pair<K, V>) {
 @PlatformName("mapContainsAll")
 fun <K, V> Assert<Map<K, V>>.containsAll(vararg elements: Pair<K, V>) {
     if (elements.all { (k, v) -> actual[k] == v }) return
-    val notFound = elements.filterNot { (k, v) -> actual[k] == v }
-    expected("to contain all:${show(elements.toMap())} some elements were not found:${show(notFound.toMap())}")
+    expected("to contain all:${show(elements.toMap())} but was:${show(actual)}")
 }
 
 /**

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
@@ -62,9 +62,7 @@ class MapTest {
         val error = assertFails {
             assert(mapOf("one" to 1)).containsAll("one" to 1, "two" to 2)
         }
-        assertEquals(
-                "expected to contain all:<{\"one\"=1, \"two\"=2}> but was:<{\"one\"=1}>",
-                error.message
+        assertEquals("expected to contain all:<{\"one\"=1, \"two\"=2}> but was:<{\"one\"=1}>", error.message
         )
     }
     //endregion

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
@@ -54,13 +54,17 @@ class MapTest {
         assert(mapOf("one" to 1, "two" to 2)).containsAll("two" to 2, "one" to 1)
     }
 
+    @Test fun containsAll_extra_elements_passes() {
+        assert(mapOf("one" to 1, "two" to 2, "three" to 3)).containsAll("one" to 1, "two" to 2)
+    }
+
     @Test fun containsAll_some_elements_fails() {
         val error = assertFails {
             assert(mapOf("one" to 1)).containsAll("one" to 1, "two" to 2)
         }
         assertEquals(
-            "expected to contain all:<{\"one\"=1, \"two\"=2}> some elements were not found:<{\"two\"=2}>",
-            error.message
+                "expected to contain all:<{\"one\"=1, \"two\"=2}> but was:<{\"one\"=1}>",
+                error.message
         )
     }
     //endregion

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
@@ -62,7 +62,7 @@ class MapTest {
         val error = assertFails {
             assert(mapOf("one" to 1)).containsAll("one" to 1, "two" to 2)
         }
-        assertEquals("expected to contain all:<{\"one\"=1, \"two\"=2}> but was:<{\"one\"=1}>", error.message
+        assertEquals("expected to contain all:<{\"one\"=1, \"two\"=2}> but was:<{\"one\"=1}>. Missing elements: <{\"two\"=2}>", error.message
         )
     }
     //endregion


### PR DESCRIPTION
This pull request changes the assertion message of `Assert<Map<K,V>>.containsAll()` to display actual map and expected map of elements. Currently it displays expected map and pair of elements that were not found.
This is in response to [https://github.com/willowtreeapps/assertk/issues/150](url)