### PR TITLE
 Add support for conditional failures. 

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assert.kt
+++ b/assertk-common/src/main/kotlin/assertk/assert.kt
@@ -153,10 +153,40 @@ fun <T> assert(actual: T, name: String? = null): Assert<T> = ValueAssert(actual,
  *   endsWith("t")
  * }
  * ```
+ * @param message An optional message to show before all failures.
+ * @param body The body to execute.
  */
-fun <T> Assert<T>.all(f: Assert<T>.() -> Unit) {
-    FailureContext.run(SoftFailure()) {
-        f()
+fun <T> Assert<T>.all(message: String = SoftFailure.defaultMessage, body: Assert<T>.() -> Unit) {
+    all(message, body, { it.isNotEmpty() })
+}
+
+/**
+ * All assertions in the given lambda are run, with their failures collected. If `failIf` returns true then a failure
+ * happens, otherwise they are ignored.
+ *
+ * ```
+ * assert("test", name = "test").all(
+ *   message = "my message",
+ *   body = {
+ *     startsWith("t")
+ *     endsWith("t")
+ *   }, {
+ *     it.size > 1
+ *   }
+ * )
+ * ```
+ *
+ * @param message An optional message to show before all failures.
+ * @param body The body to execute.
+ * @param failIf Fails if this returns true, ignores failures otherwise.
+ */
+fun <T> Assert<T>.all(
+    message: String,
+    body: Assert<T>.() -> Unit,
+    failIf: (List<AssertionError>) -> Boolean
+) {
+    FailureContext.run(SoftFailure(message, failIf)) {
+        body()
     }
 }
 

--- a/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
@@ -2,6 +2,7 @@ package assertk.assertions
 
 import assertk.Assert
 import assertk.all
+import assertk.all
 import assertk.assertions.support.expected
 import assertk.assertions.support.show
 
@@ -38,4 +39,19 @@ fun <E> Assert<Iterable<E>>.each(f: (Assert<E>) -> Unit) = given { actual ->
             f(assert(item, name = "${name ?: ""}${show(index, "[]")}"))
         }
     }
+}
+
+/**
+ * Asserts on each item in the iterable, passing if at least `times` items pass.
+ * The given lambda will be run for each item.
+ *
+ * ```
+ * assert(listOf(-1, 1, 2) as Iterable<Int>).atLeast(2) { it -> it.isPositive() }
+ * ```
+ */
+fun <E, T : Iterable<E>> Assert<T>.atLeast(times: Int, f: (Assert<E>) -> Unit) {
+    var count = 0
+    all(message = "expected to pass at least $times times",
+        body = { each { item -> count++; f(item) } },
+        failIf = { count - it.size < times })
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/predicate.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/predicate.kt
@@ -1,0 +1,17 @@
+package assertk.assertions
+
+import assertk.Assert
+import assertk.assertions.support.expected
+
+/**
+ * Asserts if the values satisfies the predicate provided.
+ *
+ * ```
+ * val divisibleBy5 : (Int) -> Boolean = { it % 5 == 0 }
+ * assert(10).matchesPredicate(divisibleBy5)
+ * ```
+ */
+fun <T> Assert<T>.matchesPredicate(f: (T) -> Boolean) = given { actual ->
+    if (f(actual)) return
+    expected("$actual to satisfy the predicate")
+}

--- a/assertk-common/src/main/kotlin/assertk/failure.kt
+++ b/assertk-common/src/main/kotlin/assertk/failure.kt
@@ -54,7 +54,11 @@ internal class SimpleFailure : Failure {
 /**
  * Failure that collects all failures and displays them at once.
  */
-internal class SoftFailure : Failure {
+internal class SoftFailure(
+    val message: String = defaultMessage,
+    val failIf: (List<AssertionError>) -> Boolean = { it.isNotEmpty() }
+) :
+    Failure {
     private val failures: MutableList<AssertionError> = ArrayList()
 
     override fun fail(error: AssertionError) {
@@ -62,7 +66,7 @@ internal class SoftFailure : Failure {
     }
 
     override fun invoke() {
-        if (!failures.isEmpty()) {
+        if (failIf(failures)) {
             FailureContext.failure.fail(compositeErrorMessage(failures))
         }
     }
@@ -71,8 +75,12 @@ internal class SoftFailure : Failure {
         return if (errors.size == 1) {
             errors.first()
         } else {
-            MultipleFailuresError("The following assertions failed", errors)
+            MultipleFailuresError(message, errors)
         }
+    }
+
+    companion object {
+        const val defaultMessage = "The following assertions failed"
     }
 }
 

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
@@ -54,4 +54,26 @@ class IterableTest {
         )
     }
     //endregion
+
+    //region atLeast
+    @Test fun atLeast_to_many_failures_fails() {
+        val error = assertFails {
+            assert(listOf(1, 2, 3)).atLeast(2) { it -> it.isGreaterThan(2) }
+        }
+        assertEquals(
+            """expected to pass at least 2 times (2 failures)
+            |${"\t"}expected [[0]] to be greater than:<2> but was:<1> ([1, 2, 3])
+            |${"\t"}expected [[1]] to be greater than:<2> but was:<2> ([1, 2, 3])
+        """.trimMargin(), error.message
+        )
+    }
+
+    @Test fun atLest_no_failures_passes() {
+        assert(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(0) }
+    }
+
+    @Test fun atLeast_less_than_times_failures_passes() {
+        assert(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(1) }
+    }
+    //endregion
 }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/PredicateTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/PredicateTest.kt
@@ -1,0 +1,23 @@
+package test.assertk.assertions
+
+import assertk.assert
+import assertk.assertions.matchesPredicate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class PredicateTest {
+
+    @Test fun matchesPredicate_true_predicate_passes() {
+        val divisibleBy5: (Int) -> Boolean = { it % 5 == 0 }
+
+        assert(10).matchesPredicate(divisibleBy5)
+    }
+
+    @Test fun matchesPredicate_false_predicate_fails() {
+        val divisibleBy5: (Int) -> Boolean = { it % 5 == 0 }
+        val error = assertFails { assert(6).matchesPredicate(divisibleBy5) }
+
+        assertEquals("expected 6 to satisfy the predicate", error.message)
+    }
+}


### PR DESCRIPTION
Added variant of `all` that takes a predicate to choose if there is a
failure or not based on failures in the body. `atLeast` uses this to
fail if at least `times` items do not pass.

Renamed `assertPredicate` to `matchesPredicate`.