### PR TITLE
Add quantitative predicate assertions for atMost and exactly

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
@@ -55,6 +55,37 @@ fun <E, T : Iterable<E>> Assert<T>.atLeast(times: Int, f: (Assert<E>) -> Unit) {
         body = { each { item -> count++; f(item) } },
         failIf = { count - it.size < times })
 }
+
+/**
+ * Asserts on each item in the iterable, passing if at most `times` items pass.
+ * The given lambda will be run for each item.
+ *
+ * ```
+ * assert(listOf(-2, -1, 1) as Iterable<Int>).atMost(2) { it -> it.isPositive() }
+ * ```
+ */
+fun <E, T : Iterable<E>> Assert<T>.atMost(times: Int, f: (Assert<E>) -> Unit) {
+    var count = 0
+    all(message = "expected to pass at most $times times",
+            body = { each { item -> count++; f(item)} },
+            failIf = { count - it.size > times})
+}
+
+/**
+ * Asserts on each item in the iterable, passing if exactly `times` items pass.
+ * The given lambda will be run for each item.
+ *
+ * ```
+ * assert(listOf(-1, 1, 2) as Iterable<Int>).exactly(2) { it -> it.isPositive() }
+ * ```
+ */
+fun <E, T : Iterable<E>> Assert<T>.exactly(times: Int, f: (Assert<E>) -> Unit) {
+    var count = 0
+    all(message = "expected to pass exactly $times times",
+            body = { each { item -> count++; f(item)} },
+            failIf = { count - it.size != times})
+}
+
 /**
  * Asserts the iterable is empty.
  * @see [isNotEmpty]

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/AnyTest.kt
@@ -130,6 +130,29 @@ class AnyTest {
         assertEquals("expected:<[not test1, test, not test2]> to not contain:<test>", error.message)
     }
 
+    @Test fun hasToString_equal_string_passes() {
+        assertThat(subject).hasToString("test")
+    }
+
+    @Test fun hasToString_not_equal_string_fails() {
+        val error = assertFails {
+            assertThat(subject).hasToString("not test")
+        }
+        assertEquals("expected [toString]:<\"[not ]test\"> but was:<\"[]test\"> (test)", error.message)
+    }
+
+    @Test fun hasHashCode_equal_value_passes() {
+        assertThat(subject).hasHashCode(42)
+    }
+
+    @Test fun hasHashCode_not_equal_value_fails() {
+        val error = assertFails {
+            assertThat(subject).hasHashCode(1337)
+        }
+        assertEquals("expected [hashCode]:<[1337]> but was:<[42]> (test)", error.message)
+    }
+
+
     private val testObject = BasicObject("test", 99, 3.14)
 
     @Test fun isEqualToWithGivenProperties_regular_equals_fail() {

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
@@ -78,10 +78,6 @@ class IterableTest {
     //endregion
 
     //region atMost
-    @Test fun atMost_too_many_failures_passes() {
-        assertThat(listOf(0, 1, 2, 3)).atMost(2) { it -> it.isGreaterThan(2) }
-    }
-
     @Test fun atMost_more_than_times_passed_fails() {
         val error = assertFails {
             assertThat(listOf(1, 2, 3) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(0) }
@@ -91,7 +87,12 @@ class IterableTest {
         )
     }
 
-    @Test fun atMost_less_than_times_failures_passes() {
+    @Test fun atMost_exactly_times_passed_passes() {
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(1) }
+    }
+
+
+    @Test fun atMost_less_than_times_passed_passes() {
         assertThat(listOf(1, 2) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(1) }
     }
     //endregion

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
@@ -56,7 +56,7 @@ class IterableTest {
     //endregion
 
     //region atLeast
-    @Test fun atLeast_to_many_failures_fails() {
+    @Test fun atLeast_too_many_failures_fails() {
         val error = assertFails {
             assertThat(listOf(1, 2, 3)).atLeast(2) { it -> it.isGreaterThan(2) }
         }
@@ -68,13 +68,61 @@ class IterableTest {
         )
     }
 
-    @Test fun atLest_no_failures_passes() {
+    @Test fun atLeast_no_failures_passes() {
         assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(0) }
     }
 
     @Test fun atLeast_less_than_times_failures_passes() {
         assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(1) }
     }
+    //endregion
+
+    //region atMost
+    @Test fun atMost_too_many_failures_passes() {
+        assertThat(listOf(0, 1, 2, 3)).atMost(2) { it -> it.isGreaterThan(2) }
+    }
+
+    @Test fun atMost_more_than_times_passed_fails() {
+        val error = assertFails {
+            assertThat(listOf(1, 2, 3) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(0) }
+        }
+        assertEquals(
+                """expected to pass at most 2 times""".trimMargin(), error.message
+        )
+    }
+
+    @Test fun atMost_less_than_times_failures_passes() {
+        assertThat(listOf(1, 2) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(1) }
+    }
+    //endregion
+
+
+    //region exactly
+    @Test fun exactly_too_few_passes_fails() {
+        val error = assertFails {
+            assertThat(listOf(1, 2, 3)).exactly(2) { it -> it.isGreaterThan(2) }
+        }
+        assertEquals(
+                """expected to pass exactly 2 times (2 failures)
+            |${"\t"}expected [[0]] to be greater than:<2> but was:<1> ([1, 2, 3])
+            |${"\t"}expected [[1]] to be greater than:<2> but was:<2> ([1, 2, 3])
+        """.trimMargin(), error.message
+        )
+    }
+
+    @Test fun exactly_too_many_passes_fails() {
+        val error = assertFails {
+            assertThat(listOf(5, 4, 3)).exactly(2) { it -> it.isGreaterThan(2) }
+        }
+        assertEquals(
+                """expected to pass exactly 2 times""".trimMargin(), error.message
+        )
+    }
+
+    @Test fun exactly_times_passed_passes() {
+        assertThat(listOf(1, 2) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(0) }
+    }
+
     //endregion
 
     //region isEmpty


### PR DESCRIPTION
I've added two of the quantitative predicate assertions mentioned in #98 along with some tests. They're based on the existing `atLeast` assertion.