### PR TITLE
Wrap custom asserts in a `given` function.

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assert.kt
+++ b/assertk-common/src/main/kotlin/assertk/assert.kt
@@ -13,7 +13,45 @@ annotation class AssertkDsl
  * @see [assert]
  */
 @AssertkDsl
-class Assert<out T> internal constructor(val actual: T, val name: String?, internal val context: Any?) {
+sealed class Assert<out T>(val name: String?, internal val context: Any?) {
+    /**
+     * Transforms an assertion from one type to another. If the assertion is failing the resulting assertion will still
+     * be failing, otherwise the mapping function is called. An optional name can be provided, otherwise this
+     * assertion's name will be used.
+     */
+    fun <R> transform(name: String? = this.name, transform: (T) -> R): Assert<R> {
+        return when (this) {
+            is ValueAssert -> {
+                try {
+                    assert(transform(value), name)
+                } catch (e: Throwable) {
+                    notifyFailure(e)
+                    FailingAssert<R>(e, name, context)
+                }
+            }
+            is FailingAssert -> FailingAssert(error, name, context)
+        }
+    }
+
+    /**
+     * Allows checking the actual value of an assert. This can be used to build your own custom assertions.
+     * ```
+     * fun Assert<Int>.isTen() = given { actual ->
+     *     if (actual == 10) return
+     *     expected("to be 10 but was:${show(actual)}")
+     * }
+     * ```
+     */
+    inline fun given(assertion: (T) -> Unit) {
+        if (this is ValueAssert) {
+            try {
+                assertion(value)
+            } catch (e: Throwable) {
+                notifyFailure(e)
+            }
+        }
+    }
+
     /**
      * Asserts on the given value with an optional name.
      *
@@ -21,8 +59,28 @@ class Assert<out T> internal constructor(val actual: T, val name: String?, inter
      * assert(true, name = "true").isTrue()
      * ```
      */
-    fun <R> assert(actual: R, name: String? = this.name)
-            : Assert<R> = Assert(actual, name, if (context != null || this.actual === actual) context else this.actual)
+    abstract fun <R> assert(actual: R, name: String? = this.name): Assert<R>
+
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated(message = "Use `given` or `transform` to access the actual value instead")
+    val actual: T
+        get() = when (this) {
+            is ValueAssert -> value
+            is FailingAssert -> throw error
+        }
+}
+
+@AssertkDsl
+class ValueAssert<out T> internal constructor(val value: T, name: String?, context: Any?) :
+    Assert<T>(name, context) {
+
+    override fun <R> assert(actual: R, name: String?): Assert<R> =
+        ValueAssert(actual, name, if (context != null || this.value === actual) context else this.value)
+}
+
+class FailingAssert<out T> internal constructor(val error: Throwable, name: String?, context: Any?) :
+    Assert<T>(name, context) {
+    override fun <R> assert(actual: R, name: String?): Assert<R> = FailingAssert(error, name, context)
 }
 
 /**
@@ -42,7 +100,9 @@ sealed class AssertBlock<out T> {
     abstract fun doesNotThrowAnyException()
 
     internal class Value<out T> internal constructor(private val value: T) : AssertBlock<T>() {
-        override fun thrownError(f: Assert<Throwable>.() -> Unit) = fail("expected exception but was:${show(value)}")
+        override fun thrownError(f: Assert<Throwable>.() -> Unit) {
+            fail("expected exception but was:${show(value)}")
+        }
 
         override fun returnedValue(f: Assert<T>.() -> Unit) {
             f(assert(value))
@@ -58,9 +118,13 @@ sealed class AssertBlock<out T> {
             f(assert(error))
         }
 
-        override fun returnedValue(f: Assert<T>.() -> Unit) = fail("expected value but threw:${showError(error)}")
+        override fun returnedValue(f: Assert<T>.() -> Unit) {
+            fail("expected value but threw:${showError(error)}")
+        }
 
-        override fun doesNotThrowAnyException() = fail("expected to not throw an exception but threw:${showError(error)}")
+        override fun doesNotThrowAnyException() {
+            fail("expected to not throw an exception but threw:${showError(error)}")
+        }
     }
 }
 
@@ -69,7 +133,7 @@ sealed class AssertBlock<out T> {
  *
  * TODO: use @OptionalExpectation (https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-optional-expectation/index.html) here once available and call default implementation of [show] for JS
  */
-internal expect fun showError(e: Throwable):String
+internal expect fun showError(e: Throwable): String
 
 /**
  * Asserts on the given value with an optional name.
@@ -78,7 +142,7 @@ internal expect fun showError(e: Throwable):String
  * assert(true, name = "true").isTrue()
  * ```
  */
-fun <T> assert(actual: T, name: String? = null): Assert<T> = Assert(actual, name, null)
+fun <T> assert(actual: T, name: String? = null): Assert<T> = ValueAssert(actual, name, null)
 
 /**
  * All assertions in the given lambda are run.

--- a/assertk-common/src/main/kotlin/assertk/assertions/any.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/any.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KProperty1
 /**
  * Returns an assert on the kotlin class of the value.
  */
-fun <T : Any> Assert<T>.kClass() = prop("class", { it::class })
+fun <T : Any> Assert<T>.kClass() = prop("class") { it::class }
 
 /**
  * Returns an assert on the toString method of the value.
@@ -21,15 +21,14 @@ fun <T> Assert<T>.toStringFun() = prop("toString", Any?::toString)
 /**
  * Returns an assert on the hasCode method of the value.
  */
-fun <T : Any> Assert<T>.hashCodeFun() = prop("hashCode", Any::hashCode)
-
+fun Assert<Any>.hashCodeFun() = prop("hashCode", Any::hashCode)
 
 /**
  * Asserts the value is equal to the expected one, using `==`.
  * @see [isNotEqualTo]
  * @see [isSameAs]
  */
-fun <T> Assert<T>.isEqualTo(expected: Any?) {
+fun <T> Assert<T>.isEqualTo(expected: Any?) = given { actual ->
     if (actual == expected) return
     fail(expected, actual)
 }
@@ -39,7 +38,7 @@ fun <T> Assert<T>.isEqualTo(expected: Any?) {
  * @see [isEqualTo]
  * @see [isNotSameAs]
  */
-fun <T> Assert<T>.isNotEqualTo(expected: Any?) {
+fun <T> Assert<T>.isNotEqualTo(expected: Any?) = given { actual ->
     if (actual != expected) return
     val showExpected = show(expected)
     val showActual = show(actual)
@@ -56,7 +55,7 @@ fun <T> Assert<T>.isNotEqualTo(expected: Any?) {
  * @see [isNotSameAs]
  * @see [isEqualTo]
  */
-fun <T> Assert<T>.isSameAs(expected: T) {
+fun <T> Assert<T>.isSameAs(expected: T) = given { actual ->
     if (actual === expected) return
     expected(":${show(expected)} and:${show(actual)} to refer to the same object")
 }
@@ -66,7 +65,7 @@ fun <T> Assert<T>.isSameAs(expected: T) {
  * @see [isSameAs]
  * @see [isNotEqualTo]
  */
-fun <T> Assert<T>.isNotSameAs(expected: Any?) {
+fun <T> Assert<T>.isNotSameAs(expected: Any?) = given { actual ->
     if (actual !== expected) return
     expected(":${show(expected)} to not refer to the same object")
 }
@@ -75,7 +74,7 @@ fun <T> Assert<T>.isNotSameAs(expected: Any?) {
  * Asserts the value is in the expected values, using `in`.
  * @see [isNotIn]
  */
-fun <T> Assert<T>.isIn(vararg values: T) {
+fun <T> Assert<T>.isIn(vararg values: T) = given { actual ->
     if (actual in values) return
     expected(":${show(values)} to contain:${show(actual)}")
 }
@@ -84,7 +83,7 @@ fun <T> Assert<T>.isIn(vararg values: T) {
  * Asserts the value is not in the expected values, using `!in`.
  * @see [isIn]
  */
-fun <T> Assert<T>.isNotIn(vararg values: T) {
+fun <T> Assert<T>.isNotIn(vararg values: T) = given { actual ->
     if (actual !in values) return
     expected(":${show(values)} to not contain:${show(actual)}")
 }
@@ -99,7 +98,7 @@ fun <T> Assert<T>.hasToString(string: String) {
 /**
  * Asserts the value has the expected hash code from it's [hashCode].
  */
-fun <T : Any> Assert<T>.hasHashCode(hashCode: Int) {
+fun Assert<Any>.hasHashCode(hashCode: Int) {
     hashCodeFun().isEqualTo(hashCode)
 }
 
@@ -107,7 +106,7 @@ fun <T : Any> Assert<T>.hasHashCode(hashCode: Int) {
 /**
  * Asserts the value is null.
  */
-fun <T : Any> Assert<T?>.isNull() {
+fun <T : Any> Assert<T?>.isNull() = given { actual ->
     if (actual == null) return
     expected("to be null but was:${show(actual)}")
 }
@@ -122,12 +121,21 @@ fun <T : Any> Assert<T?>.isNull() {
  * }
  * ```
  */
-fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
-    if (actual != null) {
-        assert(actual, name = name).all(f)
-    } else {
-        expected("to not be null")
-    }
+@Deprecated(message = "Use isNotNull() instead", replaceWith = ReplaceWith("isNotNull().let(f)"))
+fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit) {
+    isNotNull().let(f)
+}
+
+/**
+ * Asserts the value is not null. You can pass in an optional lambda to run additional assertions on the non-null value.
+ *
+ * ```
+ * val name: String? = ...
+ * assert(name).isNotNull().hasLength(4)
+ * ```
+ */
+fun <T : Any> Assert<T?>.isNotNull(): Assert<T> = transform { actual ->
+    actual ?: expected("to not be null")
 }
 
 /**
@@ -139,9 +147,8 @@ fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit = {}) {
  * assert(person).prop("name", { it.name }).isEqualTo("Sue")
  * ```
  */
-fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P)
-        = assert(extract(actual), "${if (this.name != null) this.name + "." else ""}$name")
-
+fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P): Assert<P> =
+    transform("${if (this.name != null) this.name + "." else ""}$name", extract)
 
 /**
  * Asserts the value has the expected kotlin class. This is an exact match, so `assert("test").hasClass(String::class)`
@@ -149,7 +156,7 @@ fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P)
  * @see [doesNotHaveClass]
  * @see [isInstanceOf]
  */
-fun <T : Any> Assert<T>.hasClass(kclass: KClass<out T>) {
+fun <T : Any> Assert<T>.hasClass(kclass: KClass<out T>) = given { actual ->
     if (kclass == actual::class) return
     expected("to have class:${show(kclass)} but was:${show(actual::class)}")
 }
@@ -161,7 +168,7 @@ fun <T : Any> Assert<T>.hasClass(kclass: KClass<out T>) {
  * @see [hasClass]
  * @see [isNotInstanceOf]
  */
-fun <T : Any> Assert<T>.doesNotHaveClass(kclass: KClass<out T>) {
+fun <T : Any> Assert<T>.doesNotHaveClass(kclass: KClass<out T>) = given { actual ->
     if (kclass != actual::class) return
     expected("to not have class:${show(kclass)}")
 }
@@ -172,7 +179,7 @@ fun <T : Any> Assert<T>.doesNotHaveClass(kclass: KClass<out T>) {
  * @see [isInstanceOf]
  * @see [doesNotHaveClass]
  */
-fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) {
+fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) = given { actual ->
     if (!kclass.isInstance(actual)) return
     expected("to not be instance of:${show(kclass)}")
 }
@@ -184,15 +191,25 @@ fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) {
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
-fun <T : Any, S: T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: (Assert<S>) -> Unit = {}) {
+@Deprecated(message = "Use isInstanceOf(kclass) instead.", replaceWith = ReplaceWith("isInstanceOf(kclass).let(f)"))
+fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: (Assert<S>) -> Unit) {
+    isInstanceOf(kclass).let(f)
+}
+
+/**
+ * Asserts the value is an instance of the expected kotlin class. Both `assert("test").isInstanceOf(String::class)` and
+ * `assert("test").isInstanceOf(Any::class)` is successful.
+ * @see [isNotInstanceOf]
+ * @see [hasClass]
+ */
+fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>) = transform(name) { actual ->
     if (kclass.isInstance(actual)) {
         @Suppress("UNCHECKED_CAST")
-        assert(actual as S, name = name).all(f)
+        actual as S
     } else {
         expected("to be instance of:${show(kclass)} but had class:${show(actual::class)}")
     }
 }
-
 
 /**
  * Returns an assert that compares only the given properties on the calling class
@@ -204,8 +221,10 @@ fun <T : Any, S: T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: (Assert<S>) -> 
  * ```
  */
 fun <T> Assert<T>.isEqualToWithGivenProperties(other: T, vararg properties: KProperty1<T, Any>) {
-    properties.forEach {
-        assert(it.get(actual), "${if (this.name != null) this.name + "." else ""}${it.name}")
-            .isEqualTo(it.get(other))
+    all {
+        for (prop in properties) {
+            transform("${if (this.name != null) this.name + "." else ""}${prop.name}", prop::get)
+                .isEqualTo(prop.get(other))
+        }
     }
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/boolean.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/boolean.kt
@@ -7,7 +7,7 @@ import assertk.assertions.support.expected
  * Asserts the boolean is true.
  * @see [isFalse]
  */
-fun Assert<Boolean>.isTrue() {
+fun Assert<Boolean>.isTrue() = given { actual ->
     if (actual) return
     expected("to be true")
 }
@@ -16,7 +16,7 @@ fun Assert<Boolean>.isTrue() {
  * Asserts the boolean is false.
  * @see [isTrue]
  */
-fun Assert<Boolean>.isFalse() {
+fun Assert<Boolean>.isFalse() = given { actual ->
     if (!actual) return
     expected("to be false")
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/charsequence.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/charsequence.kt
@@ -8,7 +8,7 @@ import assertk.assertions.support.show
 /**
  * Returns an assert on the CharSequence's length.
  */
-fun <T : CharSequence> Assert<T>.length() = prop("length", CharSequence::length)
+fun Assert<CharSequence>.length() = prop("length", CharSequence::length)
 
 /**
  * Asserts the char sequence is empty.
@@ -16,7 +16,7 @@ fun <T : CharSequence> Assert<T>.length() = prop("length", CharSequence::length)
  * @see [isNullOrEmpty]
  */
 @PlatformName("isCharSequenceEmpty")
-fun <T : CharSequence> Assert<T>.isEmpty() {
+fun Assert<CharSequence>.isEmpty() = given { actual ->
     if (actual.isEmpty()) return
     expected("to be empty but was:${show(actual)}")
 }
@@ -26,7 +26,7 @@ fun <T : CharSequence> Assert<T>.isEmpty() {
  * @see [isEmpty]
  */
 @PlatformName("isCharSequenceNotEmpty")
-fun <T : CharSequence> Assert<T>.isNotEmpty() {
+fun Assert<CharSequence>.isNotEmpty() = given { actual ->
     if (actual.isNotEmpty()) return
     expected("to not be empty")
 }
@@ -36,7 +36,7 @@ fun <T : CharSequence> Assert<T>.isNotEmpty() {
  * @see [isEmpty]
  */
 @PlatformName("isCharSequenceNullOrEmpty")
-fun <T : CharSequence?> Assert<T>.isNullOrEmpty() {
+fun Assert<CharSequence?>.isNullOrEmpty() = given { actual ->
     if (actual.isNullOrEmpty()) return
     expected("to be null or empty but was:${show(actual)}")
 }
@@ -45,14 +45,14 @@ fun <T : CharSequence?> Assert<T>.isNullOrEmpty() {
  * Asserts the char sequence has the expected length.
  */
 @PlatformName("charSequenceHasLength")
-fun <T : CharSequence> Assert<T>.hasLength(length: Int) {
+fun Assert<CharSequence>.hasLength(length: Int) {
     length().isEqualTo(length)
 }
 
 /**
  * Asserts the char sequence has the same length as the expected one.
  */
-fun <T : CharSequence> Assert<T>.hasSameLengthAs(other: CharSequence) {
+fun Assert<CharSequence>.hasSameLengthAs(other: CharSequence) = given { actual ->
     val actualLength = actual.length
     val otherLength = other.length
     if (actualLength == otherLength) return

--- a/assertk-common/src/main/kotlin/assertk/assertions/collection.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/collection.kt
@@ -7,14 +7,14 @@ import assertk.assertions.support.show
 /**
  * Returns an assert on the Collection's size.
  */
-fun <T : Collection<*>> Assert<T>.size() = prop("size", Collection<*>::size)
+fun Assert<Collection<*>>.size() = prop("size", Collection<*>::size)
 
 /**
  * Asserts the collection is empty.
  * @see [isNotEmpty]
  * @see [isNullOrEmpty]
  */
-fun <T : Collection<*>> Assert<T>.isEmpty() {
+fun Assert<Collection<*>>.isEmpty() = given { actual ->
     if (actual.isEmpty()) return
     expected("to be empty but was:${show(actual)}")
 }
@@ -23,7 +23,7 @@ fun <T : Collection<*>> Assert<T>.isEmpty() {
  * Asserts the collection is not empty.
  * @see [isEmpty]
  */
-fun <T : Collection<*>> Assert<T>.isNotEmpty() {
+fun Assert<Collection<*>>.isNotEmpty() = given { actual ->
     if (actual.isNotEmpty()) return
     expected("to not be empty")
 }
@@ -32,7 +32,7 @@ fun <T : Collection<*>> Assert<T>.isNotEmpty() {
  * Asserts the collection is null or empty.
  * @see [isEmpty]
  */
-fun <T : Collection<*>?> Assert<T>.isNullOrEmpty() {
+fun Assert<Collection<*>?>.isNullOrEmpty() = given { actual ->
     if (actual == null || actual.isEmpty()) return
     expected("to be null or empty but was:${show(actual)}")
 }
@@ -40,14 +40,14 @@ fun <T : Collection<*>?> Assert<T>.isNullOrEmpty() {
 /**
  * Asserts the collection has the expected size.
  */
-fun <T : Collection<*>> Assert<T>.hasSize(size: Int) {
-    assert(actual.size, "size").isEqualTo(size)
+fun Assert<Collection<*>>.hasSize(size: Int) {
+    size().isEqualTo(size)
 }
 
 /**
  * Asserts the collection has the same size as the expected collection.
  */
-fun <T : Collection<*>> Assert<T>.hasSameSizeAs(other: Collection<*>) {
+fun Assert<Collection<*>>.hasSameSizeAs(other: Collection<*>) = given { actual ->
     val actualSize = actual.size
     val otherSize = other.size
     if (actualSize == otherSize) return
@@ -58,7 +58,7 @@ fun <T : Collection<*>> Assert<T>.hasSameSizeAs(other: Collection<*>) {
  * Asserts the collection does not contain any of the expected elements.
  * @see [containsAll]
  */
-fun <T : Collection<*>> Assert<T>.containsNone(vararg elements: Any?) {
+fun Assert<Collection<*>>.containsNone(vararg elements: Any?) = given { actual ->
     if (elements.none { it in actual }) {
         return
     }
@@ -74,7 +74,7 @@ fun <T : Collection<*>> Assert<T>.containsNone(vararg elements: Any?) {
  * @see [containsExactly]
  * @see [containsOnly]
  */
-fun <T : Collection<*>> Assert<T>.containsAll(vararg elements: Any?) {
+fun Assert<Collection<*>>.containsAll(vararg elements: Any?) = given { actual ->
     if (actual.containsAll(elements.toList())) {
         return
     }
@@ -89,14 +89,14 @@ fun <T : Collection<*>> Assert<T>.containsAll(vararg elements: Any?) {
  * @see [containsExactly]
  * @see [containsAll]
  */
-fun <T : Collection<*>> Assert<T>.containsOnly(vararg elements: Any?) {
+fun Assert<Collection<*>>.containsOnly(vararg elements: Any?) = given { actual ->
     val notInActual = elements.filterNot { it in actual }
     val notInExpected = actual.filterNot { elements.contains(it) }
     if (notInExpected.isEmpty() && notInActual.isEmpty())
         return
-    if (notInActual.isNotEmpty()){
+    if (notInActual.isNotEmpty()) {
         expected("to contain only:${show(elements)} but some elements were not found:${show(notInActual)}")
-    } else if (notInExpected.isNotEmpty()){
+    } else if (notInExpected.isNotEmpty()) {
         expected("to contain only:${show(elements)} but extra elements were found:${show(notInExpected)}")
     }
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/comparable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/comparable.kt
@@ -9,7 +9,7 @@ import assertk.assertions.support.show
  * @see [isGreaterThanOrEqualTo]
  * @see [isLessThan]
  */
-fun <A, B : Comparable<A>> Assert<B>.isGreaterThan(other: A) {
+fun <A, B : Comparable<A>> Assert<B>.isGreaterThan(other: A) = given { actual ->
     if (actual > other) return
     expected("to be greater than:${show(other)} but was:${show(actual)}")
 }
@@ -19,7 +19,7 @@ fun <A, B : Comparable<A>> Assert<B>.isGreaterThan(other: A) {
  * @see [isLessThanOrEqualTo]
  * @see [isGreaterThan]
  */
-fun <A, B : Comparable<A>> Assert<B>.isLessThan(other: A) {
+fun <A, B : Comparable<A>> Assert<B>.isLessThan(other: A) = given { actual ->
     if (actual < other) return
     expected("to be less than:${show(other)} but was:${show(actual)}")
 }
@@ -29,7 +29,7 @@ fun <A, B : Comparable<A>> Assert<B>.isLessThan(other: A) {
  * @see [isGreaterThan]
  * @see [isLessThanOrEqualTo]
  */
-fun <A, B : Comparable<A>> Assert<B>.isGreaterThanOrEqualTo(other: A) {
+fun <A, B : Comparable<A>> Assert<B>.isGreaterThanOrEqualTo(other: A) = given { actual ->
     if (actual >= other) return
     expected("to be greater than or equal to:${show(other)} but was:${show(actual)}")
 }
@@ -39,7 +39,7 @@ fun <A, B : Comparable<A>> Assert<B>.isGreaterThanOrEqualTo(other: A) {
  * @see [isLessThan]
  * @see [isGreaterThanOrEqualTo]
  */
-fun <A, B : Comparable<A>> Assert<B>.isLessThanOrEqualTo(other: A) {
+fun <A, B : Comparable<A>> Assert<B>.isLessThanOrEqualTo(other: A) = given { actual ->
     if (actual <= other) return
     expected("to be less than or equal to:${show(other)} but was:${show(actual)}")
 }
@@ -48,7 +48,7 @@ fun <A, B : Comparable<A>> Assert<B>.isLessThanOrEqualTo(other: A) {
  * Asserts the value is between the expected start and end values, inclusive.
  * @see [isStrictlyBetween]
  */
-fun <A, B : Comparable<A>> Assert<B>.isBetween(start: A, end: A) {
+fun <A, B : Comparable<A>> Assert<B>.isBetween(start: A, end: A) = given { actual ->
     if (actual >= start && actual <= end) return
     expected("to be between:${show(start)} and ${show(end)} but was:${show(actual)}")
 }
@@ -57,7 +57,7 @@ fun <A, B : Comparable<A>> Assert<B>.isBetween(start: A, end: A) {
  * Asserts the value is between the expected start and end values, non-inclusive.
  * @see [isBetween]
  */
-fun <A, B : Comparable<A>> Assert<B>.isStrictlyBetween(start: A, end: A) {
+fun <A, B : Comparable<A>> Assert<B>.isStrictlyBetween(start: A, end: A) = given { actual ->
     if (actual > start && actual < end) return
     expected("to be strictly between:${show(start)} and ${show(end)} but was:${show(actual)}")
 }
@@ -65,7 +65,7 @@ fun <A, B : Comparable<A>> Assert<B>.isStrictlyBetween(start: A, end: A) {
 /**
  * Asserts the value if it is close to the expected value with given delta.
  */
-fun Assert<Float>.isCloseTo(value: Float, delta: Float) {
+fun Assert<Float>.isCloseTo(value: Float, delta: Float) = given { actual ->
     if (actual >= value.minus(delta) && actual <= value.plus(delta)) return
     expected("${show(actual)} to be close to ${show(value)} with delta of ${show(delta)}, but was not")
 }
@@ -73,7 +73,7 @@ fun Assert<Float>.isCloseTo(value: Float, delta: Float) {
 /**
  * Asserts the value if it is close to the expected value with given delta.
  */
-fun Assert<Double>.isCloseTo(value: Double, delta: Double) {
+fun Assert<Double>.isCloseTo(value: Double, delta: Double) = given { actual ->
     if (actual >= value.minus(delta) && actual <= value.plus(delta)) return
     expected("${show(actual)} to be close to ${show(value)} with delta of ${show(delta)}, but was not")
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
@@ -1,7 +1,7 @@
 package assertk.assertions
 
 import assertk.Assert
-import assertk.assertAll
+import assertk.all
 import assertk.assertions.support.expected
 import assertk.assertions.support.show
 
@@ -9,7 +9,7 @@ import assertk.assertions.support.show
  * Asserts the iterable contains the expected element, using `in`.
  * @see [doesNotContain]
  */
-fun <T : Iterable<*>> Assert<T>.contains(element: Any?) {
+fun Assert<Iterable<*>>.contains(element: Any?) = given { actual ->
     if (element in actual) return
     expected("to contain:${show(element)} but was:${show(actual)}")
 }
@@ -18,7 +18,7 @@ fun <T : Iterable<*>> Assert<T>.contains(element: Any?) {
  * Asserts the iterable does not contain the expected element, using `!in`.
  * @see [contains]
  */
-fun <T : Iterable<*>> Assert<T>.doesNotContain(element: Any?) {
+fun Assert<Iterable<*>>.doesNotContain(element: Any?) = given { actual ->
     if (element !in actual) return
     expected("to not contain:${show(element)} but was:${show(actual)}")
 }
@@ -32,10 +32,10 @@ fun <T : Iterable<*>> Assert<T>.doesNotContain(element: Any?) {
  * }
  * ```
  */
-fun <E, T : Iterable<E>> Assert<T>.each(f: (Assert<E>) -> Unit) {
-    assertAll {
+fun <E> Assert<Iterable<E>>.each(f: (Assert<E>) -> Unit) = given { actual ->
+    all {
         actual.forEachIndexed { index, item ->
-            f(assert(item, "${name ?: ""}${show(index, "[]")}"))
+            f(assert(item, name = "${name ?: ""}${show(index, "[]")}"))
         }
     }
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/list.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/list.kt
@@ -12,20 +12,33 @@ import assertk.assertions.support.show
  * assert(listOf(0, 1, 2)).index(1) { it.isPositive() }
  * ```
  */
+@Deprecated(message = "Use index(index) instead.", replaceWith = ReplaceWith("index(index).let(f)"))
 fun <T> Assert<List<T>>.index(index: Int, f: (Assert<T>) -> Unit) {
-    if (index in 0 until actual.size) {
-        f(assert(actual[index], "${name ?: ""}${show(index, "[]")}"))
-    } else {
-        expected("index to be in range:[0-${actual.size}) but was:${show(index)}")
-    }
+    index(index).let(f)
 }
+
+/**
+ * Returns an assert that assertion on the value at the given index in the list.
+ *
+ * ```
+ * assert(listOf(0, 1, 2)).index(1).isPositive()
+ * ```
+ */
+fun <T> Assert<List<T>>.index(index: Int): Assert<T> =
+    transform("${name ?: ""}${show(index, "[]")}") { actual ->
+        if (index in 0 until actual.size) {
+            actual[index]
+        } else {
+            expected("index to be in range:[0-${actual.size}) but was:${show(index)}")
+        }
+    }
 
 /**
  * Asserts the list contains exactly the expected elements. They must be in the same order and
  * there must not be any extra elements.
  * @see [containsAll]
  */
-fun <T : List<*>> Assert<T>.containsExactly(vararg elements: Any?) {
+fun Assert<List<*>>.containsExactly(vararg elements: Any?) = given { actual ->
     if (actual == elements.asList()) return
 
     val diff = ListDiffer.diff(elements.asList(), actual)

--- a/assertk-common/src/main/kotlin/assertk/assertions/number.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/number.kt
@@ -8,7 +8,7 @@ import assertk.assertions.support.show
  * Asserts the number is 0.
  * @see [isNotZero]
  */
-fun <T : Number> Assert<T>.isZero() {
+fun Assert<Number>.isZero() = given { actual ->
     if (actual == 0) return
     expected("to be 0 but was:${show(actual)}")
 }
@@ -17,7 +17,7 @@ fun <T : Number> Assert<T>.isZero() {
  * Asserts the number is not 0.
  * @see [isZero]
  */
-fun <T : Number> Assert<T>.isNotZero() {
+fun Assert<Number>.isNotZero() = given { actual ->
     if (actual != 0) return
     expected("to not be 0")
 }
@@ -26,7 +26,7 @@ fun <T : Number> Assert<T>.isNotZero() {
  * Asserts the number is greater than 0.
  * @see [isNegative]
  */
-fun <T> Assert<T>.isPositive() where T : Number, T : Comparable<T> {
+fun <T> Assert<T>.isPositive() where T : Number, T : Comparable<T> = given { actual ->
     @Suppress("UNCHECKED_CAST", "UnsafeCast")
     if (actual > 0 as T) return
     expected("to be positive but was:${show(actual)}")
@@ -36,7 +36,7 @@ fun <T> Assert<T>.isPositive() where T : Number, T : Comparable<T> {
  * Asserts the number is less than 0.
  * @see [isPositive]
  */
-fun <T> Assert<T>.isNegative() where T : Number, T : Comparable<T> {
+fun <T> Assert<T>.isNegative() where T : Number, T : Comparable<T> = given { actual ->
     @Suppress("UNCHECKED_CAST", "UnsafeCast")
     if (actual < 0 as T) return
     expected("to be negative but was:${show(actual)}")

--- a/assertk-common/src/main/kotlin/assertk/assertions/string.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/string.kt
@@ -8,7 +8,7 @@ import assertk.assertions.support.show
 /**
  * Asserts the string has the expected number of lines.
  */
-fun Assert<String>.hasLineCount(lineCount: Int) {
+fun Assert<String>.hasLineCount(lineCount: Int) = given { actual ->
     val actualLineCount = actual.lines().size
     if (actualLineCount == lineCount) return
     expected("to have line count:${show(lineCount)} but was:${show(actualLineCount)}")
@@ -19,7 +19,7 @@ fun Assert<String>.hasLineCount(lineCount: Int) {
  * @param ignoreCase true to compare ignoring case, the default if false.
  * @see [isNotEqualTo]
  */
-fun Assert<String?>.isEqualTo(other: String?, ignoreCase: Boolean = false) {
+fun Assert<String?>.isEqualTo(other: String?, ignoreCase: Boolean = false) = given { actual ->
     if (actual.equals(other, ignoreCase)) return
     fail(other, actual)
 }
@@ -29,7 +29,7 @@ fun Assert<String?>.isEqualTo(other: String?, ignoreCase: Boolean = false) {
  * @param ignoreCase true to compare ignoring case, the default if false.
  * @see [isEqualTo]
  */
-fun Assert<String?>.isNotEqualTo(other: String?, ignoreCase: Boolean = false) {
+fun Assert<String?>.isNotEqualTo(other: String?, ignoreCase: Boolean = false) = given { actual ->
     if (!actual.equals(other, ignoreCase)) return
     if (ignoreCase) {
         expected(":${show(other)} not to be equal to (ignoring case):${show(actual)}")
@@ -42,7 +42,7 @@ fun Assert<String?>.isNotEqualTo(other: String?, ignoreCase: Boolean = false) {
  * Asserts the string contains the expected string.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
-fun Assert<String>.contains(other: CharSequence, ignoreCase: Boolean = false) {
+fun Assert<String>.contains(other: CharSequence, ignoreCase: Boolean = false) = given { actual ->
     if (actual.contains(other, ignoreCase)) return
     expected("to contain:${show(other)} but was:${show(actual)}")
 }
@@ -51,7 +51,7 @@ fun Assert<String>.contains(other: CharSequence, ignoreCase: Boolean = false) {
  * Asserts the string does not contain the specified string.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
-fun Assert<String>.doesNotContain(other: CharSequence, ignoreCase: Boolean = false) {
+fun Assert<String>.doesNotContain(other: CharSequence, ignoreCase: Boolean = false) = given { actual ->
     if (!actual.contains(other, ignoreCase)) return
     expected("to not contain:${show(other)}")
 }
@@ -61,7 +61,7 @@ fun Assert<String>.doesNotContain(other: CharSequence, ignoreCase: Boolean = fal
  * @param ignoreCase true to compare ignoring case, the default if false.
  * @see [endsWith]
  */
-fun Assert<String>.startsWith(other: String, ignoreCase: Boolean = false) {
+fun Assert<String>.startsWith(other: String, ignoreCase: Boolean = false) = given { actual ->
     if (actual.startsWith(other, ignoreCase)) return
     expected("to start with:${show(other)} but was:${show(actual)}")
 }
@@ -71,7 +71,7 @@ fun Assert<String>.startsWith(other: String, ignoreCase: Boolean = false) {
  * @param ignoreCase true to compare ignoring case, the default if false.
  * @see [startsWith]
  */
-fun Assert<String>.endsWith(other: String, ignoreCase: Boolean = false) {
+fun Assert<String>.endsWith(other: String, ignoreCase: Boolean = false) = given { actual ->
     if (actual.endsWith(other, ignoreCase)) return
     expected("to end with:${show(other)} but was:${show(actual)}")
 }
@@ -79,7 +79,7 @@ fun Assert<String>.endsWith(other: String, ignoreCase: Boolean = false) {
 /**
  * Asserts the string matches the expected regular expression.
  */
-fun Assert<String>.matches(regex: Regex) {
+fun Assert<String>.matches(regex: Regex) = given { actual ->
     if (actual.matches(regex)) return
     expected("to match:${show(regex)} but was:${show(actual)}")
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/support/support.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/support/support.kt
@@ -66,7 +66,7 @@ fun <T> Assert<T>.fail(expected: Any?, actual: Any?) {
  *
  * -> "expected to be: <1> but was <2>"
  */
-fun <T> Assert<T>.expected(message: String, expected: Any? = null, actual: Any? = null) {
+fun <T> Assert<T>.expected(message: String, expected: Any? = null, actual: Any? = null): Nothing {
     val maybeSpace = if (message.startsWith(":")) "" else " "
     val maybeInstance = if (context != null) " ${show(context, "()")}" else ""
     fail(

--- a/assertk-common/src/main/kotlin/assertk/assertions/throwable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/throwable.kt
@@ -1,28 +1,28 @@
 package assertk.assertions
 
 import assertk.Assert
+import assertk.ValueAssert
 import assertk.all
-import kotlin.reflect.KClass
 
 /**
  * Returns an assert on the throwable's message.
  */
-fun <T : Throwable> Assert<T>.message() = prop("message", Throwable::message)
+fun Assert<Throwable>.message() = prop("message", Throwable::message)
 
 /**
  * Returns an assert on the throwable's cause.
  */
-fun <T : Throwable> Assert<T>.cause() = prop("cause", Throwable::cause)
+fun Assert<Throwable>.cause() = prop("cause", Throwable::cause)
 
 /**
  * Returns an assert on the throwable's root cause.
  */
-fun <T : Throwable> Assert<T>.rootCause() = prop("rootCause", Throwable::rootCause)
+fun Assert<Throwable>.rootCause() = prop("rootCause", Throwable::rootCause)
 
 /**
  * Asserts the throwable has the expected message.
  */
-fun <T : Throwable> Assert<T>.hasMessage(message: String?) {
+fun Assert<Throwable>.hasMessage(message: String?) {
     message().isEqualTo(message)
 }
 
@@ -30,10 +30,10 @@ fun <T : Throwable> Assert<T>.hasMessage(message: String?) {
  * Asserts the throwable is similar to the expected cause, checking the type and message.
  * @see [hasNoCause]
  */
-fun <T : Throwable> Assert<T>.hasCause(cause: Throwable) {
-    cause().isNotNull {
-        it.kClass().isEqualTo(cause::class)
-        it.hasMessage(cause.message)
+fun Assert<Throwable>.hasCause(cause: Throwable) {
+    cause().isNotNull().all {
+        kClass().isEqualTo(cause::class)
+        hasMessage(cause.message)
     }
 }
 
@@ -41,14 +41,14 @@ fun <T : Throwable> Assert<T>.hasCause(cause: Throwable) {
  * Asserts the throwable has no cause.
  * @see [hasCause]
  */
-fun <T : Throwable> Assert<T>.hasNoCause() {
+fun Assert<Throwable>.hasNoCause() {
     cause().isNull()
 }
 
 /**
  * Asserts the throwable is similar to the expected root cause, checking the type and message.
  */
-fun <T : Throwable> Assert<T>.hasRootCause(cause: Throwable) {
+fun Assert<Throwable>.hasRootCause(cause: Throwable) {
     rootCause().all {
         kClass().isEqualTo(cause::class)
         hasMessage(cause.message)

--- a/assertk-common/src/main/kotlin/assertk/failure.kt
+++ b/assertk-common/src/main/kotlin/assertk/failure.kt
@@ -79,15 +79,19 @@ internal class SoftFailure : Failure {
 /**
  * Fail the test with the given {@link AssertionError}.
  */
-fun fail(error: AssertionError) {
-    FailureContext.failure.fail(error)
+fun fail(error: AssertionError): Nothing {
+    throw error
 }
 
 /**
  * Fail the test with the given message.
  */
-fun fail(message: String, expected: Any? = null, actual: Any? = null) {
-    FailureContext.failure.fail(AssertionFailedError(message, expected, actual, null))
+fun fail(message: String, expected: Any? = null, actual: Any? = null): Nothing {
+    throw AssertionFailedError(message, expected, actual, null)
+}
+
+fun notifyFailure(e: Throwable) {
+    FailureContext.failure.fail(if (e is AssertionError) e else AssertionError(e))
 }
 
 internal expect inline fun failWithNotInStacktrace(error: AssertionError): Nothing

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
@@ -11,15 +11,15 @@ class AnyTest {
     val nullableSubject: BasicObject? = BasicObject("test")
 
     @Test fun extracts_kClass() {
-        assertEquals(BasicObject::class, assert(subject as TestObject).kClass().actual)
+        assertEquals(BasicObject::class, assert(subject as TestObject).kClass().valueOrFail)
     }
 
     @Test fun extracts_toStringFun() {
-        assertEquals("test", assert(subject).toStringFun().actual)
+        assertEquals("test", assert(subject).toStringFun().valueOrFail)
     }
 
     @Test fun extracts_hashCodeFun() {
-        assertEquals(42, assert(subject).hashCodeFun().actual)
+        assertEquals(42, assert(subject).hashCodeFun().valueOrFail)
     }
 
     @Test fun isEqualTo_equal_objects_passes() {
@@ -195,20 +195,20 @@ class AnyTest {
     }
 
     @Test fun isNotNull_non_null_and_equal_object_passes() {
-        assert(nullableSubject).isNotNull { it.isEqualTo(subject) }
+        assert(nullableSubject).isNotNull().isEqualTo(subject)
     }
 
     @Test fun isNotNull_non_null_and_non_equal_object_fails() {
         val unequal = BasicObject("not test")
         val error = assertFails {
-            assert(nullableSubject).isNotNull { it.isEqualTo(unequal) }
+            assert(nullableSubject).isNotNull().isEqualTo(unequal)
         }
         assertEquals("expected:<[not ]test> but was:<[]test>", error.message)
     }
 
     @Test fun isNotNull_null_and_equal_object_fails() {
         val error = assertFails {
-            assert(null as String?).isNotNull { it.isEqualTo(null) }
+            assert(null as String?).isNotNull().isEqualTo(null)
         }
         assertEquals("expected to not be null", error.message)
     }
@@ -258,18 +258,15 @@ class AnyTest {
 
     @Test fun isInstanceOf_kclass_run_block_when_passes() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(BasicObject::class) {
-                it.prop("str", BasicObject::str).isEqualTo("wrong")
-            }
+            assert(subject as TestObject).isInstanceOf(BasicObject::class).prop("str", BasicObject::str)
+                .isEqualTo("wrong")
         }
         assertEquals("expected [str]:<\"[wrong]\"> but was:<\"[test]\"> (test)", error.message)
     }
 
     @Test fun isInstanceOf_kclass_doesnt_run_block_when_fails() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(DifferentObject::class) {
-                it.isNull()
-            }
+            assert(subject as TestObject).isInstanceOf(DifferentObject::class).isNull()
         }
         assertEquals(
             "expected to be instance of:<${DifferentObject::class}> but had class:<${BasicObject::class}>",

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
@@ -246,12 +246,12 @@ class ArrayTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert(arrayOf("one", "two"), name = "subject").index(0) { it.isEqualTo("one") }
+        assert(arrayOf("one", "two"), name = "subject").index(0).isEqualTo("one")
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(arrayOf("one", "two"), name = "subject").index(0) { it.isEqualTo("wrong") }
+            assert(arrayOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
         }
         assertEquals(
             "expected [subject[0]]:<\"[wrong]\"> but was:<\"[one]\"> ([\"one\", \"two\"])",
@@ -261,7 +261,7 @@ class ArrayTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert(arrayOf("one", "two"), name = "subject").index(-1) { it.isEqualTo(listOf("one")) }
+            assert(arrayOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/AssertExt.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/AssertExt.kt
@@ -1,0 +1,11 @@
+package test.assertk.assertions
+
+import assertk.Assert
+import assertk.FailingAssert
+import assertk.ValueAssert
+
+val Assert<*>.valueOrFail
+    get() = when (this) {
+        is ValueAssert -> value
+        is FailingAssert -> throw error
+    }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/CharSequenceTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/CharSequenceTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFails
 class CharSequenceTest {
     //region props
     @Test fun extracts_length() {
-        assertEquals(4, assert("test").length().actual)
+        assertEquals(4, assert("test").length().valueOrFail)
     }
     //endregion
 

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ListTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ListTest.kt
@@ -75,12 +75,12 @@ class ListTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert(listOf("one", "two"), name = "subject").index(0) { it.isEqualTo("one") }
+        assert(listOf("one", "two"), name = "subject").index(0).isEqualTo("one")
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(listOf("one", "two"), name = "subject").index(0) { it.isEqualTo("wrong") }
+            assert(listOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
         }
         assertEquals(
             "expected [subject[0]]:<\"[wrong]\"> but was:<\"[one]\"> ([\"one\", \"two\"])",
@@ -90,7 +90,7 @@ class ListTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert(listOf("one", "two"), name = "subject").index(-1) { it.isEqualTo(listOf("one")) }
+            assert(listOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
@@ -158,19 +158,19 @@ class MapTest {
 
     //region key
     @Test fun index_successful_assertion_passes() {
-        assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one") { it.isEqualTo(1) }
+        assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one").isEqualTo(1)
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one") { it.isEqualTo(2) }
+            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one").isEqualTo(2)
         }
         assertEquals("expected [subject[\"one\"]]:<[2]> but was:<[1]> ({\"one\"=1, \"two\"=2})", error.message)
     }
 
     @Test fun index_missing_key_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("wrong") { it.isEqualTo(1) }
+            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("wrong").isEqualTo(1)
         }
         assertEquals("expected [subject] to have key:<\"wrong\">", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ThrowableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ThrowableTest.kt
@@ -13,15 +13,15 @@ class ThrowableTest {
     val subject = Exception("test", cause)
 
     @Test fun extracts_message() {
-        assertEquals(subject.message, assert(subject).message().actual)
+        assertEquals(subject.message, assert(subject).message().valueOrFail)
     }
 
     @Test fun extracts_cause() {
-        assertEquals(cause, assert(subject).cause().actual)
+        assertEquals(cause, assert(subject).cause().valueOrFail)
     }
 
     @Test fun extracts_root_cause() {
-        assertEquals(rootCause, assert(subject).rootCause().actual)
+        assertEquals(rootCause, assert(subject).rootCause().valueOrFail)
     }
 
     //region hasMessage

--- a/assertk-common/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
+++ b/assertk-common/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
@@ -245,12 +245,12 @@ class $TTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0) { it.isEqualTo(1.to$E()) }
+        assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0).isEqualTo(1.to$E())
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0) { it.isGreaterThan(2.to$E()) }
+            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0).isGreaterThan(2.to$E())
         }
         assertEquals(
             "expected [subject[0]] to be greater than:<${show(2.to$E(), "")}> but was:<${show(1.to$E(), "")}> ([${show(1.to$E(), "")}, ${show(2.to$E(), "")}])",
@@ -260,7 +260,7 @@ class $TTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1) { it.isEqualTo(listOf(1.to$E())) }
+            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1).isEqualTo(listOf(1.to$E()))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-js/package-lock.json
+++ b/assertk-js/package-lock.json
@@ -12,7 +12,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -59,12 +59,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "growl": {
@@ -87,8 +87,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -101,7 +101,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -144,7 +144,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "path-is-absolute": {
@@ -157,7 +157,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "2.0.0"
       }
     },
     "wrappy": {

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/file.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/file.kt
@@ -5,6 +5,8 @@ import assertk.assertions.support.expected
 import assertk.assertions.support.show
 import java.io.File
 import java.nio.charset.Charset
+import kotlin.io.extension
+import kotlin.io.readBytes
 
 /**
  * Returns an assert on the file's name.
@@ -29,7 +31,7 @@ fun Assert<File>.extension() = prop("extension", File::extension)
 /**
  * Returns an assert on the file's contents as text.
  */
-fun Assert<File>.text(charset: Charset = Charsets.UTF_8) = prop("text", { it.readText(charset) })
+fun Assert<File>.text(charset: Charset = Charsets.UTF_8) = prop("text") { it.readText(charset) }
 
 /**
  * Returns an assert on the file's contents as bytes.
@@ -39,7 +41,7 @@ fun Assert<File>.bytes() = prop("bytes", File::readBytes)
 /**
  * Asserts the file exists.
  */
-fun Assert<File>.exists() {
+fun Assert<File>.exists() = given { actual ->
     if (actual.exists()) return
     expected("to exist")
 }
@@ -48,7 +50,7 @@ fun Assert<File>.exists() {
  * Asserts the file is a directory.
  * @see [isFile]
  */
-fun Assert<File>.isDirectory() {
+fun Assert<File>.isDirectory() = given { actual ->
     if (actual.isDirectory) return
     expected("to be a directory")
 }
@@ -57,7 +59,7 @@ fun Assert<File>.isDirectory() {
  * Asserts the file is a simple file (not a directory).
  * @see [isDirectory]
  */
-fun Assert<File>.isFile() {
+fun Assert<File>.isFile() = given { actual ->
     if (actual.isFile) return
     expected("to be a file")
 }
@@ -66,7 +68,7 @@ fun Assert<File>.isFile() {
  * Asserts the file is hidden.
  * @see [isNotHidden]
  */
-fun Assert<File>.isHidden() {
+fun Assert<File>.isHidden() = given { actual ->
     if (actual.isHidden) return
     expected("to be hidden")
 }
@@ -75,7 +77,7 @@ fun Assert<File>.isHidden() {
  * Asserts the file is not hidden.
  * @see [isHidden]
  */
-fun Assert<File>.isNotHidden() {
+fun Assert<File>.isNotHidden() = given { actual ->
     if (!actual.isHidden) return
     expected("to not be hidden")
 }
@@ -120,7 +122,7 @@ fun Assert<File>.hasText(expected: String, charset: Charset = Charsets.UTF_8) {
 /**
  * Asserts the file has the expected direct child.
  */
-fun Assert<File>.hasDirectChild(expected: File) {
+fun Assert<File>.hasDirectChild(expected: File) = given { actual ->
     if (actual.listFiles()?.contains(expected) == true) return
     expected("to have direct child ${show(expected)}")
 }

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/inputstream.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/inputstream.kt
@@ -10,7 +10,7 @@ import java.io.InputStream
  *
  * @param expected which content is compared to the actual one
  */
-fun Assert<InputStream>.hasSameContentAs(expected: InputStream) {
+fun Assert<InputStream>.hasSameContentAs(expected: InputStream) = given { actual ->
     val msg = doTheStreamHaveTheSameContent(actual, expected)
     if (msg != null) {
         expected(msg)
@@ -23,12 +23,11 @@ fun Assert<InputStream>.hasSameContentAs(expected: InputStream) {
  *
  * @param expected which content is compared to the actual one
  */
-fun Assert<InputStream>.hasNotSameContentAs(expected: InputStream) {
+fun Assert<InputStream>.hasNotSameContentAs(expected: InputStream) = given { actual ->
     val msg = doTheStreamHaveTheSameContent(actual, expected)
     if (msg == null) {
         expected("streams not to be equal, but they were equal")
     }
-
 }
 
 private const val BUFFER_SIZE = 4096

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/path.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/path.kt
@@ -8,11 +8,23 @@ import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
 
+/**
+ * Assert on file lines
+ *
+ * @param charset charset to use when reading file
+ */
+fun Assert<Path>.lines(charset: Charset = Charsets.UTF_8): Assert<List<String>> =
+    transform { actual -> Files.readAllLines(actual, charset) }
+
+/** Assert on file bytes */
+fun Assert<Path>.bytes(): Assert<ByteArray> =
+    transform { actual -> Files.readAllBytes(actual) }
+
 /** Assert that the path is a regular file.
  *
  * @param options indicating how symbolic links are handled
  */
-fun Assert<Path>.isRegularFile(vararg options: LinkOption) {
+fun Assert<Path>.isRegularFile(vararg options: LinkOption) = given { actual ->
     if (!Files.isRegularFile(actual, *options)) {
         expected("${show(actual)} to be a regular file, but it is not")
     }
@@ -22,42 +34,42 @@ fun Assert<Path>.isRegularFile(vararg options: LinkOption) {
  *
  * @param options indicating how symbolic links are handled
  */
-fun Assert<Path>.isDirectory(vararg options: LinkOption) {
+fun Assert<Path>.isDirectory(vararg options: LinkOption) = given { actual ->
     if (!Files.isDirectory(actual, *options)) {
         expected("${show(actual)} to be a directory, but it is not")
     }
 }
 
 /** Assert that the path is an executable. */
-fun Assert<Path>.isExecutable() {
+fun Assert<Path>.isExecutable() = given { actual ->
     if (!Files.isExecutable(actual)) {
         expected("${show(actual)} to be an executable, but it is not")
     }
 }
 
 /** Assert that the path is hidden. */
-fun Assert<Path>.isHidden() {
+fun Assert<Path>.isHidden() = given { actual ->
     if (!Files.isHidden(actual)) {
         expected("${show(actual)} to be hidden, but it is not")
     }
 }
 
 /** Assert that the path is readable. */
-fun Assert<Path>.isReadable() {
+fun Assert<Path>.isReadable() = given { actual ->
     if (!Files.isReadable(actual)) {
         expected("${show(actual)} to be readable, but it is not")
     }
 }
 
 /** Assert that the path is a symbolic link. */
-fun Assert<Path>.isSymbolicLink() {
+fun Assert<Path>.isSymbolicLink() = given { actual ->
     if (!Files.isSymbolicLink(actual)) {
         expected("${show(actual)} to be a symbolic link, but it is not")
     }
 }
 
 /** Assert that the path is writable link. */
-fun Assert<Path>.isWritable() {
+fun Assert<Path>.isWritable() = given { actual ->
     if (!Files.isWritable(actual)) {
         expected("${show(actual)} to be writable, but it is not")
     }
@@ -68,22 +80,8 @@ fun Assert<Path>.isWritable() {
  *
  * @param expected the path which the actual is compared to.
  */
-fun Assert<Path>.isSameFileAs(expected: Path) {
+fun Assert<Path>.isSameFileAs(expected: Path) = given { actual ->
     if (!Files.isSameFile(actual, expected)) {
         expected("${show(actual)} to be the same file as ${show(actual)} but is not")
     }
-}
-
-/**
- * Assert on file lines
- *
- * @param charset charset to use when reading file
- */
-fun Assert<Path>.lines(charset: Charset = Charsets.UTF_8): Assert<List<String>> {
-    return assert(Files.readAllLines(actual, charset))
-}
-
-/** Assert on file bytes */
-fun Assert<Path>.bytes(): Assert<ByteArray> {
-    return assert(Files.readAllBytes(actual))
 }

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/throwable.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/throwable.kt
@@ -7,4 +7,4 @@ import assertk.Assert
 /**
  * Returns an assert on the throwable's stack trace.
  */
-fun <T : Throwable> Assert<T>.stackTrace() = prop("stack trace", { it.stackTrace.map { it.toString() } })
+fun Assert<Throwable>.stackTrace() = prop("stackTrace") { it.stackTrace.map(StackTraceElement::toString) }

--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -12,7 +12,7 @@ class JavaAnyTest {
 
     //region jClass
     @Test fun extracts_jClass() {
-        assertEquals(BasicObject::class.java, assert(subject as TestObject).jClass().actual)
+        assertEquals(BasicObject::class.java, assert(subject as TestObject).jClass().valueOrFail)
     }
     //endregion
 
@@ -37,18 +37,19 @@ class JavaAnyTest {
 
     @Test fun isInstanceOf_jclass_run_block_when_passes() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(BasicObject::class.java) {
-                it.prop("str", BasicObject::str).isEqualTo("wrong")
-            }
+            assert(subject as TestObject)
+                .isInstanceOf(BasicObject::class.java)
+                .prop("str", BasicObject::str)
+                .isEqualTo("wrong")
         }
         assertEquals("expected [str]:<\"[wrong]\"> but was:<\"[test]\"> (test)", error.message)
     }
 
     @Test fun isInstanceOf_jclass_doesnt_run_block_when_fails() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(DifferentObject::class.java) {
-                it.isNull()
-            }
+            assert(subject as TestObject)
+                .isInstanceOf(DifferentObject::class.java)
+                .isNull()
         }
         assertEquals(
             "expected to be instance of:<$p\$DifferentObject> but had class:<$p\$BasicObject>",


### PR DESCRIPTION
Wrap custom asserts in a `given` function.

This is an alternative to #142, allowing assertions to be chained
instead of requiring lambdas. Soft assertions are still supported the
same way they were before. However, `fail()` and `expect() now always
throw exceptions which removes the foot-gun of them sometimes not.

Custom assertions that work on the actual value need to be wrapped in a
`given` function:
```kotlin
fun <T> Assert<T>.isEqualTo(expected: Any?) {
   if (actual == expected) return
   fail(expected, actual)
}
```
to
```kotlin
fun <T> Assert<T>.isEqualTo(expected: Any?) = given { actual ->
   if (actual == expected) return
   fail(expected, actual)
}
```

One nice thing about this `given` function is it can also be used in
line for one-off assertions.
```kotlin
assert(foo).given { actual ->
    if (actual >= 10)
    	expected("to be less than 10 but was:${show(actual)}")
}
```
