### PR TITLE
Rename assert to assertThat deprecating the old one

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assertions/any.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/any.kt
@@ -116,7 +116,7 @@ fun <T : Any> Assert<T?>.isNull() = given { actual ->
  *
  * ```
  * val name: String? = ...
- * assert(name).isNotNull() {
+ * assertThat(name).isNotNull() {
  *   it.hasLength(4)
  * }
  * ```
@@ -131,7 +131,7 @@ fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit) {
  *
  * ```
  * val name: String? = ...
- * assert(name).isNotNull().hasLength(4)
+ * assertThat(name).isNotNull().hasLength(4)
  * ```
  */
 fun <T : Any> Assert<T?>.isNotNull(): Assert<T> = transform { actual ->
@@ -144,15 +144,15 @@ fun <T : Any> Assert<T?>.isNotNull(): Assert<T> = transform { actual ->
  * @param extract The function to extract the property value out of the value of the current assert.
  *
  * ```
- * assert(person).prop("name", { it.name }).isEqualTo("Sue")
+ * assertThat(person).prop("name", { it.name }).isEqualTo("Sue")
  * ```
  */
 fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P): Assert<P> =
     transform("${if (this.name != null) this.name + "." else ""}$name", extract)
 
 /**
- * Asserts the value has the expected kotlin class. This is an exact match, so `assert("test").hasClass(String::class)`
- * is successful but `assert("test").hasClass(Any::class)` fails.
+ * Asserts the value has the expected kotlin class. This is an exact match, so `assertThat("test").hasClass(String::class)`
+ * is successful but `assertThat("test").hasClass(Any::class)` fails.
  * @see [doesNotHaveClass]
  * @see [isInstanceOf]
  */
@@ -163,7 +163,7 @@ fun <T : Any> Assert<T>.hasClass(kclass: KClass<out T>) = given { actual ->
 
 /**
  * Asserts the value does not have the expected kotlin class. This is an exact match, so
- * `assert("test").doesNotHaveClass(String::class)` is fails but `assert("test").doesNotHaveClass(Any::class)` is
+ * `assertThat("test").doesNotHaveClass(String::class)` is fails but `assertThat("test").doesNotHaveClass(Any::class)` is
  * successful.
  * @see [hasClass]
  * @see [isNotInstanceOf]
@@ -175,7 +175,7 @@ fun <T : Any> Assert<T>.doesNotHaveClass(kclass: KClass<out T>) = given { actual
 
 /**
  * Asserts the value is not an instance of the expected kotlin class. Both
- * `assert("test").isNotInstanceOf(String::class)` and `assert("test").isNotInstanceOf(Any::class)` fails.
+ * `assertThat("test").isNotInstanceOf(String::class)` and `assertThat("test").isNotInstanceOf(Any::class)` fails.
  * @see [isInstanceOf]
  * @see [doesNotHaveClass]
  */
@@ -185,8 +185,8 @@ fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) = given { actual 
 }
 
 /**
- * Asserts the value is an instance of the expected kotlin class. Both `assert("test").isInstanceOf(String::class)` and
- * `assert("test").isInstanceOf(Any::class)` is successful.
+ * Asserts the value is an instance of the expected kotlin class. Both `assertThat("test").isInstanceOf(String::class)` and
+ * `assertThat("test").isInstanceOf(Any::class)` is successful.
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
@@ -196,8 +196,8 @@ fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: (Assert<S>) ->
 }
 
 /**
- * Asserts the value is an instance of the expected kotlin class. Both `assert("test").isInstanceOf(String::class)` and
- * `assert("test").isInstanceOf(Any::class)` is successful.
+ * Asserts the value is an instance of the expected kotlin class. Both `assertThat("test").isInstanceOf(String::class)` and
+ * `assertThat("test").isInstanceOf(Any::class)` is successful.
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
@@ -216,7 +216,7 @@ fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>) = transform(name)
  * @param properties properties of the type with which to compare
  *
  * ```
- * assert(person).isEqualToWithGivenProperties(other, Person::name, Person::age)
+ * assertThat(person).isEqualToWithGivenProperties(other, Person::name, Person::age)
  * ```
  */
 fun <T> Assert<T>.isEqualToWithGivenProperties(other: T, vararg properties: KProperty1<T, Any>) {

--- a/assertk-common/src/main/kotlin/assertk/assertions/array.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/array.kt
@@ -1,6 +1,8 @@
 package assertk.assertions
 
-import assertk.*
+import assertk.Assert
+import assertk.PlatformName
+import assertk.all
 import assertk.assertions.support.expected
 import assertk.assertions.support.fail
 import assertk.assertions.support.show
@@ -134,7 +136,7 @@ fun <T> Assert<Array<T>>.containsAll(vararg elements: Any?) = given { actual ->
  * Returns an assert that assertion on the value at the given index in the array.
  *
  * ```
- * assert(arrayOf(0, 1, 2)).index(1) { it.isPositive() }
+ * assertThat(arrayOf(0, 1, 2)).index(1) { it.isPositive() }
  * ```
  */
 @Deprecated(message = "Use index(index) instead.", replaceWith = ReplaceWith("index(index).let(f)"))
@@ -146,7 +148,7 @@ fun <T> Assert<Array<T>>.index(index: Int, f: (Assert<T>) -> Unit) {
  * Returns an assert that assertion on the value at the given index in the array.
  *
  * ```
- * assert(arrayOf(0, 1, 2)).index(1).isPositive()
+ * assertThat(arrayOf(0, 1, 2)).index(1).isPositive()
  * ```
  */
 fun <T> Assert<Array<T>>.index(index: Int): Assert<T> =
@@ -174,7 +176,7 @@ fun <T> Assert<Array<T>>.containsExactly(vararg elements: Any?) = given { actual
  * Asserts on each item in the array. The given lambda will be run for each item.
  *
  * ```
- * assert(arrayOf("one", "two")).each {
+ * assertThat(arrayOf("one", "two")).each {
  *   it.hasLength(3)
  * }
  * ```
@@ -183,7 +185,7 @@ fun <T> Assert<Array<T>>.containsExactly(vararg elements: Any?) = given { actual
 fun <T> Assert<Array<T>>.each(f: (Assert<T>) -> Unit) = given { actual ->
     all {
         actual.forEachIndexed { index, item ->
-            f(assert(item, name = "${name ?: ""}${show(index, "[]")}"))
+            f(assertThat(item, name = "${name ?: ""}${show(index, "[]")}"))
         }
     }
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
@@ -28,7 +28,7 @@ fun Assert<Iterable<*>>.doesNotContain(element: Any?) = given { actual ->
  * Asserts on each item in the iterable. The given lambda will be run for each item.
  *
  * ```
- * assert(listOf("one", "two")).each {
+ * assertThat(listOf("one", "two")).each {
  *   it.hasLength(3)
  * }
  * ```
@@ -36,7 +36,7 @@ fun Assert<Iterable<*>>.doesNotContain(element: Any?) = given { actual ->
 fun <E> Assert<Iterable<E>>.each(f: (Assert<E>) -> Unit) = given { actual ->
     all {
         actual.forEachIndexed { index, item ->
-            f(assert(item, name = "${name ?: ""}${show(index, "[]")}"))
+            f(assertThat(item, name = "${name ?: ""}${show(index, "[]")}"))
         }
     }
 }

--- a/assertk-common/src/main/kotlin/assertk/assertions/list.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/list.kt
@@ -9,7 +9,7 @@ import assertk.assertions.support.show
  * Returns an assert that assertion on the value at the given index in the list.
  *
  * ```
- * assert(listOf(0, 1, 2)).index(1) { it.isPositive() }
+ * assertThat(listOf(0, 1, 2)).index(1) { it.isPositive() }
  * ```
  */
 @Deprecated(message = "Use index(index) instead.", replaceWith = ReplaceWith("index(index).let(f)"))
@@ -21,7 +21,7 @@ fun <T> Assert<List<T>>.index(index: Int, f: (Assert<T>) -> Unit) {
  * Returns an assert that assertion on the value at the given index in the list.
  *
  * ```
- * assert(listOf(0, 1, 2)).index(1).isPositive()
+ * assertThat(listOf(0, 1, 2)).index(1).isPositive()
  * ```
  */
 fun <T> Assert<List<T>>.index(index: Int): Assert<T> =

--- a/assertk-common/src/main/kotlin/assertk/assertions/map.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/map.kt
@@ -148,7 +148,7 @@ fun <K, V> Assert<Map<K, V>>.containsOnly(vararg elements: Pair<K, V>) = given {
  * Returns an assert that asserts on the value at the given key in the map.
  *
  * ```
- * assert(mapOf("key" to "value")).key("key") { it.isEqualTo("value") }
+ * assertThat(mapOf("key" to "value")).key("key") { it.isEqualTo("value") }
  * ```
  */
 @Deprecated(message = "Use key(key) instead.", replaceWith = ReplaceWith("key(key).let(f)"))
@@ -160,7 +160,7 @@ fun <K, V> Assert<Map<K, V>>.key(key: K, f: (Assert<V>) -> Unit) {
  * Returns an assert that asserts on the value at the given key in the map.
  *
  * ```
- * assert(mapOf("key" to "value")).key("key").isEqualTo("value")
+ * assertThat(mapOf("key" to "value")).key("key").isEqualTo("value")
  * ```
  */
 fun <K, V> Assert<Map<K, V>>.key(key: K): Assert<V> = transform("${name ?: ""}${show(key, "[]")}") { actual ->

--- a/assertk-common/src/template/assertk/assertions/primativeArray.kt
+++ b/assertk-common/src/template/assertk/assertions/primativeArray.kt
@@ -139,7 +139,7 @@ fun Assert<$T>.containsAll(vararg elements: $E) = given { actual ->
  * Returns an assert that assertion on the value at the given index in the array.
  *
  * ```
- * assert($NOf(0, 1, 2)).index(1) { it.isPositive() }
+ * assertThat($NOf(0, 1, 2)).index(1) { it.isPositive() }
  * ```
  */
 @PlatformName("$NIndexOld")
@@ -152,7 +152,7 @@ fun Assert<$T>.index(index: Int, f: (Assert<$E>) -> Unit) {
  * Returns an assert that assertion on the value at the given index in the array.
  *
  * ```
- * assert($NOf(0, 1, 2)).index(1).isPositive()
+ * assertThat($NOf(0, 1, 2)).index(1).isPositive()
  * ```
  */
 @PlatformName("$NIndex")
@@ -181,7 +181,7 @@ fun Assert<$T>.containsExactly(vararg elements: $E) = given { actual ->
  * Asserts on each item in the $T. The given lambda will be run for each item.
  *
  * ```
- * assert($NOf("one", "two")).each {
+ * assertThat($NOf("one", "two")).each {
  *   it.hasLength(3)
  * }
  * ```
@@ -190,7 +190,7 @@ fun Assert<$T>.containsExactly(vararg elements: $E) = given { actual ->
 fun Assert<$T>.each(f: (Assert<$E>) -> Unit) = given { actual ->
     all {
         actual.forEachIndexed { index, item ->
-            f(assert(item, name = "${name ?: ""}${show(index, "[]")}"))
+            f(assertThat(item, name = "${name ?: ""}${show(index, "[]")}"))
         }
     }
 }

--- a/assertk-common/src/test/kotlin/test/assertk/AssertAllTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/AssertAllTest.kt
@@ -1,12 +1,9 @@
 package test.assertk
 
-import assertk.all
-import assertk.assert
-import assertk.assertAll
+import assertk.*
 import assertk.assertions.endsWith
 import assertk.assertions.isEqualTo
 import assertk.assertions.startsWith
-import assertk.fail
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -15,7 +12,7 @@ import kotlin.test.assertFalse
 class AssertAllTest {
     //region all
     @Test fun all_multiple_successful_passes() {
-        assert("test").all {
+        assertThat("test").all {
             startsWith("t")
             endsWith("t")
         }
@@ -23,7 +20,7 @@ class AssertAllTest {
 
     @Test fun all_one_failure_fails() {
         val error = assertFails {
-            assert("test", name = "test").all {
+            assertThat("test", name = "test").all {
                 startsWith("t")
                 endsWith("g")
             }
@@ -36,7 +33,7 @@ class AssertAllTest {
 
     @Test fun all_both_failures_fails_with_both() {
         val error = assertFails {
-            assert("test", name = "test").all {
+            assertThat("test", name = "test").all {
                 startsWith("w")
                 endsWith("g")
             }
@@ -54,16 +51,16 @@ class AssertAllTest {
     //region assertAll
     @Test fun assertAll_multiple_successful_passes() {
         assertAll {
-            assert("test1", name = "test1").isEqualTo("test1")
-            assert("test2", name = "test2").isEqualTo("test2")
+            assertThat("test1", name = "test1").isEqualTo("test1")
+            assertThat("test2", name = "test2").isEqualTo("test2")
         }
     }
 
     @Test fun assertAll_one_failure_fails() {
         val error = assertFails {
             assertAll {
-                assert("test1", name = "test1").isEqualTo("wrong1")
-                assert("test2", name = "test2").isEqualTo("test2")
+                assertThat("test1", name = "test1").isEqualTo("wrong1")
+                assertThat("test2", name = "test2").isEqualTo("test2")
             }
         }
         assertEquals(
@@ -75,8 +72,8 @@ class AssertAllTest {
     @Test fun assertAll_both_failures_fails_with_both() {
         val error = assertFails {
             assertAll {
-                assert("test1", name = "test1").isEqualTo("wrong1")
-                assert("test2", name = "test2").isEqualTo("wrong2")
+                assertThat("test1", name = "test1").isEqualTo("wrong1")
+                assertThat("test2", name = "test2").isEqualTo("wrong2")
             }
         }
         assertEquals(
@@ -91,7 +88,7 @@ class AssertAllTest {
     @Test fun leaves_soft_assert_scope_properly_on_exception() {
         val error = assertFails {
             try {
-                assert("This").all {
+                assertThat("This").all {
                     throw AssertionError()
                 }
             } catch (e: Throwable) {

--- a/assertk-common/src/test/kotlin/test/assertk/AssertBlockTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/AssertBlockTest.kt
@@ -1,9 +1,8 @@
 package test.assertk
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNegative
-import assertk.assertions.isPositive
 import assertk.assertions.message
 import assertk.assertions.support.show
 import kotlin.test.Test
@@ -11,8 +10,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
 class AssertBlockTest {
-    val returnSubject = assert { 1 + 1 }
-    val errorSubject = assert { throw Exception("test") }
+    val returnSubject = assertThat { 1 + 1 }
+    val errorSubject = assertThat { throw Exception("test") }
 
     //region returnedValue
     @Test fun returnedValue_successful_assertion_passes() {

--- a/assertk-common/src/test/kotlin/test/assertk/NameTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/NameTest.kt
@@ -1,6 +1,6 @@
 package test.assertk
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,14 +9,14 @@ import kotlin.test.assertFails
 class NameTest {
     @Test fun with_no_name_fails_with_default_error_message() {
         val error = assertFails {
-            assert("yes").isEqualTo("no")
+            assertThat("yes").isEqualTo("no")
         }
         assertEquals("expected:<\"[no]\"> but was:<\"[yes]\">", error.message)
     }
 
     @Test fun with_name_fails_with_name_prefixing_message() {
         val error = assertFails {
-            assert("yes", name = "test").isEqualTo("no")
+            assertThat("yes", name = "test").isEqualTo("no")
         }
         assertEquals("expected [test]:<\"[no]\"> but was:<\"[yes]\">", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/TableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/TableTest.kt
@@ -1,6 +1,6 @@
 package test.assertk
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.tableOf
 import kotlin.test.Test
@@ -14,7 +14,7 @@ class TableTest {
             .row(1, 1)
             .row(2, 2)
             .forAll { a, b ->
-                assert(a).isEqualTo(b)
+                assertThat(a).isEqualTo(b)
                 invokeCount += 1
             }
 
@@ -28,7 +28,7 @@ class TableTest {
                 .row(1, 1)
                 .row(2, 3)
                 .forAll { a, b ->
-                    assert(a).isEqualTo(b)
+                    assertThat(a).isEqualTo(b)
                     invokeCount += 1
                 }
         }
@@ -50,7 +50,7 @@ class TableTest {
                 .row(1, 2)
                 .row(2, 3)
                 .forAll { a, b ->
-                    assert(a).isEqualTo(b)
+                    assertThat(a).isEqualTo(b)
                     invokeCount += 1
                 }
         }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -11,76 +11,76 @@ class AnyTest {
     val nullableSubject: BasicObject? = BasicObject("test")
 
     @Test fun extracts_kClass() {
-        assertEquals(BasicObject::class, assert(subject as TestObject).kClass().valueOrFail)
+        assertEquals(BasicObject::class, assertThat(subject as TestObject).kClass().valueOrFail)
     }
 
     @Test fun extracts_toStringFun() {
-        assertEquals("test", assert(subject).toStringFun().valueOrFail)
+        assertEquals("test", assertThat(subject).toStringFun().valueOrFail)
     }
 
     @Test fun extracts_hashCodeFun() {
-        assertEquals(42, assert(subject).hashCodeFun().valueOrFail)
+        assertEquals(42, assertThat(subject).hashCodeFun().valueOrFail)
     }
 
     @Test fun isEqualTo_equal_objects_passes() {
         val equal = BasicObject("test")
-        assert(subject).isEqualTo(equal)
+        assertThat(subject).isEqualTo(equal)
     }
 
     @Test fun isEqualTo_non_equal_objects_fails() {
         val nonEqual = BasicObject("not test")
         val error = assertFails {
-            assert(subject).isEqualTo(nonEqual)
+            assertThat(subject).isEqualTo(nonEqual)
         }
         assertEquals("expected:<[not ]test> but was:<[]test>", error.message)
     }
 
     @Test fun isNotEqualTo_non_equal_objects_passes() {
         val nonEqual = BasicObject("not test")
-        assert(subject).isNotEqualTo(nonEqual)
+        assertThat(subject).isNotEqualTo(nonEqual)
     }
 
     @Test fun isNotEqualTo_equal_objects_fails() {
         val equal = BasicObject("test")
         val error = assertFails {
-            assert(subject).isNotEqualTo(equal)
+            assertThat(subject).isNotEqualTo(equal)
         }
         assertEquals("expected to not be equal to:<test>", error.message)
     }
 
     @Test fun isSameAs_same_objects_passes() {
-        assert(subject).isSameAs(subject)
+        assertThat(subject).isSameAs(subject)
     }
 
     @Test fun isSameAs_different_objects_fails() {
         val nonSame = BasicObject("test")
         val error = assertFails("") {
-            assert(subject).isSameAs(nonSame)
+            assertThat(subject).isSameAs(nonSame)
         }
         assertEquals("expected:<test> and:<test> to refer to the same object", error.message)
     }
 
     @Test fun isNotSameAs_non_same_objects_passes() {
         val nonSame = BasicObject("test")
-        assert(subject).isNotSameAs(nonSame)
+        assertThat(subject).isNotSameAs(nonSame)
     }
 
     @Test fun isNotSameAs_same_objects_fails() {
         val error = assertFails {
-            assert(subject).isNotSameAs(subject)
+            assertThat(subject).isNotSameAs(subject)
         }
         assertEquals("expected:<test> to not refer to the same object", error.message)
     }
 
     @Test fun isIn_one_equal_item_passes() {
         val isIn = BasicObject("test")
-        assert(subject).isIn(isIn)
+        assertThat(subject).isIn(isIn)
     }
 
     @Test fun isIn_one_non_equal_item_fails() {
         val isOut1 = BasicObject("not test1")
         val error = assertFails {
-            assert(subject).isIn(isOut1)
+            assertThat(subject).isIn(isOut1)
         }
         assertEquals("expected:<[not test1]> to contain:<test>", error.message)
     }
@@ -89,27 +89,27 @@ class AnyTest {
         val isOut1 = BasicObject("not test1")
         val isIn = BasicObject("test")
         val isOut2 = BasicObject("not test2")
-        assert(subject).isIn(isOut1, isIn, isOut2)
+        assertThat(subject).isIn(isOut1, isIn, isOut2)
     }
 
     @Test fun isIn_no_equal_items_in_may_fails() {
         val isOut1 = BasicObject("not test1")
         val isOut2 = BasicObject("not test2")
         val error = assertFails {
-            assert(subject).isIn(isOut1, isOut2)
+            assertThat(subject).isIn(isOut1, isOut2)
         }
         assertEquals("expected:<[not test1, not test2]> to contain:<test>", error.message)
     }
 
     @Test fun isNotIn_one_non_equal_item_passes() {
         val isOut1 = BasicObject("not test1")
-        assert(subject).isNotIn(isOut1)
+        assertThat(subject).isNotIn(isOut1)
     }
 
     @Test fun isNotIn_one_equal_item_fails() {
         val isIn = BasicObject("test")
         val error = assertFails {
-            assert(subject).isNotIn(isIn)
+            assertThat(subject).isNotIn(isIn)
         }
         assertEquals("expected:<[test]> to not contain:<test>", error.message)
     }
@@ -117,7 +117,7 @@ class AnyTest {
     @Test fun isNotIn_no_equal_items_in_many_passes() {
         val isOut1 = BasicObject("not test1")
         val isOut2 = BasicObject("not test2")
-        assert(subject).isNotIn(isOut1, isOut2)
+        assertThat(subject).isNotIn(isOut1, isOut2)
     }
 
     @Test fun isNotIn_one_equal_item_in_many_fails() {
@@ -125,7 +125,7 @@ class AnyTest {
         val isIn = BasicObject("test")
         val isOut2 = BasicObject("not test2")
         val error = assertFails {
-            assert(subject).isNotIn(isOut1, isIn, isOut2)
+            assertThat(subject).isNotIn(isOut1, isIn, isOut2)
         }
         assertEquals("expected:<[not test1, test, not test2]> to not contain:<test>", error.message)
     }
@@ -134,12 +134,12 @@ class AnyTest {
 
     @Test fun isEqualToWithGivenProperties_regular_equals_fail() {
         assertFails {
-            assert(subject).isEqualTo(testObject)
+            assertThat(subject).isEqualTo(testObject)
         }
     }
 
     @Test fun isEqualToWithGivenProperties_extract_prop_passes() {
-        assert(subject).isEqualToWithGivenProperties(
+        assertThat(subject).isEqualToWithGivenProperties(
             testObject,
             BasicObject::str,
             BasicObject::double
@@ -148,78 +148,78 @@ class AnyTest {
 
     @Test fun isEqualToWithGivenProperties_extract_prop_includes_name_in_failure_message() {
         val error = assertFails {
-            assert(subject).isEqualToWithGivenProperties(testObject, BasicObject::int)
+            assertThat(subject).isEqualToWithGivenProperties(testObject, BasicObject::int)
         }
         assertEquals("expected [int]:<[99]> but was:<[42]> (test)", error.message)
     }
 
 
     @Test fun prop_passes() {
-        assert(subject).prop("str") { it.str }.isEqualTo("test")
+        assertThat(subject).prop("str") { it.str }.isEqualTo("test")
     }
 
     @Test fun prop_includes_name_in_failure_message() {
         val error = assertFails {
-            assert(subject).prop("str") { it.str }.isEmpty()
+            assertThat(subject).prop("str") { it.str }.isEmpty()
         }
         assertEquals("expected [str] to be empty but was:<\"test\"> (test)", error.message)
     }
 
     @Test fun nested_prop_include_names_in_failure_message() {
         val error = assertFails {
-            assert(subject).prop("other") { it.other }.prop("str") { it?.str }.isNotNull()
+            assertThat(subject).prop("other") { it.other }.prop("str") { it?.str }.isNotNull()
         }
         assertEquals("expected [other.str] to not be null (test)", error.message)
     }
 
     @Test fun isNull_null_passes() {
-        assert(null as String?).isNull()
+        assertThat(null as String?).isNull()
     }
 
     @Test fun isNull_non_null_fails() {
         val error = assertFails {
-            assert(nullableSubject).isNull()
+            assertThat(nullableSubject).isNull()
         }
         assertEquals("expected to be null but was:<test>", error.message)
     }
 
     @Test fun isNotNull_non_null_passes() {
-        assert(nullableSubject).isNotNull()
+        assertThat(nullableSubject).isNotNull()
     }
 
     @Test fun isNotNull_null_fails() {
         val error = assertFails {
-            assert(null as String?).isNotNull()
+            assertThat(null as String?).isNotNull()
         }
         assertEquals("expected to not be null", error.message)
     }
 
     @Test fun isNotNull_non_null_and_equal_object_passes() {
-        assert(nullableSubject).isNotNull().isEqualTo(subject)
+        assertThat(nullableSubject).isNotNull().isEqualTo(subject)
     }
 
     @Test fun isNotNull_non_null_and_non_equal_object_fails() {
         val unequal = BasicObject("not test")
         val error = assertFails {
-            assert(nullableSubject).isNotNull().isEqualTo(unequal)
+            assertThat(nullableSubject).isNotNull().isEqualTo(unequal)
         }
         assertEquals("expected:<[not ]test> but was:<[]test>", error.message)
     }
 
     @Test fun isNotNull_null_and_equal_object_fails() {
         val error = assertFails {
-            assert(null as String?).isNotNull().isEqualTo(null)
+            assertThat(null as String?).isNotNull().isEqualTo(null)
         }
         assertEquals("expected to not be null", error.message)
     }
 
     @Test fun hasClass_same_class_passes() {
-        assert(subject).hasClass(BasicObject::class)
+        assertThat(subject).hasClass(BasicObject::class)
     }
 
     @Test fun hasClass_parent_class_fails() {
         val error = assertFails {
-            assert(subject).hasClass(TestObject::class)
+            assertThat(subject).hasClass(TestObject::class)
         }
         assertEquals(
             "expected to have class:<${TestObject::class}> but was:<${BasicObject::class}>",
@@ -228,27 +228,27 @@ class AnyTest {
     }
 
     @Test fun doesNotHaveClass_parent_class_passes() {
-        assert(subject).doesNotHaveClass(TestObject::class)
+        assertThat(subject).doesNotHaveClass(TestObject::class)
     }
 
     @Test fun doesNotHaveClass_same_class_fails() {
         val error = assertFails {
-            assert(subject).doesNotHaveClass(BasicObject::class)
+            assertThat(subject).doesNotHaveClass(BasicObject::class)
         }
         assertEquals("expected to not have class:<${BasicObject::class}>", error.message)
     }
 
     @Test fun isInstanceOf_kclass_same_class_passes() {
-        assert(subject as TestObject).isInstanceOf(BasicObject::class)
+        assertThat(subject as TestObject).isInstanceOf(BasicObject::class)
     }
 
     @Test fun isInstanceOf_kclass_parent_class_passes() {
-        assert(subject).isInstanceOf(TestObject::class)
+        assertThat(subject).isInstanceOf(TestObject::class)
     }
 
     @Test fun isInstanceOf_kclass_different_class_fails() {
         val error = assertFails {
-            assert(subject).isInstanceOf(DifferentObject::class)
+            assertThat(subject).isInstanceOf(DifferentObject::class)
         }
         assertEquals(
             "expected to be instance of:<${DifferentObject::class}> but had class:<${BasicObject::class}>",
@@ -258,7 +258,7 @@ class AnyTest {
 
     @Test fun isInstanceOf_kclass_run_block_when_passes() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(BasicObject::class).prop("str", BasicObject::str)
+            assertThat(subject as TestObject).isInstanceOf(BasicObject::class).prop("str", BasicObject::str)
                 .isEqualTo("wrong")
         }
         assertEquals("expected [str]:<\"[wrong]\"> but was:<\"[test]\"> (test)", error.message)
@@ -266,7 +266,7 @@ class AnyTest {
 
     @Test fun isInstanceOf_kclass_doesnt_run_block_when_fails() {
         val error = assertFails {
-            assert(subject as TestObject).isInstanceOf(DifferentObject::class).isNull()
+            assertThat(subject as TestObject).isInstanceOf(DifferentObject::class).isNull()
         }
         assertEquals(
             "expected to be instance of:<${DifferentObject::class}> but had class:<${BasicObject::class}>",
@@ -275,19 +275,19 @@ class AnyTest {
     }
 
     @Test fun isNotInstanceOf_kclass_different_class_passes() {
-        assert(subject).isNotInstanceOf(DifferentObject::class)
+        assertThat(subject).isNotInstanceOf(DifferentObject::class)
     }
 
     @Test fun isNotInstanceOf_kclass_same_class_fails() {
         val error = assertFails {
-            assert(subject).isNotInstanceOf(BasicObject::class)
+            assertThat(subject).isNotInstanceOf(BasicObject::class)
         }
         assertEquals("expected to not be instance of:<${BasicObject::class}>", error.message)
     }
 
     @Test fun isNotInstanceOf_kclass_parent_class_fails() {
         val error = assertFails {
-            assert(subject).isNotInstanceOf(TestObject::class)
+            assertThat(subject).isNotInstanceOf(TestObject::class)
         }
         assertEquals("expected to not be instance of:<${TestObject::class}>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ArrayTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,12 +9,12 @@ import kotlin.test.assertFails
 class ArrayTest {
     //region isEqualTo
     @Test fun isEqualTo_same_contents_passes() {
-        assert(arrayOf("one")).isEqualTo(arrayOf("one"))
+        assertThat(arrayOf("one")).isEqualTo(arrayOf("one"))
     }
 
     @Test fun isEqualTo_different_contents_fails() {
         val error = assertFails {
-            assert(arrayOf("one")).isEqualTo(arrayOf("two"))
+            assertThat(arrayOf("one")).isEqualTo(arrayOf("two"))
         }
         assertEquals("expected:<[\"[two]\"]> but was:<[\"[one]\"]>", error.message)
     }
@@ -22,12 +22,12 @@ class ArrayTest {
 
     //region isNotEqualTo
     @Test fun isNotEqualTo_different_contents_passes() {
-        assert(arrayOf("one")).isNotEqualTo(arrayOf("two"))
+        assertThat(arrayOf("one")).isNotEqualTo(arrayOf("two"))
     }
 
     @Test fun isNotEqualTo_same_contents_fails() {
         val error = assertFails {
-            assert(arrayOf("one")).isNotEqualTo(arrayOf("one"))
+            assertThat(arrayOf("one")).isNotEqualTo(arrayOf("one"))
         }
         assertEquals("expected to not be equal to:<[\"one\"]>", error.message)
     }
@@ -35,12 +35,12 @@ class ArrayTest {
 
     //region isEmpty
     @Test fun isEmpty_empty_passes() {
-        assert(emptyArray<Any?>()).isEmpty()
+        assertThat(emptyArray<Any?>()).isEmpty()
     }
 
     @Test fun isEmpty_non_empty_fails() {
         val error = assertFails {
-            assert(arrayOf<Any?>(null)).isEmpty()
+            assertThat(arrayOf<Any?>(null)).isEmpty()
         }
         assertEquals("expected to be empty but was:<[null]>", error.message)
     }
@@ -48,12 +48,12 @@ class ArrayTest {
 
     //region isNotEmpty
     @Test fun isNotEmpty_non_empty_passes() {
-        assert(arrayOf<Any?>(null)).isNotEmpty()
+        assertThat(arrayOf<Any?>(null)).isNotEmpty()
     }
 
     @Test fun isNotEmpty_empty_fails() {
         val error = assertFails {
-            assert(arrayOf<Any?>()).isNotEmpty()
+            assertThat(arrayOf<Any?>()).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
     }
@@ -61,16 +61,16 @@ class ArrayTest {
 
     //region isNullOrEmpty
     @Test fun isNullOrEmpty_null_passes() {
-        assert(null as Array<Any?>?).isNullOrEmpty()
+        assertThat(null as Array<Any?>?).isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_empty_passes() {
-        assert(emptyArray<Any?>()).isNullOrEmpty()
+        assertThat(emptyArray<Any?>()).isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
         val error = assertFails {
-            assert(arrayOf<Any?>(null)).isNullOrEmpty()
+            assertThat(arrayOf<Any?>(null)).isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<[null]>", error.message)
     }
@@ -78,12 +78,12 @@ class ArrayTest {
 
     //region hasSize
     @Test fun hasSize_correct_size_passes() {
-        assert(emptyArray<Any?>()).hasSize(0)
+        assertThat(emptyArray<Any?>()).hasSize(0)
     }
 
     @Test fun hasSize_wrong_size_fails() {
         val error = assertFails {
-            assert(emptyArray<Any?>()).hasSize(1)
+            assertThat(emptyArray<Any?>()).hasSize(1)
         }
         assertEquals("expected [size]:<[1]> but was:<[0]> ([])", error.message)
     }
@@ -91,12 +91,12 @@ class ArrayTest {
 
     //region hasSameSizeAs
     @Test fun hasSameSizeAs_equal_sizes_passes() {
-        assert(emptyArray<Any?>()).hasSameSizeAs(emptyArray<Any?>())
+        assertThat(emptyArray<Any?>()).hasSameSizeAs(emptyArray<Any?>())
     }
 
     @Test fun hasSameSizeAs_non_equal_sizes_fails() {
         val error = assertFails {
-            assert(emptyArray<Any?>()).hasSameSizeAs(arrayOf<Any?>(null))
+            assertThat(emptyArray<Any?>()).hasSameSizeAs(arrayOf<Any?>(null))
         }
         assertEquals("expected to have same size as:<[null]> (1) but was size:(0)", error.message)
     }
@@ -104,12 +104,12 @@ class ArrayTest {
 
     //region contains
     @Test fun contains_element_present_passes() {
-        assert(arrayOf(1, 2)).contains(2)
+        assertThat(arrayOf(1, 2)).contains(2)
     }
 
     @Test fun contains_element_missing_fails() {
         val error = assertFails {
-            assert(emptyArray<Any?>()).contains(1)
+            assertThat(emptyArray<Any?>()).contains(1)
         }
         assertEquals("expected to contain:<1> but was:<[]>", error.message)
     }
@@ -117,12 +117,12 @@ class ArrayTest {
 
     //region doesNotContain
     @Test fun doesNotContain_element_missing_passes() {
-        assert(emptyArray<Any?>()).doesNotContain(1)
+        assertThat(emptyArray<Any?>()).doesNotContain(1)
     }
 
     @Test fun doesNotContain_element_present_fails() {
         val error = assertFails {
-            assert(arrayOf(1, 2)).doesNotContain(2)
+            assertThat(arrayOf(1, 2)).doesNotContain(2)
         }
         assertEquals("expected to not contain:<2> but was:<[1, 2]>", error.message)
     }
@@ -130,12 +130,12 @@ class ArrayTest {
 
     //region containsNone
     @Test fun containsNone_missing_elements_passes() {
-        assert(emptyArray<Any?>()).containsNone(1)
+        assertThat(emptyArray<Any?>()).containsNone(1)
     }
 
     @Test fun containsNone_present_element_fails() {
         val error = assertFails {
-            assert(arrayOf(1, 2)).containsNone(2, 3)
+            assertThat(arrayOf(1, 2)).containsNone(2, 3)
         }
         assertEquals("expected to contain none of:<[2, 3]> some elements were not expected:<[2]>", error.message)
     }
@@ -143,16 +143,16 @@ class ArrayTest {
 
     //region containsAll
     @Test fun containsAll_all_elements_passes() {
-        assert(arrayOf(1, 2)).containsAll(2, 1)
+        assertThat(arrayOf(1, 2)).containsAll(2, 1)
     }
 
     @Test fun containsAll_extra_elements_passes() {
-        assert(arrayOf(1, 2, 3)).containsAll(1, 2)
+        assertThat(arrayOf(1, 2, 3)).containsAll(1, 2)
     }
 
     @Test fun containsAll_some_elements_fails() {
         val error = assertFails {
-            assert(arrayOf(1)).containsAll(1, 2)
+            assertThat(arrayOf(1)).containsAll(1, 2)
         }
         assertEquals("expected to contain all:<[1, 2]> but was:<[1]>. Missing elements:<[2]>", error.message)
     }
@@ -160,12 +160,12 @@ class ArrayTest {
 
     //region containsExactly
     @Test fun containsExactly_all_elements_in_same_order_passes() {
-        assert(arrayOf(1, 2)).containsExactly(1, 2)
+        assertThat(arrayOf(1, 2)).containsExactly(1, 2)
     }
 
     @Test fun containsExactly_all_elements_in_different_order_fails() {
         val error = assertFails {
-            assert(arrayOf(1, 2)).containsExactly(2, 1)
+            assertThat(arrayOf(1, 2)).containsExactly(2, 1)
         }
         assertEquals(
             """expected to contain exactly:
@@ -177,7 +177,7 @@ class ArrayTest {
 
     @Test fun containsExactly_missing_element_fails() {
         val error = assertFails {
-            assert(arrayOf(1, 2)).containsExactly(3)
+            assertThat(arrayOf(1, 2)).containsExactly(3)
         }
         assertEquals(
             """expected to contain exactly:
@@ -190,7 +190,7 @@ class ArrayTest {
 
     @Test fun containsExactly_same_indexes_are_together() {
         val error = assertFails {
-            assert(arrayOf(1, 1)).containsExactly(2, 2)
+            assertThat(arrayOf(1, 1)).containsExactly(2, 2)
         }
         assertEquals(
             """expected to contain exactly:
@@ -204,7 +204,7 @@ class ArrayTest {
 
     @Test fun containsExactly_extra_element_fails() {
         val error = assertFails {
-            assert(arrayOf(1, 2)).containsExactly(1, 2, 3)
+            assertThat(arrayOf(1, 2)).containsExactly(1, 2, 3)
         }
         assertEquals(
             """expected to contain exactly:
@@ -215,7 +215,7 @@ class ArrayTest {
 
     @Test fun containsExactly_missing_element_in_middle_fails() {
         val error = assertFails {
-            assert(arrayOf(1, 3)).containsExactly(1, 2, 3)
+            assertThat(arrayOf(1, 3)).containsExactly(1, 2, 3)
         }
         assertEquals(
             """expected to contain exactly:
@@ -226,7 +226,7 @@ class ArrayTest {
 
     @Test fun containsExactly_extra_element_in_middle_fails() {
         val error = assertFails {
-            assert(arrayOf(1, 2, 3)).containsExactly(1, 3)
+            assertThat(arrayOf(1, 2, 3)).containsExactly(1, 3)
         }
         assertEquals(
             """expected to contain exactly:
@@ -238,16 +238,16 @@ class ArrayTest {
 
     //region each
     @Test fun each_empty_list_passes() {
-        assert(emptyArray<Int>()).each { it.isEqualTo(1) }
+        assertThat(emptyArray<Int>()).each { it.isEqualTo(1) }
     }
 
     @Test fun each_content_passes() {
-        assert(arrayOf(1, 2)).each { it.isGreaterThan(0) }
+        assertThat(arrayOf(1, 2)).each { it.isGreaterThan(0) }
     }
 
     @Test fun each_non_matching_content_fails() {
         val error = assertFails {
-            assert(arrayOf(1, 2, 3)).each { it.isLessThan(2) }
+            assertThat(arrayOf(1, 2, 3)).each { it.isLessThan(2) }
         }
         assertEquals(
             """The following assertions failed (2 failures)
@@ -260,12 +260,12 @@ class ArrayTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert(arrayOf("one", "two"), name = "subject").index(0).isEqualTo("one")
+        assertThat(arrayOf("one", "two"), name = "subject").index(0).isEqualTo("one")
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(arrayOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
+            assertThat(arrayOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
         }
         assertEquals(
             "expected [subject[0]]:<\"[wrong]\"> but was:<\"[one]\"> ([\"one\", \"two\"])",
@@ -275,7 +275,7 @@ class ArrayTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert(arrayOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
+            assertThat(arrayOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/BooleanTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/BooleanTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import kotlin.test.Test
@@ -10,12 +10,12 @@ import kotlin.test.assertFails
 class BooleanTest {
     //region isTrue
     @Test fun isTrue_true_value_passes() {
-        assert(true).isTrue()
+        assertThat(true).isTrue()
     }
 
     @Test fun isTrue_false_value_fails() {
         val error = assertFails {
-            assert(false).isTrue()
+            assertThat(false).isTrue()
         }
         assertEquals("expected to be true", error.message)
     }
@@ -23,12 +23,12 @@ class BooleanTest {
 
     //region isFalse
     @Test fun isFalse_false_value_passes() {
-        assert(false).isFalse()
+        assertThat(false).isFalse()
     }
 
     @Test fun isFalse_true_value_fails() {
         val error = assertFails {
-            assert(true).isFalse()
+            assertThat(true).isFalse()
         }
         assertEquals("expected to be false", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/CharSequenceTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/CharSequenceTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,18 +9,18 @@ import kotlin.test.assertFails
 class CharSequenceTest {
     //region props
     @Test fun extracts_length() {
-        assertEquals(4, assert("test").length().valueOrFail)
+        assertEquals(4, assertThat("test").length().valueOrFail)
     }
     //endregion
 
     //region isEmpty
     @Test fun isEmpty_empty_passes() {
-        assert("").isEmpty()
+        assertThat("").isEmpty()
     }
 
     @Test fun isEmpty_non_empty_fails() {
         val error = assertFails {
-            assert("test").isEmpty()
+            assertThat("test").isEmpty()
         }
         assertEquals("expected to be empty but was:<\"test\">", error.message)
     }
@@ -28,12 +28,12 @@ class CharSequenceTest {
 
     //region isNotEmpty
     @Test fun isNotEmpty_non_empty_passes() {
-        assert("test").isNotEmpty()
+        assertThat("test").isNotEmpty()
     }
 
     @Test fun isNotEmpty_empty_fails() {
         val error = assertFails {
-            assert("").isNotEmpty()
+            assertThat("").isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
     }
@@ -41,16 +41,16 @@ class CharSequenceTest {
 
     //region isNullOrEmpty
     @Test fun isNullOrEmpty_null_passes() {
-        assert(null as CharSequence?).isNullOrEmpty()
+        assertThat(null as CharSequence?).isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_empty_passes() {
-        assert("").isNullOrEmpty()
+        assertThat("").isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
         val error = assertFails {
-            assert("test").isNullOrEmpty()
+            assertThat("test").isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<\"test\">", error.message)
     }
@@ -58,12 +58,12 @@ class CharSequenceTest {
 
     //region hasLength
     @Test fun hasLength_correct_length_passes() {
-        assert("test").hasLength(4)
+        assertThat("test").hasLength(4)
     }
 
     @Test fun hasLength_wrong_length_fails() {
         val error = assertFails {
-            assert("test").hasLength(0)
+            assertThat("test").hasLength(0)
         }
         assertEquals("expected [length]:<[0]> but was:<[4]> (\"test\")", error.message)
     }
@@ -71,12 +71,12 @@ class CharSequenceTest {
 
     //region hasSameLengthAs
     @Test fun hasSameLengthAs_same_length_passes() {
-        assert("test").hasSameLengthAs("four")
+        assertThat("test").hasSameLengthAs("four")
     }
 
     @Test fun hasSameLengthAs_different_length_fails() {
         val error = assertFails {
-            assert("test").hasSameLengthAs("")
+            assertThat("test").hasSameLengthAs("")
         }
         assertEquals("expected to have same length as:<\"\"> (0) but was:<\"test\"> (4)", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/CollectionTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/CollectionTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,12 +9,12 @@ import kotlin.test.assertFails
 class CollectionTest {
     //region isEmpty
     @Test fun isEmpty_empty_passes() {
-        assert(emptyList<Any?>()).isEmpty()
+        assertThat(emptyList<Any?>()).isEmpty()
     }
 
     @Test fun isEmpty_non_empty_fails() {
         val error = assertFails {
-            assert(listOf<Any?>(null)).isEmpty()
+            assertThat(listOf<Any?>(null)).isEmpty()
         }
         assertEquals("expected to be empty but was:<[null]>", error.message)
     }
@@ -22,12 +22,12 @@ class CollectionTest {
 
     //region isNotEmpty
     @Test fun isNotEmpty_non_empty_passes() {
-        assert(listOf<Any?>(null)).isNotEmpty()
+        assertThat(listOf<Any?>(null)).isNotEmpty()
     }
 
     @Test fun isNotEmpty_empty_fails() {
         val error = assertFails {
-            assert(emptyList<Any?>()).isNotEmpty()
+            assertThat(emptyList<Any?>()).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
     }
@@ -35,16 +35,16 @@ class CollectionTest {
 
     //region isNullOrEmpty
     @Test fun isNullOrEmpty_null_passes() {
-        assert(null as List<Any?>?).isNullOrEmpty()
+        assertThat(null as List<Any?>?).isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_empty_passes() {
-        assert(emptyList<Any?>()).isNullOrEmpty()
+        assertThat(emptyList<Any?>()).isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
         val error = assertFails {
-            assert(listOf<Any?>(null)).isNullOrEmpty()
+            assertThat(listOf<Any?>(null)).isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<[null]>", error.message)
     }
@@ -52,12 +52,12 @@ class CollectionTest {
 
     //region hasSize
     @Test fun hasSize_correct_size_passes() {
-        assert(emptyList<Any?>()).hasSize(0)
+        assertThat(emptyList<Any?>()).hasSize(0)
     }
 
     @Test fun hasSize_wrong_size_fails() {
         val error = assertFails {
-            assert(emptyList<Any?>()).hasSize(1)
+            assertThat(emptyList<Any?>()).hasSize(1)
         }
         assertEquals("expected [size]:<[1]> but was:<[0]> ([])", error.message)
     }
@@ -65,12 +65,12 @@ class CollectionTest {
 
     //region hasSameSizeAs
     @Test fun hasSameSizeAs_equal_sizes_passes() {
-        assert(emptyList<Any?>()).hasSameSizeAs(emptyList<Any?>())
+        assertThat(emptyList<Any?>()).hasSameSizeAs(emptyList<Any?>())
     }
 
     @Test fun hasSameSizeAs_non_equal_sizes_fails() {
         val error = assertFails {
-            assert(emptyList<Any?>()).hasSameSizeAs(listOf<Any?>(null))
+            assertThat(emptyList<Any?>()).hasSameSizeAs(listOf<Any?>(null))
         }
         assertEquals("expected to have same size as:<[null]> (1) but was size:(0)", error.message)
     }
@@ -78,12 +78,12 @@ class CollectionTest {
 
     //region containsNone
     @Test fun containsNone_missing_elements_passes() {
-        assert(emptyList<Any?>()).containsNone(1)
+        assertThat(emptyList<Any?>()).containsNone(1)
     }
 
     @Test fun containsNone_present_element_fails() {
         val error = assertFails {
-            assert(listOf(1, 2)).containsNone(2, 3)
+            assertThat(listOf(1, 2)).containsNone(2, 3)
         }
         assertEquals("expected to contain none of:<[2, 3]> some elements were not expected:<[2]>", error.message)
     }
@@ -91,12 +91,12 @@ class CollectionTest {
 
     //region containsAll
     @Test fun containsAll_all_elements_passes() {
-        assert(listOf(1, 2)).containsAll(2, 1)
+        assertThat(listOf(1, 2)).containsAll(2, 1)
     }
 
     @Test fun containsAll_some_elements_fails() {
         val error = assertFails {
-            assert(listOf(1)).containsAll(1, 2)
+            assertThat(listOf(1)).containsAll(1, 2)
         }
         assertEquals("expected to contain all:<[1, 2]> some elements were not found:<[2]>", error.message)
     }
@@ -104,19 +104,19 @@ class CollectionTest {
 
     //region containsOnly
     @Test fun containsOnly_only_elements_passes() {
-        assert(listOf(1, 2)).containsOnly(2, 1)
+        assertThat(listOf(1, 2)).containsOnly(2, 1)
     }
 
     @Test fun containsOnly_more_elements_fails() {
         val error = assertFails{
-            assert(listOf(1, 2, 3)).containsOnly(2, 1)
+            assertThat(listOf(1, 2, 3)).containsOnly(2, 1)
         }
         assertEquals("expected to contain only:<[2, 1]> but extra elements were found:<[3]>", error.message)
     }
 
     @Test fun containsOnly_less_elements_fails() {
         val error = assertFails{
-            assert(listOf(1, 2, 3)).containsOnly(2, 1, 3, 4)
+            assertThat(listOf(1, 2, 3)).containsOnly(2, 1, 3, 4)
         }
         assertEquals("expected to contain only:<[2, 1, 3, 4]> but some elements were not found:<[4]>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ComparableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ComparableTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import assertk.assertions.support.show
 import kotlin.test.Test
@@ -10,12 +10,12 @@ import kotlin.test.assertFails
 class ComparableTest {
     //region isGreaterThan
     @Test fun isGreaterThan_greater_value_passes() {
-        assert(2).isGreaterThan(1)
+        assertThat(2).isGreaterThan(1)
     }
 
     @Test fun isGreaterThan_non_greater_value_fails() {
         val error = assertFails {
-            assert(0).isGreaterThan(0)
+            assertThat(0).isGreaterThan(0)
         }
         assertEquals("expected to be greater than:<0> but was:<0>", error.message)
     }
@@ -23,12 +23,12 @@ class ComparableTest {
 
     //region isLessThan
     @Test fun isLessThan_lesser_value_passes() {
-        assert(1).isLessThan(2)
+        assertThat(1).isLessThan(2)
     }
 
     @Test fun isLessThan_non_lesser_value_fails() {
         val error = assertFails {
-            assert(0).isLessThan(0)
+            assertThat(0).isLessThan(0)
         }
         assertEquals("expected to be less than:<0> but was:<0>", error.message)
     }
@@ -36,16 +36,16 @@ class ComparableTest {
 
     //region isGreaterThanOrEqualTo
     @Test fun isGreaterThanOrEqualTo_greater_value_passes() {
-        assert(2).isGreaterThanOrEqualTo(1)
+        assertThat(2).isGreaterThanOrEqualTo(1)
     }
 
     @Test fun isGreaterThanOrEqualTo_equal_value_passes() {
-        assert(2).isGreaterThanOrEqualTo(2)
+        assertThat(2).isGreaterThanOrEqualTo(2)
     }
 
     @Test fun isGreaterThanOrEqualTo_lesser_value_fails() {
         val error = assertFails {
-            assert(0).isGreaterThanOrEqualTo(2)
+            assertThat(0).isGreaterThanOrEqualTo(2)
         }
         assertEquals("expected to be greater than or equal to:<2> but was:<0>", error.message)
     }
@@ -53,16 +53,16 @@ class ComparableTest {
 
     //region isLessThanOrEqualTo
     @Test fun isLessThanOrEqualTo_lesser_value_passes() {
-        assert(1).isLessThanOrEqualTo(2)
+        assertThat(1).isLessThanOrEqualTo(2)
     }
 
     @Test fun isLessThanOrEqualTo_equal_value_passes() {
-        assert(2).isLessThanOrEqualTo(2)
+        assertThat(2).isLessThanOrEqualTo(2)
     }
 
     @Test fun isLessThanOrEqualTo_greater_value_fails() {
         val error = assertFails {
-            assert(2).isLessThanOrEqualTo(0)
+            assertThat(2).isLessThanOrEqualTo(0)
         }
         assertEquals("expected to be less than or equal to:<0> but was:<2>", error.message)
     }
@@ -70,27 +70,27 @@ class ComparableTest {
 
     //region isBetween
     @Test fun isBetween_inside_range_passes() {
-        assert(1).isBetween(0, 2)
+        assertThat(1).isBetween(0, 2)
     }
 
     @Test fun isBetween_lower_bound_passes() {
-        assert(0).isBetween(0, 2)
+        assertThat(0).isBetween(0, 2)
     }
 
     @Test fun isBetween_upper_bound_passes() {
-        assert(2).isBetween(0, 2)
+        assertThat(2).isBetween(0, 2)
     }
 
     @Test fun isBetween_below_lower_bound_fails() {
         val error = assertFails {
-            assert(-1).isBetween(0, 2)
+            assertThat(-1).isBetween(0, 2)
         }
         assertEquals("expected to be between:<0> and <2> but was:<-1>", error.message)
     }
 
     @Test fun isBetween_above_upper_bound_fails() {
         val error = assertFails {
-            assert(3).isBetween(0, 2)
+            assertThat(3).isBetween(0, 2)
         }
         assertEquals("expected to be between:<0> and <2> but was:<3>", error.message)
     }
@@ -98,33 +98,33 @@ class ComparableTest {
 
     //region isStrictlyBetween
     @Test fun isStrictlyBetween_inside_range_passes() {
-        assert(0 + 1).isStrictlyBetween(0, 2)
+        assertThat(0 + 1).isStrictlyBetween(0, 2)
     }
 
     @Test fun isStrictlyBetween_lower_bound_fails() {
         val error = assertFails {
-            assert(0).isStrictlyBetween(0, 2)
+            assertThat(0).isStrictlyBetween(0, 2)
         }
         assertEquals("expected to be strictly between:<0> and <2> but was:<0>", error.message)
     }
 
     @Test fun isStrictlyBetween_upper_bound_fails() {
         val error = assertFails {
-            assert(2).isStrictlyBetween(0, 2)
+            assertThat(2).isStrictlyBetween(0, 2)
         }
         assertEquals("expected to be strictly between:<0> and <2> but was:<2>", error.message)
     }
 
     @Test fun isStrictlyBetween_below_lower_bound_fails() {
         val error = assertFails {
-            assert(0 - 1).isStrictlyBetween(0, 2)
+            assertThat(0 - 1).isStrictlyBetween(0, 2)
         }
         assertEquals("expected to be strictly between:<0> and <2> but was:<-1>", error.message)
     }
 
     @Test fun isStrictlyBetween_above_upper_bound_fails() {
         val error = assertFails {
-            assert(2 + 1).isStrictlyBetween(0, 2)
+            assertThat(2 + 1).isStrictlyBetween(0, 2)
         }
         assertEquals("expected to be strictly between:<0> and <2> but was:<3>", error.message)
     }
@@ -133,28 +133,28 @@ class ComparableTest {
     //region isCloseTo
     @Test
     fun isCloseToFloat_with_equal_value_passes() {
-        assert(10.0f).isCloseTo(10.0f, 0.0f)
+        assertThat(10.0f).isCloseTo(10.0f, 0.0f)
     }
 
     @Test
     fun isCloseToFloat_with_non_zero_delta_within_range_passes() {
-        assert(10.5f).isCloseTo(8.5f, delta = 3f)
+        assertThat(10.5f).isCloseTo(8.5f, delta = 3f)
     }
 
     @Test
     fun isCloseToDouble_with_equal_value_passes() {
-        assert(10.0).isCloseTo(10.0, 0.0)
+        assertThat(10.0).isCloseTo(10.0, 0.0)
     }
 
     @Test
     fun isCloseToDouble_with_non_zero_delta_within_range_passes() {
-        assert(10.0).isCloseTo(8.0, delta = 3.0)
+        assertThat(10.0).isCloseTo(8.0, delta = 3.0)
     }
 
     @Test
     fun isCloseToFloat_with_delta_out_of_range_fails() {
         val error = assertFails {
-            assert(10.1f).isCloseTo(15.0f, 3f)
+            assertThat(10.1f).isCloseTo(15.0f, 3f)
         }
         assertEquals("expected ${show(10.1f)} to be close to ${show(15.0f)} with delta of ${show(3f)}, but was not", error.message)
     }
@@ -162,7 +162,7 @@ class ComparableTest {
     @Test
     fun isCloseToDouble_with_delta_out_of_range_fails() {
         val error = assertFails {
-            assert(10.1).isCloseTo(15.0, 3.0)
+            assertThat(10.1).isCloseTo(15.0, 3.0)
         }
         assertEquals("expected ${show(10.1)} to be close to ${show(15.0)} with delta of ${show(3.0)}, but was not", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,12 +9,12 @@ import kotlin.test.assertFails
 class IterableTest {
     //region contains
     @Test fun contains_element_present_passes() {
-        assert(listOf(1, 2) as Iterable<Int>).contains(2)
+        assertThat(listOf(1, 2) as Iterable<Int>).contains(2)
     }
 
     @Test fun contains_element_missing_fails() {
         val error = assertFails {
-            assert(emptyList<Any?>() as Iterable<Any?>).contains(1)
+            assertThat(emptyList<Any?>() as Iterable<Any?>).contains(1)
         }
         assertEquals("expected to contain:<1> but was:<[]>", error.message)
     }
@@ -22,12 +22,12 @@ class IterableTest {
 
     //region doesNotContain
     @Test fun doesNotContain_element_missing_passes() {
-        assert(emptyList<Any?>() as Iterable<Any?>).doesNotContain(1)
+        assertThat(emptyList<Any?>() as Iterable<Any?>).doesNotContain(1)
     }
 
     @Test fun doesNotContain_element_present_fails() {
         val error = assertFails {
-            assert(listOf(1, 2) as Iterable<Int>).doesNotContain(2)
+            assertThat(listOf(1, 2) as Iterable<Int>).doesNotContain(2)
         }
         assertEquals("expected to not contain:<2> but was:<[1, 2]>", error.message)
     }
@@ -35,16 +35,16 @@ class IterableTest {
 
     //region each
     @Test fun each_empty_list_passes() {
-        assert(emptyList<Int>() as Iterable<Int>).each { it.isEqualTo(1) }
+        assertThat(emptyList<Int>() as Iterable<Int>).each { it.isEqualTo(1) }
     }
 
     @Test fun each_content_passes() {
-        assert(listOf(1, 2) as Iterable<Int>).each { it.isGreaterThan(0) }
+        assertThat(listOf(1, 2) as Iterable<Int>).each { it.isGreaterThan(0) }
     }
 
     @Test fun each_non_matching_content_fails() {
         val error = assertFails {
-            assert(listOf(1, 2, 3) as Iterable<Int>).each { it.isLessThan(2) }
+            assertThat(listOf(1, 2, 3) as Iterable<Int>).each { it.isLessThan(2) }
         }
         assertEquals(
             """The following assertions failed (2 failures)
@@ -58,7 +58,7 @@ class IterableTest {
     //region atLeast
     @Test fun atLeast_to_many_failures_fails() {
         val error = assertFails {
-            assert(listOf(1, 2, 3)).atLeast(2) { it -> it.isGreaterThan(2) }
+            assertThat(listOf(1, 2, 3)).atLeast(2) { it -> it.isGreaterThan(2) }
         }
         assertEquals(
             """expected to pass at least 2 times (2 failures)
@@ -69,11 +69,11 @@ class IterableTest {
     }
 
     @Test fun atLest_no_failures_passes() {
-        assert(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(0) }
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(0) }
     }
 
     @Test fun atLeast_less_than_times_failures_passes() {
-        assert(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(1) }
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(1) }
     }
     //endregion
 }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ListTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ListTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.index
 import assertk.assertions.isEqualTo
@@ -11,12 +11,12 @@ import kotlin.test.assertFails
 class ListTest {
     //region containsExactly
     @Test fun containsExactly_all_elements_in_same_order_passes() {
-        assert(listOf(1, 2)).containsExactly(1, 2)
+        assertThat(listOf(1, 2)).containsExactly(1, 2)
     }
 
     @Test fun containsExactly_all_elements_in_different_order_fails() {
         val error = assertFails {
-            assert(listOf(1, 2)).containsExactly(2, 1)
+            assertThat(listOf(1, 2)).containsExactly(2, 1)
         }
         assertEquals(
             """expected to contain exactly:
@@ -28,7 +28,7 @@ class ListTest {
 
     @Test fun containsExactly_same_indexes_are_together() {
         val error = assertFails {
-            assert(listOf(1, 1)).containsExactly(2, 2)
+            assertThat(listOf(1, 1)).containsExactly(2, 2)
         }
         assertEquals(
             """expected to contain exactly:
@@ -42,7 +42,7 @@ class ListTest {
 
     @Test fun containsExactly_missing_element_fails() {
         val error = assertFails {
-            assert(listOf(1, 2)).containsExactly(3)
+            assertThat(listOf(1, 2)).containsExactly(3)
         }
         assertEquals(
             """expected to contain exactly:
@@ -55,7 +55,7 @@ class ListTest {
 
     @Test fun containsExactly_extra_element_fails() {
         val error = assertFails {
-            assert(listOf(1, 2)).containsExactly(1, 2, 3)
+            assertThat(listOf(1, 2)).containsExactly(1, 2, 3)
         }
         assertEquals(
             """expected to contain exactly:
@@ -66,7 +66,7 @@ class ListTest {
 
     @Test fun containsExactly_missing_element_in_middle_fails() {
         val error = assertFails {
-            assert(listOf(1, 3)).containsExactly(1, 2, 3)
+            assertThat(listOf(1, 3)).containsExactly(1, 2, 3)
         }
         assertEquals(
             """expected to contain exactly:
@@ -77,7 +77,7 @@ class ListTest {
 
     @Test fun containsExactly_extra_element_in_middle_fails() {
         val error = assertFails {
-            assert(listOf(1, 2, 3)).containsExactly(1, 3)
+            assertThat(listOf(1, 2, 3)).containsExactly(1, 3)
         }
         assertEquals(
             """expected to contain exactly:
@@ -89,12 +89,12 @@ class ListTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert(listOf("one", "two"), name = "subject").index(0).isEqualTo("one")
+        assertThat(listOf("one", "two"), name = "subject").index(0).isEqualTo("one")
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(listOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
+            assertThat(listOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
         }
         assertEquals(
             "expected [subject[0]]:<\"[wrong]\"> but was:<\"[one]\"> ([\"one\", \"two\"])",
@@ -104,7 +104,7 @@ class ListTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert(listOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
+            assertThat(listOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/MapTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,12 +9,12 @@ import kotlin.test.assertFails
 class MapTest {
     //region contains
     @Test fun contains_element_present_passes() {
-        assert(mapOf("one" to 1, "two" to 2)).contains("two" to 2)
+        assertThat(mapOf("one" to 1, "two" to 2)).contains("two" to 2)
     }
 
     @Test fun contains_element_missing_fails() {
         val error = assertFails {
-            assert(emptyMap<String, Int>()).contains("one" to 1)
+            assertThat(emptyMap<String, Int>()).contains("one" to 1)
         }
         assertEquals("expected to contain:<{\"one\"=1}> but was:<{}>", error.message)
     }
@@ -22,12 +22,12 @@ class MapTest {
 
     //region doesNotContain
     @Test fun doesNotContain_element_missing_passes() {
-        assert(emptyMap<String, Int>()).doesNotContain("one" to 1)
+        assertThat(emptyMap<String, Int>()).doesNotContain("one" to 1)
     }
 
     @Test fun doesNotContain_element_present_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2)).doesNotContain("two" to 2)
+            assertThat(mapOf("one" to 1, "two" to 2)).doesNotContain("two" to 2)
         }
         assertEquals("expected to not contain:<{\"two\"=2}> but was:<{\"one\"=1, \"two\"=2}>", error.message)
     }
@@ -35,12 +35,12 @@ class MapTest {
 
     //region containsNone
     @Test fun containsNone_missing_elements_passes() {
-        assert(emptyMap<String, Int>()).containsNone("one" to 1)
+        assertThat(emptyMap<String, Int>()).containsNone("one" to 1)
     }
 
     @Test fun containsNone_present_element_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2)).containsNone("two" to 2, "three" to 3)
+            assertThat(mapOf("one" to 1, "two" to 2)).containsNone("two" to 2, "three" to 3)
         }
         assertEquals(
             "expected to contain none of:<{\"two\"=2, \"three\"=3}> some elements were not expected:<{\"two\"=2}>",
@@ -51,16 +51,16 @@ class MapTest {
 
     //region containsAll
     @Test fun containsAll_all_elements_passes() {
-        assert(mapOf("one" to 1, "two" to 2)).containsAll("two" to 2, "one" to 1)
+        assertThat(mapOf("one" to 1, "two" to 2)).containsAll("two" to 2, "one" to 1)
     }
 
     @Test fun containsAll_extra_elements_passes() {
-        assert(mapOf("one" to 1, "two" to 2, "three" to 3)).containsAll("one" to 1, "two" to 2)
+        assertThat(mapOf("one" to 1, "two" to 2, "three" to 3)).containsAll("one" to 1, "two" to 2)
     }
 
     @Test fun containsAll_some_elements_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1)).containsAll("one" to 1, "two" to 2)
+            assertThat(mapOf("one" to 1)).containsAll("one" to 1, "two" to 2)
         }
         assertEquals("expected to contain all:<{\"one\"=1, \"two\"=2}> but was:<{\"one\"=1}>. Missing elements: <{\"two\"=2}>", error.message
         )
@@ -69,19 +69,19 @@ class MapTest {
 
     //region containsOnly
     @Test fun containsOnly_all_elements_passes() {
-        assert(mapOf("one" to 1, "two" to 2)).containsOnly("two" to 2, "one" to 1)
+        assertThat(mapOf("one" to 1, "two" to 2)).containsOnly("two" to 2, "one" to 1)
     }
 
     @Test fun containsOnly_missing_element_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2)).containsOnly("three" to 3)
+            assertThat(mapOf("one" to 1, "two" to 2)).containsOnly("three" to 3)
         }
         assertEquals("expected to contain only:<{\"three\"=3}> but was:<{\"one\"=1, \"two\"=2}>", error.message)
     }
 
     @Test fun containsOnly_extra_element_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2)).containsOnly("one" to 1)
+            assertThat(mapOf("one" to 1, "two" to 2)).containsOnly("one" to 1)
         }
         assertEquals("expected to contain only:<{\"one\"=1}> but was:<{\"one\"=1, \"two\"=2}>", error.message)
     }
@@ -89,12 +89,12 @@ class MapTest {
 
     //region isEmpty
     @Test fun isEmpty_empty_passes() {
-        assert(emptyMap<Any?, Any?>()).isEmpty()
+        assertThat(emptyMap<Any?, Any?>()).isEmpty()
     }
 
     @Test fun isEmpty_non_empty_fails() {
         val error = assertFails {
-            assert(mapOf<Any?, Any?>(null to null)).isEmpty()
+            assertThat(mapOf<Any?, Any?>(null to null)).isEmpty()
         }
         assertEquals("expected to be empty but was:<{null=null}>", error.message)
     }
@@ -102,12 +102,12 @@ class MapTest {
 
     //region isNotEmpty
     @Test fun isNotEmpty_non_empty_passes() {
-        assert(mapOf<Any?, Any?>(null to null)).isNotEmpty()
+        assertThat(mapOf<Any?, Any?>(null to null)).isNotEmpty()
     }
 
     @Test fun isNotEmpty_empty_fails() {
         val error = assertFails {
-            assert(mapOf<Any?, Any?>()).isNotEmpty()
+            assertThat(mapOf<Any?, Any?>()).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
     }
@@ -115,16 +115,16 @@ class MapTest {
 
     //region isNullOrEmpty
     @Test fun isNullOrEmpty_null_passes() {
-        assert(null as Map<Any?, Any?>?).isNullOrEmpty()
+        assertThat(null as Map<Any?, Any?>?).isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_empty_passes() {
-        assert(emptyMap<Any?, Any?>()).isNullOrEmpty()
+        assertThat(emptyMap<Any?, Any?>()).isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
         val error = assertFails {
-            assert(mapOf<Any?, Any?>(null to null)).isNullOrEmpty()
+            assertThat(mapOf<Any?, Any?>(null to null)).isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<{null=null}>", error.message)
     }
@@ -132,12 +132,12 @@ class MapTest {
 
     //region hasSize
     @Test fun hasSize_correct_size_passes() {
-        assert(emptyMap<String, Int>()).hasSize(0)
+        assertThat(emptyMap<String, Int>()).hasSize(0)
     }
 
     @Test fun hasSize_wrong_size_fails() {
         val error = assertFails {
-            assert(emptyMap<String, Int>()).hasSize(1)
+            assertThat(emptyMap<String, Int>()).hasSize(1)
         }
         assertEquals("expected [size]:<[1]> but was:<[0]> ({})", error.message)
     }
@@ -145,12 +145,12 @@ class MapTest {
 
     //region hasSameSizeAs
     @Test fun hasSameSizeAs_equal_sizes_passes() {
-        assert(emptyMap<String, Int>()).hasSameSizeAs(emptyMap<String, Int>())
+        assertThat(emptyMap<String, Int>()).hasSameSizeAs(emptyMap<String, Int>())
     }
 
     @Test fun hasSameSizeAs_non_equal_sizes_fails() {
         val error = assertFails {
-            assert(emptyMap<String, Int>()).hasSameSizeAs(mapOf("one" to 1))
+            assertThat(emptyMap<String, Int>()).hasSameSizeAs(mapOf("one" to 1))
         }
         assertEquals("expected to have same size as:<{\"one\"=1}> (1) but was size:(0)", error.message)
     }
@@ -158,19 +158,19 @@ class MapTest {
 
     //region key
     @Test fun index_successful_assertion_passes() {
-        assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one").isEqualTo(1)
+        assertThat(mapOf("one" to 1, "two" to 2), name = "subject").key("one").isEqualTo(1)
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("one").isEqualTo(2)
+            assertThat(mapOf("one" to 1, "two" to 2), name = "subject").key("one").isEqualTo(2)
         }
         assertEquals("expected [subject[\"one\"]]:<[2]> but was:<[1]> ({\"one\"=1, \"two\"=2})", error.message)
     }
 
     @Test fun index_missing_key_fails() {
         val error = assertFails {
-            assert(mapOf("one" to 1, "two" to 2), name = "subject").key("wrong").isEqualTo(1)
+            assertThat(mapOf("one" to 1, "two" to 2), name = "subject").key("wrong").isEqualTo(1)
         }
         assertEquals("expected [subject] to have key:<\"wrong\">", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/NumberTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/NumberTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isNegative
 import assertk.assertions.isNotZero
 import assertk.assertions.isPositive
@@ -13,12 +13,12 @@ class NumberTest {
 
     //region isZero
     @Test fun isZero_value_zero_passes() {
-        assert(0).isZero()
+        assertThat(0).isZero()
     }
 
     @Test fun isZero_value_non_zero_fails() {
         val error = assertFails {
-            assert(1).isZero()
+            assertThat(1).isZero()
         }
         assertEquals("expected to be 0 but was:<1>", error.message)
     }
@@ -26,12 +26,12 @@ class NumberTest {
 
     //region isNonZero
     @Test fun isNonZero_value_non_zero_passes() {
-        assert(1).isNotZero()
+        assertThat(1).isNotZero()
     }
 
     @Test fun isNonZero_value_zero_fails() {
         val error = assertFails {
-            assert(0).isNotZero()
+            assertThat(0).isNotZero()
         }
         assertEquals("expected to not be 0", error.message)
     }
@@ -39,19 +39,19 @@ class NumberTest {
 
     //region isPositive
     @Test fun isPositive_value_positive_passes() {
-        assert(1).isPositive()
+        assertThat(1).isPositive()
     }
 
     @Test fun isPositive_value_zero_fails() {
         val error = assertFails {
-            assert(0).isPositive()
+            assertThat(0).isPositive()
         }
         assertEquals("expected to be positive but was:<0>", error.message)
     }
 
     @Test fun isPositive_value_negative_fails() {
         val error = assertFails {
-            assert(-1).isPositive()
+            assertThat(-1).isPositive()
         }
         assertEquals("expected to be positive but was:<-1>", error.message)
     }
@@ -59,19 +59,19 @@ class NumberTest {
 
     //region isNegative
     @Test fun isNegative_value_negative_passes() {
-        assert(-1).isNegative()
+        assertThat(-1).isNegative()
     }
 
     @Test fun isNegative_value_zero_fails() {
         val error = assertFails {
-            assert(0).isNegative()
+            assertThat(0).isNegative()
         }
         assertEquals("expected to be negative but was:<0>", error.message)
     }
 
     @Test fun isNegative_value_positive_fails() {
         val error = assertFails {
-            assert(1).isNegative()
+            assertThat(1).isNegative()
         }
         assertEquals("expected to be negative but was:<1>", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/PredicateTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/PredicateTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.matchesPredicate
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -11,12 +11,12 @@ class PredicateTest {
     @Test fun matchesPredicate_true_predicate_passes() {
         val divisibleBy5: (Int) -> Boolean = { it % 5 == 0 }
 
-        assert(10).matchesPredicate(divisibleBy5)
+        assertThat(10).matchesPredicate(divisibleBy5)
     }
 
     @Test fun matchesPredicate_false_predicate_fails() {
         val divisibleBy5: (Int) -> Boolean = { it % 5 == 0 }
-        val error = assertFails { assert(6).matchesPredicate(divisibleBy5) }
+        val error = assertFails { assertThat(6).matchesPredicate(divisibleBy5) }
 
         assertEquals("expected 6 to satisfy the predicate", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/StringTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/StringTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import assertk.assertions.support.show
 import kotlin.test.Test
@@ -11,23 +11,23 @@ class StringTest {
 
     //region isEqualTo
     @Test fun isEqualTo_same_value_passes() {
-        assert("test").isEqualTo("test")
+        assertThat("test").isEqualTo("test")
     }
 
     @Test fun isEqualTo_different_value_fails() {
         val error = assertFails {
-            assert("").isEqualTo("test")
+            assertThat("").isEqualTo("test")
         }
         assertEquals("expected:<\"[test]\"> but was:<\"[]\">", error.message)
     }
 
     @Test fun isEqualTo_same_value_ignore_case_passes() {
-        assert("Test").isEqualTo("tesT", true)
+        assertThat("Test").isEqualTo("tesT", true)
     }
 
     @Test fun isEqualTo_different_value_ignore_case_fails() {
         val error = assertFails {
-            assert("Test").isEqualTo("tesT", false)
+            assertThat("Test").isEqualTo("tesT", false)
         }
         assertEquals("expected:<\"[tesT]\"> but was:<\"[Test]\">", error.message)
     }
@@ -36,46 +36,46 @@ class StringTest {
     //region isNotEqualTo
     @Test fun isNotEqualTo_same_value_fails() {
         val error = assertFails {
-            assert("test").isNotEqualTo("test")
+            assertThat("test").isNotEqualTo("test")
         }
         assertEquals("expected to not be equal to:<\"test\">", error.message)
     }
 
     @Test fun isNotEqualTo_different_value_passes() {
-        assert("").isNotEqualTo("test")
+        assertThat("").isNotEqualTo("test")
     }
 
     @Test fun isNotEqualTo_same_value_ignore_case_fails() {
         val error = assertFails {
-            assert("Test").isNotEqualTo("tesT", true)
+            assertThat("Test").isNotEqualTo("tesT", true)
         }
         assertEquals("expected:<\"tesT\"> not to be equal to (ignoring case):<\"Test\">", error.message)
     }
 
     @Test fun isNotEqualTo_different_value_ignore_case_passes() {
-        assert("Test").isNotEqualTo("tesT", false)
+        assertThat("Test").isNotEqualTo("tesT", false)
     }
     //endregion
 
     //region contains
     @Test fun contains_value_substring_passes() {
-        assert("test").contains("est")
+        assertThat("test").contains("est")
     }
 
     @Test fun contains_value_not_substring_fails() {
         val error = assertFails {
-            assert("test").contains("not")
+            assertThat("test").contains("not")
         }
         assertEquals("expected to contain:<\"not\"> but was:<\"test\">", error.message)
     }
 
     @Test fun contains_value_substring_ignore_case_passes() {
-        assert("Test").contains("EST", true)
+        assertThat("Test").contains("EST", true)
     }
 
     @Test fun contains_value_not_substring_ignore_case_fails() {
         val error = assertFails {
-            assert("Test").contains("EST", false)
+            assertThat("Test").contains("EST", false)
         }
         assertEquals("expected to contain:<\"EST\"> but was:<\"Test\">", error.message)
     }
@@ -83,47 +83,47 @@ class StringTest {
 
     //region doesNotContain
     @Test fun doesNotContain_value_not_substring_passes() {
-        assert("test").doesNotContain("not")
+        assertThat("test").doesNotContain("not")
     }
 
     @Test fun doesNotContain_value_substring_fails() {
         val error = assertFails {
-            assert("test").doesNotContain("est")
+            assertThat("test").doesNotContain("est")
         }
         assertEquals("expected to not contain:<\"est\">", error.message)
     }
 
     @Test fun doesNotContain_value_substring_ignore_case_fails() {
         val error = assertFails {
-            assert("Test").doesNotContain("EST", true)
+            assertThat("Test").doesNotContain("EST", true)
         }
         assertEquals("expected to not contain:<\"EST\">", error.message)
     }
 
     @Test fun doesNotContain_value_not_substring_ignore_case_passes() {
-        assert("Test").doesNotContain("EST", false)
+        assertThat("Test").doesNotContain("EST", false)
     }
     //endregion
 
     //region startsWith
     @Test fun startsWith_value_prefix_passes() {
-        assert("test").startsWith("te")
+        assertThat("test").startsWith("te")
     }
 
     @Test fun startsWith_value_not_prefix_fails() {
         val error = assertFails {
-            assert("test").startsWith("st")
+            assertThat("test").startsWith("st")
         }
         assertEquals("expected to start with:<\"st\"> but was:<\"test\">", error.message)
     }
 
     @Test fun startsWith_value_prefix_ignore_case_passes() {
-        assert("test").startsWith("TE", true)
+        assertThat("test").startsWith("TE", true)
     }
 
     @Test fun startsWith_value_not_prefix_ignore_case_fails() {
         val error = assertFails {
-            assert("test").startsWith("TE", false)
+            assertThat("test").startsWith("TE", false)
         }
         assertEquals("expected to start with:<\"TE\"> but was:<\"test\">", error.message)
     }
@@ -131,23 +131,23 @@ class StringTest {
 
     //region endsWith
     @Test fun endsWith_value_suffix_passes() {
-        assert("test").endsWith("st")
+        assertThat("test").endsWith("st")
     }
 
     @Test fun endsWith_value_not_suffix_fails() {
         val error = assertFails {
-            assert("test").endsWith("te")
+            assertThat("test").endsWith("te")
         }
         assertEquals("expected to end with:<\"te\"> but was:<\"test\">", error.message)
     }
 
     @Test fun endsWith_value_suffix_ignore_case_passes() {
-        assert("test").endsWith("ST", true)
+        assertThat("test").endsWith("ST", true)
     }
 
     @Test fun endsWith_value_not_suffix_ignore_case_passes() {
         val error = assertFails {
-            assert("test").endsWith("ST", false)
+            assertThat("test").endsWith("ST", false)
         }
         assertEquals("expected to end with:<\"ST\"> but was:<\"test\">", error.message)
     }
@@ -155,16 +155,16 @@ class StringTest {
 
     //region hasLineCount
     @Test fun hasLineCount_correct_value_passes() {
-        assert("").hasLineCount(1)
-        assert("test test").hasLineCount(1)
-        assert("test test\ntest test").hasLineCount(2)
-        assert("test test\r\ntest test").hasLineCount(2)
-        assert("test test\rtest test").hasLineCount(2)
+        assertThat("").hasLineCount(1)
+        assertThat("test test").hasLineCount(1)
+        assertThat("test test\ntest test").hasLineCount(2)
+        assertThat("test test\r\ntest test").hasLineCount(2)
+        assertThat("test test\rtest test").hasLineCount(2)
     }
 
     @Test fun hasLineCount_wrong_value_fails() {
         val error = assertFails {
-            assert("test test").hasLineCount(2)
+            assertThat("test test").hasLineCount(2)
         }
         assertEquals("expected to have line count:<2> but was:<1>", error.message)
     }
@@ -172,13 +172,13 @@ class StringTest {
 
     //region matches
     @Test fun matches_matching_value_passes() {
-        assert("1234").matches(Regex("\\d\\d\\d\\d"))
+        assertThat("1234").matches(Regex("\\d\\d\\d\\d"))
     }
 
     @Test fun matches_not_matching_value_fails() {
         val regex = Regex("\\d\\d\\d\\d")
         val error = assertFails {
-            assert("12345").matches(regex)
+            assertThat("12345").matches(regex)
         }
         assertEquals("expected to match:${show(regex)} but was:<\"12345\">", error.message)
     }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/ThrowableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/ThrowableTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import test.assertk.exceptionPackageName
 import kotlin.test.Test
@@ -13,25 +13,25 @@ class ThrowableTest {
     val subject = Exception("test", cause)
 
     @Test fun extracts_message() {
-        assertEquals(subject.message, assert(subject).message().valueOrFail)
+        assertEquals(subject.message, assertThat(subject).message().valueOrFail)
     }
 
     @Test fun extracts_cause() {
-        assertEquals(cause, assert(subject).cause().valueOrFail)
+        assertEquals(cause, assertThat(subject).cause().valueOrFail)
     }
 
     @Test fun extracts_root_cause() {
-        assertEquals(rootCause, assert(subject).rootCause().valueOrFail)
+        assertEquals(rootCause, assertThat(subject).rootCause().valueOrFail)
     }
 
     //region hasMessage
     @Test fun hasMessage_same_message_passes() {
-        assert(subject).hasMessage("test")
+        assertThat(subject).hasMessage("test")
     }
 
     @Test fun hasMessage_different_message_fails() {
         val error = assertFails {
-            assert(subject).hasMessage("not test")
+            assertThat(subject).hasMessage("not test")
         }
         assertEquals("expected [message]:<\"[not ]test\"> but was:<\"[]test\"> ($subject)", error.message)
     }
@@ -39,13 +39,13 @@ class ThrowableTest {
 
     //region hasCause
     @Test fun hasCause_same_type_and_message_passes() {
-        assert(subject).hasCause(Exception("cause"))
+        assertThat(subject).hasCause(Exception("cause"))
     }
 
     @Test fun hasCause_no_cause_fails() {
         val causeless = Exception("test")
         val error = assertFails {
-            assert(causeless).hasCause(cause)
+            assertThat(causeless).hasCause(cause)
         }
         assertEquals(
             "expected [cause] to not be null ($subject)",
@@ -56,7 +56,7 @@ class ThrowableTest {
     @Test fun hasCause_different_message_fails() {
         val wrongCause = Exception("wrong")
         val error = assertFails {
-            assert(subject).hasCause(wrongCause)
+            assertThat(subject).hasCause(wrongCause)
         }
         assertEquals(
             "expected [cause.message]:<\"[wrong]\"> but was:<\"[cause]\"> ($subject)",
@@ -67,7 +67,7 @@ class ThrowableTest {
     @Test fun hasCause_different_type_fails() {
         val wrongCause = IllegalArgumentException("cause")
         val error = assertFails {
-            assert(subject).hasCause(wrongCause)
+            assertThat(subject).hasCause(wrongCause)
         }
         assertEquals(
             "expected [cause.class]:<class $exceptionPackageName[IllegalArgument]Exception> but was:<class $exceptionPackageName[]Exception> ($subject)",
@@ -79,12 +79,12 @@ class ThrowableTest {
     //region hasNoCause
     @Test fun hasNoCause_no_cause_passes() {
         val causeless = Exception("test")
-        assert(causeless).hasNoCause()
+        assertThat(causeless).hasNoCause()
     }
 
     @Test fun hasNoCause_cause_fails() {
         val error = assertFails {
-            assert(subject).hasNoCause()
+            assertThat(subject).hasNoCause()
         }
         assertEquals("expected [cause] to be null but was:<$cause> ($subject)", error.message)
     }
@@ -92,13 +92,13 @@ class ThrowableTest {
 
     //region hasRootCause
     @Test fun hasRootCause_same_root_cause_type_and_message_passes() {
-        assert(subject).hasRootCause(Exception("rootCause"))
+        assertThat(subject).hasRootCause(Exception("rootCause"))
     }
 
     @Test fun hasRootCause_wrong_cause_type_fails() {
         val wrongCause = IllegalArgumentException("rootCause")
         val error = assertFails {
-            assert(subject).hasRootCause(wrongCause)
+            assertThat(subject).hasRootCause(wrongCause)
         }
         assertEquals(
             "expected [rootCause.class]:<class $exceptionPackageName[IllegalArgument]Exception> but was:<class $exceptionPackageName[]Exception> ($subject)",
@@ -109,7 +109,7 @@ class ThrowableTest {
     @Test fun hasRootCause_wrong_cause_message_fails() {
         val wrongCause = Exception("wrong")
         val error = assertFails {
-            assert(subject).hasRootCause(wrongCause)
+            assertThat(subject).hasRootCause(wrongCause)
         }
         assertEquals(
             "expected [rootCause.message]:<\"[wrong]\"> but was:<\"[rootCause]\"> ($subject)",

--- a/assertk-common/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
+++ b/assertk-common/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import assertk.assertions.support.show
 import kotlin.test.Test
@@ -12,12 +12,12 @@ $T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArra
 class $TTest {
     //region isEqualTo
     @Test fun isEqualTo_same_contents_passes() {
-        assert($NOf(0.to$E())).isEqualTo($NOf(0.to$E()))
+        assertThat($NOf(0.to$E())).isEqualTo($NOf(0.to$E()))
     }
 
 //    @Test fun isEqualTo_different_contents_fails() {
 //        val error = assertFails {
-//            assert($NOf(97.to$E())).isEqualTo($NOf(98.to$E()))
+//            assertThat($NOf(97.to$E())).isEqualTo($NOf(98.to$E()))
 //        }
 //        assertEquals("expected:<[[${show(98.to$E(), "")}]]> but was:<[[${show(97.to$E(), "")}]]>", error.message)
 //    }
@@ -25,12 +25,12 @@ class $TTest {
 
     //region isNotEqualTo
     @Test fun isNotEqualTo_different_contents_passes() {
-        assert($NOf(0.to$E())).isNotEqualTo($NOf(1.to$E()))
+        assertThat($NOf(0.to$E())).isNotEqualTo($NOf(1.to$E()))
     }
 
     @Test fun isNotEqualTo_same_contents_fails() {
         val error = assertFails {
-            assert($NOf(0.to$E())).isNotEqualTo($NOf(0.to$E()))
+            assertThat($NOf(0.to$E())).isNotEqualTo($NOf(0.to$E()))
         }
         assertEquals("expected to not be equal to:<[${show(0.to$E(), "")}]>", error.message)
     }
@@ -38,12 +38,12 @@ class $TTest {
 
     //region isEmpty
     @Test fun isEmpty_empty_passes() {
-        assert($NOf()).isEmpty()
+        assertThat($NOf()).isEmpty()
     }
 
     @Test fun isEmpty_non_empty_fails() {
         val error = assertFails {
-            assert($NOf(0.to$E())).isEmpty()
+            assertThat($NOf(0.to$E())).isEmpty()
         }
         assertEquals("expected to be empty but was:<[${show(0.to$E(), "")}]>", error.message)
     }
@@ -51,12 +51,12 @@ class $TTest {
 
     //region isNotEmpty
     @Test fun isNotEmpty_non_empty_passes() {
-        assert($NOf(0.to$E())).isNotEmpty()
+        assertThat($NOf(0.to$E())).isNotEmpty()
     }
 
     @Test fun isNotEmpty_empty_fails() {
         val error = assertFails {
-            assert($NOf()).isNotEmpty()
+            assertThat($NOf()).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
     }
@@ -64,16 +64,16 @@ class $TTest {
 
     //region isNullOrEmpty
     @Test fun isNullOrEmpty_null_passes() {
-        assert(null as $T?).isNullOrEmpty()
+        assertThat(null as $T?).isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_empty_passes() {
-        assert($NOf()).isNullOrEmpty()
+        assertThat($NOf()).isNullOrEmpty()
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
         val error = assertFails {
-            assert($NOf(0.to$E())).isNullOrEmpty()
+            assertThat($NOf(0.to$E())).isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<[${show(0.to$E(), "")}]>", error.message)
     }
@@ -81,12 +81,12 @@ class $TTest {
 
     //region hasSize
     @Test fun hasSize_correct_size_passes() {
-        assert($NOf()).hasSize(0)
+        assertThat($NOf()).hasSize(0)
     }
 
     @Test fun hasSize_wrong_size_fails() {
         val error = assertFails {
-            assert($NOf()).hasSize(1)
+            assertThat($NOf()).hasSize(1)
         }
         assertEquals("expected [size]:<[1]> but was:<[0]> ([])", error.message)
     }
@@ -94,12 +94,12 @@ class $TTest {
 
     //region hasSameSizeAs
     @Test fun hasSameSizeAs_equal_sizes_passes() {
-        assert($NOf()).hasSameSizeAs($NOf())
+        assertThat($NOf()).hasSameSizeAs($NOf())
     }
 
     @Test fun hasSameSizeAs_non_equal_sizes_fails() {
         val error = assertFails {
-            assert($NOf()).hasSameSizeAs($NOf(0.to$E()))
+            assertThat($NOf()).hasSameSizeAs($NOf(0.to$E()))
         }
         assertEquals("expected to have same size as:<[${show(0.to$E(), "")}]> (1) but was size:(0)", error.message)
     }
@@ -107,12 +107,12 @@ class $TTest {
 
     //region contains
     @Test fun contains_element_present_passes() {
-        assert($NOf(1.to$E(), 2.to$E())).contains(2.to$E())
+        assertThat($NOf(1.to$E(), 2.to$E())).contains(2.to$E())
     }
 
     @Test fun contains_element_missing_fails() {
         val error = assertFails {
-            assert($NOf()).contains(1.to$E())
+            assertThat($NOf()).contains(1.to$E())
         }
         assertEquals("expected to contain:<${show(1.to$E(), "")}> but was:<[]>", error.message)
     }
@@ -120,12 +120,12 @@ class $TTest {
 
     //region doesNotContain
     @Test fun doesNotContain_element_missing_passes() {
-        assert($NOf()).doesNotContain(1.to$E())
+        assertThat($NOf()).doesNotContain(1.to$E())
     }
 
     @Test fun doesNotContain_element_present_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E())).doesNotContain(2.to$E())
+            assertThat($NOf(1.to$E(), 2.to$E())).doesNotContain(2.to$E())
         }
         assertEquals("expected to not contain:<${show(2.to$E(), "")}> but was:<[${show(1.to$E(), "")}, ${show(2.to$E(), "")}]>", error.message)
     }
@@ -133,12 +133,12 @@ class $TTest {
 
     //region containsNone
     @Test fun containsNone_missing_elements_passes() {
-        assert($NOf()).containsNone(1.to$E())
+        assertThat($NOf()).containsNone(1.to$E())
     }
 
     @Test fun containsNone_present_element_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E())).containsNone(2.to$E(), 3.to$E())
+            assertThat($NOf(1.to$E(), 2.to$E())).containsNone(2.to$E(), 3.to$E())
         }
         assertEquals("expected to contain none of:<[${show(2.to$E(), "")}, ${show(3.to$E(), "")}]> some elements were not expected:<[${show(2.to$E(), "")}]>", error.message)
     }
@@ -146,12 +146,12 @@ class $TTest {
 
     //region containsAll
     @Test fun containsAll_all_elements_passes() {
-        assert($NOf(1.to$E(), 2.to$E())).containsAll(2.to$E(), 1.to$E())
+        assertThat($NOf(1.to$E(), 2.to$E())).containsAll(2.to$E(), 1.to$E())
     }
 
     @Test fun containsAll_some_elements_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E())).containsAll(1.to$E(), 2.to$E())
+            assertThat($NOf(1.to$E())).containsAll(1.to$E(), 2.to$E())
         }
         assertEquals("expected to contain all:<[${show(1.to$E(), "")}, ${show(2.to$E(), "")}]> some elements were not found:<[${show(2.to$E(), "")}]>", error.message)
     }
@@ -159,12 +159,12 @@ class $TTest {
 
     //region containsExactly
     @Test fun containsExactly_all_elements_in_same_order_passes() {
-        assert($NOf(1.to$E(), 2.to$E())).containsExactly(1.to$E(), 2.to$E())
+        assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(1.to$E(), 2.to$E())
     }
 
     @Test fun containsExactly_all_elements_in_different_order_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E())).containsExactly(2.to$E(), 1.to$E())
+            assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(2.to$E(), 1.to$E())
         }
         assertEquals(
             """expected to contain exactly:
@@ -176,7 +176,7 @@ class $TTest {
 
     @Test fun containsExactly_missing_element_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E())).containsExactly(3.to$E())
+            assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(3.to$E())
         }
         assertEquals(
             """expected to contain exactly:
@@ -189,7 +189,7 @@ class $TTest {
 
     @Test fun containsExactly_same_indexes_are_together() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 1.to$E())).containsExactly(2.to$E(), 2.to$E())
+            assertThat($NOf(1.to$E(), 1.to$E())).containsExactly(2.to$E(), 2.to$E())
         }
         assertEquals(
             """expected to contain exactly:
@@ -203,7 +203,7 @@ class $TTest {
 
     @Test fun containsExactly_extra_element_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
+            assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
         }
         assertEquals(
             """expected to contain exactly:
@@ -214,7 +214,7 @@ class $TTest {
 
     @Test fun containsExactly_missing_element_in_middle_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 3.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
+            assertThat($NOf(1.to$E(), 3.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
         }
         assertEquals(
             """expected to contain exactly:
@@ -225,7 +225,7 @@ class $TTest {
 
     @Test fun containsExactly_extra_element_in_middle_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsExactly(1.to$E(), 3.to$E())
+            assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsExactly(1.to$E(), 3.to$E())
         }
         assertEquals(
             """expected to contain exactly:
@@ -237,16 +237,16 @@ class $TTest {
 
     //region each
     @Test fun each_empty_list_passes() {
-        assert($NOf()).each { it.isEqualTo(1) }
+        assertThat($NOf()).each { it.isEqualTo(1) }
     }
 
     @Test fun each_content_passes() {
-        assert($NOf(1.to$E(), 2.to$E())).each { it.isGreaterThan(0.to$E()) }
+        assertThat($NOf(1.to$E(), 2.to$E())).each { it.isGreaterThan(0.to$E()) }
     }
 
     @Test fun each_non_matching_content_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E(), 3.to$E())).each { it.isLessThan(2.to$E()) }
+            assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).each { it.isLessThan(2.to$E()) }
         }
         assertEquals(
             """The following assertions failed (2 failures)
@@ -259,12 +259,12 @@ class $TTest {
 
     //region index
     @Test fun index_successful_assertion_passes() {
-        assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0).isEqualTo(1.to$E())
+        assertThat($NOf(1.to$E(), 2.to$E()), name = "subject").index(0).isEqualTo(1.to$E())
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(0).isGreaterThan(2.to$E())
+            assertThat($NOf(1.to$E(), 2.to$E()), name = "subject").index(0).isGreaterThan(2.to$E())
         }
         assertEquals(
             "expected [subject[0]] to be greater than:<${show(2.to$E(), "")}> but was:<${show(1.to$E(), "")}> ([${show(1.to$E(), "")}, ${show(2.to$E(), "")}])",
@@ -274,7 +274,7 @@ class $TTest {
 
     @Test fun index_out_of_range_fails() {
         val error = assertFails {
-            assert($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1).isEqualTo(listOf(1.to$E()))
+            assertThat($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1).isEqualTo(listOf(1.to$E()))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
     }

--- a/assertk-js/src/test/kotlin/test/assertk/JSAssertBlockTest.kt
+++ b/assertk-js/src/test/kotlin/test/assertk/JSAssertBlockTest.kt
@@ -1,6 +1,6 @@
 package test.assertk
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isPositive
 import assertk.assertions.support.show
 import kotlin.test.Test
@@ -9,7 +9,7 @@ import kotlin.test.assertFails
 
 class JSAssertBlockTest {
 
-    private val errorSubject = assert { throw Exception("test") }
+    private val errorSubject = assertThat { throw Exception("test") }
 
     //region thrown error
     @Test fun returnedValue_exception_in_block_fails() {

--- a/assertk-jvm/src/main/kotlin/assertk/assertions/any.kt
+++ b/assertk-jvm/src/main/kotlin/assertk/assertions/any.kt
@@ -17,7 +17,7 @@ fun <T : Any> Assert<T>.jClass() = prop("class") { it::class.java }
 
 /**
  * Asserts the value has the expected java class. This is an exact match, so
- * `assert("test").hasClass(String::class.java)` is successful but `assert("test").hasClass(Any::class.java)` fails.
+ * `assertThat("test").hasClass(String::class.java)` is successful but `assertThat("test").hasClass(Any::class.java)` fails.
  * @see [doesNotHaveClass]
  * @see [isInstanceOf]
  */
@@ -28,7 +28,7 @@ fun <T : Any> Assert<T>.hasClass(jclass: Class<out T>) = given { actual ->
 
 /**
  * Asserts the value does not have the expected java class. This is an exact match, so
- * `assert("test").doesNotHaveClass(String::class.java)` is fails but `assert("test").doesNotHaveClass(Any::class.java)`
+ * `assertThat("test").doesNotHaveClass(String::class.java)` is fails but `assertThat("test").doesNotHaveClass(Any::class.java)`
  * is successful.
  * @see [hasClass]
  * @see [isNotInstanceOf]
@@ -39,8 +39,8 @@ fun <T : Any> Assert<T>.doesNotHaveClass(jclass: Class<out T>) = given { actual 
 }
 
 /**
- * Asserts the value is an instance of the expected java class. Both `assert("test").isInstanceOf(String::class.java)`
- * and `assert("test").isInstanceOf(Any::class.java)` is successful.
+ * Asserts the value is an instance of the expected java class. Both `assertThat("test").isInstanceOf(String::class.java)`
+ * and `assertThat("test").isInstanceOf(Any::class.java)` is successful.
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
@@ -54,8 +54,8 @@ fun <T : Any, S : T> Assert<T>.isInstanceOf(jclass: Class<S>): Assert<S> = trans
 }
 
 /**
- * Asserts the value is an instance of the expected java class. Both `assert("test").isInstanceOf(String::class.java)`
- * and `assert("test").isInstanceOf(Any::class.java)` is successful.
+ * Asserts the value is an instance of the expected java class. Both `assertThat("test").isInstanceOf(String::class.java)`
+ * and `assertThat("test").isInstanceOf(Any::class.java)` is successful.
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
@@ -65,8 +65,8 @@ fun <T : Any, S : T> Assert<T>.isInstanceOf(jclass: Class<S>, f: (Assert<S>) -> 
 }
 
 /**
- * Asserts the value is not an instance of the expected java class. Both `assert("test").isNotInstanceOf(String::class)`
- * and `assert("test").isNotInstanceOf(Any::class)` fails.
+ * Asserts the value is not an instance of the expected java class. Both `assertThat("test").isNotInstanceOf(String::class)`
+ * and `assertThat("test").isNotInstanceOf(Any::class)` fails.
  * @see [isInstanceOf]
  * @see [doesNotHaveClass]
  */
@@ -81,7 +81,7 @@ fun <T : Any> Assert<T>.isNotInstanceOf(jclass: Class<out T>) = given { actual -
  * callable will be shown in failure messages.
  *
  * ```
- * assert(person).prop(Person::name).isEqualTo("Sue")
+ * assertThat(person).prop(Person::name).isEqualTo("Sue")
  * ```
  */
 fun <T, P> Assert<T>.prop(callable: KCallable<P>) = prop(callable.name) { callable.call(it) }

--- a/assertk-jvm/src/test/kotlin/test/assertk/JVMAssertBlockTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/JVMAssertBlockTest.kt
@@ -1,6 +1,6 @@
 package test.assertk
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isPositive
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -10,7 +10,7 @@ import kotlin.test.assertTrue
 
 class JVMAssertBlockTest {
 
-    private val errorSubject = assert { throw Exception("test") }
+    private val errorSubject = assertThat { throw Exception("test") }
 
     //region thrown error
     @Test fun returnedValue_exception_fails_with_stacktrace() {

--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/FileTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/FileTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import java.io.File
 import java.nio.file.Files
@@ -13,14 +13,14 @@ class FileTest {
 
     //region exists
     @Test fun exists_with_existing_file_passes() {
-        assert(file).exists()
+        assertThat(file).exists()
     }
 
     @Test fun exists_with_nonexistent_file_fails() {
         val tempFile = File.createTempFile("exists", "txt")
         tempFile.delete()
         val error = assertFails {
-            assert(tempFile).exists()
+            assertThat(tempFile).exists()
         }
         assertEquals("expected to exist", error.message)
     }
@@ -28,12 +28,12 @@ class FileTest {
 
     //region isDirectory
     @Test fun isDirectory_value_directory_passes() {
-        assert(directory).isDirectory()
+        assertThat(directory).isDirectory()
     }
 
     @Test fun isDirectory_value_file_fails() {
         val error = assertFails {
-            assert(file).isDirectory()
+            assertThat(file).isDirectory()
         }
         assertEquals("expected to be a directory", error.message)
     }
@@ -41,12 +41,12 @@ class FileTest {
 
     //region isFile
     @Test fun isFile_value_file_passes() {
-        assert(file).isFile()
+        assertThat(file).isFile()
     }
 
     @Test fun isFile_value_directory_fails() {
         val error = assertFails {
-            assert(directory).isFile()
+            assertThat(directory).isFile()
         }
         assertEquals("expected to be a file", error.message)
     }
@@ -54,14 +54,14 @@ class FileTest {
 
     //region isNotHidden
     @Test fun isNotHidden_value_regular_file_passes() {
-        assert(file).isNotHidden()
+        assertThat(file).isNotHidden()
     }
     //endregion
 
     //region isHidden
     @Test fun isHidden_value_regular_file_fails() {
         val error = assertFails {
-            assert(file).isHidden()
+            assertThat(file).isHidden()
         }
         assertEquals("expected to be hidden", error.message)
     }
@@ -72,23 +72,23 @@ class FileTest {
     val namedDirectory = File("assertKt/directory")
 
     @Test fun hasName_correct_value_file_passes() {
-        assert(namedFile).hasName("file.txt")
+        assertThat(namedFile).hasName("file.txt")
     }
 
     @Test fun hasName_correct_value_directory_pases() {
-        assert(namedDirectory).hasName("directory")
+        assertThat(namedDirectory).hasName("directory")
     }
 
     @Test fun hasName_wrong_value_file_fails() {
         val error = assertFails {
-            assert(namedFile).hasName("file")
+            assertThat(namedFile).hasName("file")
         }
         assertEquals("expected [name]:<\"file[]\"> but was:<\"file[.txt]\"> (assertKt/file.txt)", error.message)
     }
 
     @Test fun hasName_wront_value_directory_fails() {
         val error = assertFails {
-            assert(namedDirectory).hasName("assertKt")
+            assertThat(namedDirectory).hasName("assertKt")
         }
         assertEquals(
             "expected [name]:<\"[assertKt]\"> but was:<\"[${namedDirectory.name}]\"> (assertKt/directory)",
@@ -101,12 +101,12 @@ class FileTest {
     val fileWithPath = File("assertKt/file.txt")
 
     @Test fun hasPath_correct_path_passes() {
-        assert(fileWithPath).hasPath("assertKt/file.txt")
+        assertThat(fileWithPath).hasPath("assertKt/file.txt")
     }
 
     @Test fun hasPath_wrong_path_fails() {
         val error = assertFails {
-            assert(fileWithPath).hasPath("/directory")
+            assertThat(fileWithPath).hasPath("/directory")
         }
         assertEquals(
             "expected [path]:<\"[/directory]\"> but was:<\"[${fileWithPath.path}]\"> (assertKt/file.txt)",
@@ -119,12 +119,12 @@ class FileTest {
     val fileWithParent = File("assertKt/file.txt")
 
     @Test fun hasParent_correct_parent_passes() {
-        assert(fileWithParent).hasParent("assertKt")
+        assertThat(fileWithParent).hasParent("assertKt")
     }
 
     @Test fun hasParent_wrong_parent_passes() {
         val error = assertFails {
-            assert(fileWithParent).hasParent("directory")
+            assertThat(fileWithParent).hasParent("directory")
         }
         assertEquals(
             "expected [parent]:<\"[directory]\"> but was:<\"[${fileWithParent.parent}]\"> (assertKt/file.txt)",
@@ -137,12 +137,12 @@ class FileTest {
     val fileWithExtension = File("file.txt")
 
     @Test fun hasExtension_correct_extension_passes() {
-        assert(fileWithExtension).hasExtension("txt")
+        assertThat(fileWithExtension).hasExtension("txt")
     }
 
     @Test fun hasExtension_wrong_extension_fails() {
         val error = assertFails {
-            assert(fileWithExtension).hasExtension("png")
+            assertThat(fileWithExtension).hasExtension("png")
         }
         assertEquals("expected [extension]:<\"[png]\"> but was:<\"[${fileWithExtension.extension}]\"> (file.txt)", error.message)
     }
@@ -159,12 +159,12 @@ class FileTest {
     }
 
     @Test fun hasText_correct_value_passes() {
-        assert(fileWithText).hasText(text)
+        assertThat(fileWithText).hasText(text)
     }
 
     @Test fun hasText_wrong_value_fails() {
         val error = assertFails {
-            assert(fileWithText).hasText("Forty-two!")
+            assertThat(fileWithText).hasText("Forty-two!")
         }
         assertTrue(error.message!!.startsWith("expected [text]:<\"[Forty-two!]\"> but was:<\"[$text]\">"))
         assertTrue(error.message!!.contains("file_contains"))
@@ -173,12 +173,12 @@ class FileTest {
 
     //region contains
     @Test fun contains_correct_substring_passes() {
-        assert(fileWithText).text().contains("Forty-two")
+        assertThat(fileWithText).text().contains("Forty-two")
     }
 
     @Test fun contains_wrong_substring_fails() {
         val error = assertFails {
-            assert(fileWithText).text().contains("Forty-two!")
+            assertThat(fileWithText).text().contains("Forty-two!")
         }
         assertTrue(error.message!!.startsWith("expected [text] to contain:<\"Forty-two!\"> but was:<\"$text\">"))
         assertTrue(error.message!!.contains("file_contains"))
@@ -195,13 +195,13 @@ class FileTest {
     }
 
     @Test fun matches_correct_regex_passes() {
-        assert(matchingFile).text().matches(".a...e.".toRegex())
+        assertThat(matchingFile).text().matches(".a...e.".toRegex())
     }
 
     @Test fun matches_wrong_regex_fails() {
         val incorrectRegexp = ".*d".toRegex()
         val error = assertFails {
-            assert(matchingFile).text().matches(incorrectRegexp)
+            assertThat(matchingFile).text().matches(incorrectRegexp)
         }
         assertTrue(error.message!!.startsWith("expected [text] to match:</$incorrectRegexp/> but was:<\"$matchingText\">"))
         assertTrue(error.message!!.contains("file_contains"))
@@ -213,13 +213,13 @@ class FileTest {
     val childFile = File.createTempFile("file", ".txt", directoryWithChild)
 
     @Test fun hasDirectChild_value_is_child_passes() {
-        assert(directoryWithChild).hasDirectChild(childFile)
+        assertThat(directoryWithChild).hasDirectChild(childFile)
     }
 
     @Test fun hasDirectChild_value_not_child_fails() {
         val newFile = File.createTempFile("file", ".txt")
         val error = assertFails {
-            assert(directoryWithChild).hasDirectChild(newFile)
+            assertThat(directoryWithChild).hasDirectChild(newFile)
         }
         assertEquals("expected to have direct child <$newFile>", error.message)
     }
@@ -227,7 +227,7 @@ class FileTest {
     @Test fun hasDirectChild_empty_directory_fails() {
         directoryWithChild.listFiles().forEach { it.delete() }
         val error = assertFails {
-            assert(directory).hasDirectChild(file)
+            assertThat(directory).hasDirectChild(file)
         }
         assertEquals("expected to have direct child <$file>", error.message)
     }

--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/InputStreamTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/InputStreamTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.hasNotSameContentAs
 import assertk.assertions.hasSameContentAs
 import java.io.ByteArrayInputStream
@@ -13,12 +13,12 @@ class InputStreamTest {
 
     //region hasSameContentAs
     @Test fun hasSameContentAs_on_empty_streams_passes() {
-        assert(emptyStream()).hasSameContentAs(emptyStream())
+        assertThat(emptyStream()).hasSameContentAs(emptyStream())
     }
 
     @Test fun hasSameContentAs_on_different_streams_fails() {
         val error = assertFails {
-            assert(emptyStream()).hasSameContentAs(streamA())
+            assertThat(emptyStream()).hasSameContentAs(streamA())
         }
         assertEquals(
             "expected to have the same size, but actual stream size (0) differs from other stream size (10)",
@@ -28,7 +28,7 @@ class InputStreamTest {
 
     @Test fun hasSameContentAs_on_different_non_empty_streams_fails() {
         val error = assertFails {
-            assert(streamA()).hasSameContentAs(streamB())
+            assertThat(streamA()).hasSameContentAs(streamB())
         }
         assertEquals(
             "expected to have the same content, but actual stream differs at pos 0. Actual stream: value=0x00, size=10. Other stream: value=0x64, size=10",
@@ -37,24 +37,24 @@ class InputStreamTest {
     }
 
     @Test fun hasSameContentAs_with_same_streams_passes() {
-        assert(streamA()).hasSameContentAs(streamA())
+        assertThat(streamA()).hasSameContentAs(streamA())
     }
 
     @Test fun hasSameContent_on_different_sized_streams_fails() {
         val error = assertFails {
-            assert(prefixOfStreamA()).hasSameContentAs(streamA())
+            assertThat(prefixOfStreamA()).hasSameContentAs(streamA())
         }
         assertEquals("expected to have the same size, but actual size (5) differs from other size (10)", error.message)
 
         val error2 = assertFails {
-            assert(streamA()).hasSameContentAs(prefixOfStreamA())
+            assertThat(streamA()).hasSameContentAs(prefixOfStreamA())
         }
         assertEquals("expected to have the same size, but actual size (10) differs from other size (5)", error2.message)
     }
 
     @Test fun hasSameContentAs_streams_different_in_single_value_fails() {
         val error = assertFails {
-            assert(streamB()).hasSameContentAs(streamC())
+            assertThat(streamB()).hasSameContentAs(streamC())
         }
         assertEquals(
             "expected to have the same content, but actual stream differs at pos 0. Actual stream: value=0x66, size=10. Other stream: value=0x77, size=10",
@@ -67,30 +67,30 @@ class InputStreamTest {
     //region hasNotSameContentAs
     @Test fun hasNotSameContentAs_on_empty_streams_fails() {
         val error = assertFails {
-            assert(emptyStream()).hasNotSameContentAs(emptyStream())
+            assertThat(emptyStream()).hasNotSameContentAs(emptyStream())
         }
         assertEquals("expected streams not to be equal, but they were equal", error.message)
     }
 
     @Test fun hasNotSameContentAs_on_different_streams_passes() {
-        assert(emptyStream()).hasNotSameContentAs(streamA())
+        assertThat(emptyStream()).hasNotSameContentAs(streamA())
     }
 
     @Test fun hasNotSameContentAs_on_same_streams_fails() {
         val error = assertFails {
-            assert(streamA()).hasNotSameContentAs(streamA())
+            assertThat(streamA()).hasNotSameContentAs(streamA())
         }
         assertEquals("expected streams not to be equal, but they were equal", error.message)
     }
 
     @Test fun hasNotSameContentAs_on_different_non_empty_streams_passes() {
-        assert(streamA()).hasNotSameContentAs(streamB())
+        assertThat(streamA()).hasNotSameContentAs(streamB())
     }
 
     @Test fun hasNotSameContentAs_on_different_sized_streams_passes() {
-        assert(prefixOfStreamA()).hasNotSameContentAs(streamA())
-        assert(streamA()).hasNotSameContentAs(prefixOfStreamA())
-        assert(streamB()).hasNotSameContentAs(streamC())
+        assertThat(prefixOfStreamA()).hasNotSameContentAs(streamA())
+        assertThat(streamA()).hasNotSameContentAs(prefixOfStreamA())
+        assertThat(streamB()).hasNotSameContentAs(streamC())
     }
     //endregion
 }

--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,22 +12,22 @@ class JavaAnyTest {
 
     //region jClass
     @Test fun extracts_jClass() {
-        assertEquals(BasicObject::class.java, assert(subject as TestObject).jClass().valueOrFail)
+        assertEquals(BasicObject::class.java, assertThat(subject as TestObject).jClass().valueOrFail)
     }
     //endregion
 
     //region isInstanceOf
     @Test fun isInstanceOf_jclass_same_class_passes() {
-        assert(subject).isInstanceOf(BasicObject::class.java)
+        assertThat(subject).isInstanceOf(BasicObject::class.java)
     }
 
     @Test fun isInstanceOf_jclass_parent_class_passes() {
-        assert(subject).isInstanceOf(TestObject::class.java)
+        assertThat(subject).isInstanceOf(TestObject::class.java)
     }
 
     @Test fun isInstanceOf_jclass_different_class_fails() {
         val error = assertFails {
-            assert(subject).isInstanceOf(DifferentObject::class.java)
+            assertThat(subject).isInstanceOf(DifferentObject::class.java)
         }
         assertEquals(
             "expected to be instance of:<$p\$DifferentObject> but had class:<$p\$BasicObject>",
@@ -37,7 +37,7 @@ class JavaAnyTest {
 
     @Test fun isInstanceOf_jclass_run_block_when_passes() {
         val error = assertFails {
-            assert(subject as TestObject)
+            assertThat(subject as TestObject)
                 .isInstanceOf(BasicObject::class.java)
                 .prop("str", BasicObject::str)
                 .isEqualTo("wrong")
@@ -47,7 +47,7 @@ class JavaAnyTest {
 
     @Test fun isInstanceOf_jclass_doesnt_run_block_when_fails() {
         val error = assertFails {
-            assert(subject as TestObject)
+            assertThat(subject as TestObject)
                 .isInstanceOf(DifferentObject::class.java)
                 .isNull()
         }
@@ -60,19 +60,19 @@ class JavaAnyTest {
 
     //region isNotInstanceOf
     @Test fun isNotInstanceOf_jclass_different_class_passess() {
-        assert(subject).isNotInstanceOf(DifferentObject::class.java)
+        assertThat(subject).isNotInstanceOf(DifferentObject::class.java)
     }
 
     @Test fun isNotInstanceOf_jclass_same_class_fails() {
         val error = assertFails {
-            assert(subject).isNotInstanceOf(BasicObject::class.java)
+            assertThat(subject).isNotInstanceOf(BasicObject::class.java)
         }
         assertEquals("expected to not be instance of:<$p\$BasicObject>", error.message)
     }
 
     @Test fun isNotInstanceOf_jclass_parent_class_fails() {
         val error = assertFails {
-            assert(subject).isNotInstanceOf(TestObject::class.java)
+            assertThat(subject).isNotInstanceOf(TestObject::class.java)
         }
         assertEquals("expected to not be instance of:<$p\$TestObject>", error.message)
     }
@@ -80,12 +80,12 @@ class JavaAnyTest {
 
     //region prop
     @Test fun prop_callable_extract_prop_passes() {
-        assert(subject).prop(BasicObject::str).isEqualTo("test")
+        assertThat(subject).prop(BasicObject::str).isEqualTo("test")
     }
 
     @Test fun prop_callable_extract_prop_includes_name_in_failure_message() {
         val error = assertFails {
-            assert(subject).prop(BasicObject::str).isEmpty()
+            assertThat(subject).prop(BasicObject::str).isEmpty()
         }
         assertEquals("expected [str] to be empty but was:<\"test\"> (test)", error.message)
     }
@@ -93,13 +93,13 @@ class JavaAnyTest {
 
     //region isDataClassEqualTo
     @Test fun isDataClassEqualTo_equal_data_classes_passes() {
-        assert(DataClass(InnerDataClass("test"), 1, 'a'))
+        assertThat(DataClass(InnerDataClass("test"), 1, 'a'))
             .isDataClassEqualTo(DataClass(InnerDataClass("test"), 1, 'a'))
     }
 
     @Test fun isDataClassEqualTo_reports_all_properties_that_differ_on_failure() {
         val error = assertFails {
-            assert(DataClass(InnerDataClass("test"), 1, 'a'))
+            assertThat(DataClass(InnerDataClass("test"), 1, 'a'))
                 .isDataClassEqualTo(DataClass(InnerDataClass("wrong"), 1, 'b'))
         }
         assertEquals(

--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaNullableStringTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaNullableStringTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import kotlin.test.Test
@@ -11,12 +11,12 @@ class JavaNullableStringTest {
 
     //region isEqualTo
     @Test fun isEqualTo_same_nullable_string_passes() {
-        assert(JavaNullableString.string()).isEqualTo(JavaNullableString.string())
+        assertThat(JavaNullableString.string()).isEqualTo(JavaNullableString.string())
     }
 
     @Test fun isEqualTo_different_string_fails() {
         val error = assertFails {
-            assert(JavaNullableString.string()).isEqualTo("wrong")
+            assertThat(JavaNullableString.string()).isEqualTo("wrong")
         }
         assertEquals("expected:<\"wrong\"> but was:<null>", error.message)
     }
@@ -24,12 +24,12 @@ class JavaNullableStringTest {
 
     //region isNotEqualTo
     @Test fun isNotEqualTo_different_string_passes() {
-        assert(JavaNullableString.string()).isNotEqualTo("wrong")
+        assertThat(JavaNullableString.string()).isNotEqualTo("wrong")
     }
 
     @Test fun isNotEqualTo_same_nullable_string_fails() {
         val error = assertFails {
-            assert(JavaNullableString.string()).isNotEqualTo(JavaNullableString.string())
+            assertThat(JavaNullableString.string()).isNotEqualTo(JavaNullableString.string())
         }
         assertEquals("expected to not be equal to:<null>", error.message)
     }

--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/PathTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/PathTest.kt
@@ -1,6 +1,6 @@
 package test.assertk.assertions
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.*
 import java.nio.file.Files
 import java.nio.file.Path
@@ -28,12 +28,12 @@ class PathTest {
 
     //region isRegularFile
     @Test fun isRegularFile_value_regularFile_passes() {
-        assert(regularFile!!).isRegularFile()
+        assertThat(regularFile!!).isRegularFile()
     }
 
     @Test fun isRegularFile_value_directory_fails() {
         val error = assertFails {
-            assert(directory!!).isRegularFile()
+            assertThat(directory!!).isRegularFile()
         }
         assertEquals("expected <$directory> to be a regular file, but it is not", error.message)
     }
@@ -42,27 +42,27 @@ class PathTest {
     //region isDirectory
     @Test fun isDirectory_value_not_directory_fails() {
         val error = assertFails {
-            assert(regularFile!!).isDirectory()
+            assertThat(regularFile!!).isDirectory()
         }
         assertEquals("expected <$regularFile> to be a directory, but it is not", error.message)
     }
 
     @Test fun isDirectory_value_directory_passes() {
-        assert(directory!!).isDirectory()
+        assertThat(directory!!).isDirectory()
     }
     //endregion
 
     //region isHidden
     @Test fun isHidden_value_regular_file_not_hidden_fails() {
         val error = assertFails {
-            assert(regularFile!!).isHidden()
+            assertThat(regularFile!!).isHidden()
         }
         assertEquals("expected <$regularFile> to be hidden, but it is not", error.message)
     }
 
     @Test fun isHidden_value_directory_not_hidden_fails() {
         val error = assertFails {
-            assert(directory!!).isHidden()
+            assertThat(directory!!).isHidden()
         }
         assertEquals("expected <$directory> to be hidden, but it is not", error.message)
     }
@@ -70,25 +70,25 @@ class PathTest {
 
     //region isReadable
     @Test fun isReadable_value_readable_file_passes() {
-        assert(regularFile!!).isReadable()
+        assertThat(regularFile!!).isReadable()
     }
 
     @Test fun isReadable_value_readable_directory_passes() {
-        assert(directory!!).isReadable()
+        assertThat(directory!!).isReadable()
     }
     //endregion
 
     //region isSymbolicLink
     @Test fun isSymbolicLink_value_regular_file_fails() {
         val error = assertFails {
-            assert(regularFile!!).isSymbolicLink()
+            assertThat(regularFile!!).isSymbolicLink()
         }
         assertEquals("expected <$regularFile> to be a symbolic link, but it is not", error.message)
     }
 
     @Test fun isSymbolicLink_value_directory_fails() {
         val error = assertFails {
-            assert(directory!!).isSymbolicLink()
+            assertThat(directory!!).isSymbolicLink()
         }
         assertEquals("expected <$directory> to be a symbolic link, but it is not", error.message)
     }
@@ -96,41 +96,41 @@ class PathTest {
 
     //region isWritable
     @Test fun isWritable_value_writable_file_passes() {
-        assert(regularFile!!).isWritable()
+        assertThat(regularFile!!).isWritable()
     }
 
     @Test fun isWritable_value_writable_directory_passes() {
-        assert(directory!!).isWritable()
+        assertThat(directory!!).isWritable()
     }
     //endregion
 
     //region isSameFileAs
     @Test fun isSameFileAs_value_same_file_passes() {
-        assert(regularFile!!).isSameFileAs(regularFile!!)
+        assertThat(regularFile!!).isSameFileAs(regularFile!!)
     }
 
     @Test fun isSameFileAs_value_same_directory_passes() {
-        assert(directory!!).isSameFileAs(directory!!)
+        assertThat(directory!!).isSameFileAs(directory!!)
     }
 
     @Test fun isSameFileAs_value_same_file_different_path_passes() {
-        assert(regularFile!!).isSameFileAs(regularFile!!.toAbsolutePath())
+        assertThat(regularFile!!).isSameFileAs(regularFile!!.toAbsolutePath())
     }
 
     @Test fun isSameFileAs_value_same_directory_different_path_passes() {
-        assert(directory!!).isSameFileAs(directory!!.toAbsolutePath())
+        assertThat(directory!!).isSameFileAs(directory!!.toAbsolutePath())
     }
     //endregion
 
     //region lines
     @Test fun lines_correct_string_passes() {
-        assert(regularFileWithText!!).lines().containsExactly("a", "b")
+        assertThat(regularFileWithText!!).lines().containsExactly("a", "b")
     }
     //endregion
 
     //region bytes
     @Test fun bytes_value_correct_byte_array_passes() {
-        assert(regularFile!!).bytes().isEqualTo(ByteArray(10))
+        assertThat(regularFile!!).bytes().isEqualTo(ByteArray(10))
     }
     //endregion
 }

--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/support/JavaNumberTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/support/JavaNumberTest.kt
@@ -1,5 +1,6 @@
 package test.assertk.assertions.support
 
+import assertk.assertThat
 import assertk.assertions.isNegative
 import assertk.assertions.isPositive
 import assertk.assertions.isZero
@@ -14,13 +15,13 @@ class BigDecimalSpecNumberOnIsZero {
 
     @Test
     fun itGivenZeroTestShouldPass() {
-        assertk.assert(BigDecimal.ZERO).isZero()
+        assertThat(BigDecimal.ZERO).isZero()
     }
 
     @Test
     fun itGivenNoZeroTestShouldFail() {
         val error = assertFails {
-            assertk.assert(BigDecimal.ONE).isZero()
+            assertThat(BigDecimal.ONE).isZero()
         }
         assertEquals("expected to be 0 but was:<1>", error.message)
     }
@@ -30,13 +31,13 @@ class BigIntegerSpecNumberOnIsZero {
 
     @Test
     fun itGivenZeroTestShouldPass() {
-        assertk.assert(BigInteger.ZERO).isZero()
+        assertThat(BigInteger.ZERO).isZero()
     }
 
     @Test
     fun it_Given_a_not_zero_test_should_fail() {
         val error = assertFails {
-            assertk.assert(BigInteger.ONE).isZero()
+            assertThat(BigInteger.ONE).isZero()
         }
         assertEquals("expected to be 0 but was:<1>", error.message)
     }
@@ -45,13 +46,13 @@ class BigIntegerSpecNumberOnIsZero {
 class BigDecimalSpecNumberOnIsPositive {
     @Test
     fun itGivenPositiveNumberTestShouldPass() {
-        assertk.assert(BigDecimal.ONE).isPositive()
+        assertThat(BigDecimal.ONE).isPositive()
     }
 
     @Test
     fun itGivenZeroNumberTestShouldFail() {
         val error = assertFails {
-            assertk.assert(BigDecimal.ZERO).isPositive()
+            assertThat(BigDecimal.ZERO).isPositive()
         }
         assertEquals("expected to be positive but was:<0>", error.message)
     }
@@ -59,7 +60,7 @@ class BigDecimalSpecNumberOnIsPositive {
     @Test
     fun itGivenNegativeNumberTestShouldFail() {
         val error = assertFails {
-            assertk.assert(BigDecimal.ONE.negate()).isPositive()
+            assertThat(BigDecimal.ONE.negate()).isPositive()
         }
         assertEquals("expected to be positive but was:<-1>", error.message)
     }
@@ -69,7 +70,7 @@ class NumberSpecNumberOnIsNegative {
     @Test
     fun itGivenZeroNumberTestShouldFail() {
         val error = assertFails {
-            assertk.assert(BigDecimal.ZERO).isNegative()
+            assertThat(BigDecimal.ZERO).isNegative()
         }
         assertEquals("expected to be negative but was:<0>", error.message)
     }
@@ -77,13 +78,13 @@ class NumberSpecNumberOnIsNegative {
     @Test
     fun itGivePositiveNumberTestShouldFail() {
         val error = assertFails {
-            assertk.assert(BigDecimal.ONE).isNegative()
+            assertThat(BigDecimal.ONE).isNegative()
         }
         assertEquals("expected to be negative but was:<1>", error.message)
     }
 
     @Test
     fun itGivenNegativeNumberTestShouldPass() {
-        assertk.assert(BigDecimal.ONE.negate()).isNegative()
+        assertThat(BigDecimal.ONE.negate()).isNegative()
     }
 }


### PR DESCRIPTION
Unfortuantly, assert clashes with kotlin's built-in assert methods which
cause import issues and potential confusion. By using the widely-used
assertThat instead, it's more clear what's using a flutent assert style.

Fixes #146