### PR TITLE
Change assertion message for containsAll on Array

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assertions/array.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/array.kt
@@ -130,7 +130,7 @@ fun <T> Assert<Array<T>>.containsNone(vararg elements: Any?) {
 fun <T> Assert<Array<T>>.containsAll(vararg elements: Any?) {
     if (elements.all { actual.contains(it) }) return
     val notFound = elements.filterNot { it in actual }
-    expected("to contain all:${show(elements)} some elements were not found:${show(notFound)}")
+    expected("to contain all:${show(elements)} but was:${show(actual)}. Missing elements:${show(notFound)}")
 }
 
 /**

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
@@ -146,11 +146,15 @@ class ArrayTest {
         assert(arrayOf(1, 2)).containsAll(2, 1)
     }
 
+    @Test fun containsAll_extra_elements_passes() {
+        assert(arrayOf(1, 2, 3)).containsAll(1, 2)
+    }
+
     @Test fun containsAll_some_elements_fails() {
         val error = assertFails {
             assert(arrayOf(1)).containsAll(1, 2)
         }
-        assertEquals("expected to contain all:<[1, 2]> some elements were not found:<[2]>", error.message)
+        assertEquals("expected to contain all:<[1, 2]> but was:<[1]>. Missing elements:<[2]>", error.message)
     }
     //endregion
 


### PR DESCRIPTION
This pull request changes the assertion message of Assert<Array<T>>.containsAll() to display actual array, expected array and missing elements.