### PR TITLE
Add isEqualToIgnoringGivenFields for JVM

### DIFF
--- a/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk-jvm/src/test/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -111,6 +111,18 @@ class JavaAnyTest {
     }
     //endregion
 
+    //region isEqualToIgnoringGivenFields
+    @Test fun isEqualToIgnoringGivenFields_passes() {
+        assertThat (AnyTest.Companion.BasicObject("Rarity")).isEqualToIgnoringGivenFields(AnyTest.Companion.BasicObject("notRarity"), AnyTest.Companion.BasicObject::str)
+    }
+
+    @Test fun isEqualToIgnoringGivenFields_fails() {
+        assertFails {
+            assertThat (AnyTest.Companion.BasicObject("Rarity", int = 42)).isEqualToIgnoringGivenFields(AnyTest.Companion.BasicObject("notRarity", int = 1337), AnyTest.Companion.BasicObject::str)
+        }
+    }
+    //endregion
+
     open class TestObject
 
     class BasicObject(


### PR DESCRIPTION
I've done it only for JVM because JavaScript Reflection can't list properties.