### PR TITLE
Ensure correct AssertionFailedError constructor is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add `assertThat` for Kotlin property based assertions.
 
+### Fixed
+- Fixed showing null expected/actual values in intellj when those values aren't provided. (#180)
 
 ## [0.13] - 2019-01-17
 

--- a/assertk-common/src/main/kotlin/assertk/assertions/support/support.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/support/support.kt
@@ -1,6 +1,7 @@
 package assertk.assertions.support
 
 import assertk.Assert
+import assertk.NONE
 import assertk.fail
 
 /**
@@ -66,7 +67,7 @@ fun <T> Assert<T>.fail(expected: Any?, actual: Any?) {
  *
  * -> "expected to be: <1> but was <2>"
  */
-fun <T> Assert<T>.expected(message: String, expected: Any? = null, actual: Any? = null): Nothing {
+fun <T> Assert<T>.expected(message: String, expected: Any? = NONE, actual: Any? = NONE): Nothing {
     val maybeSpace = if (message.startsWith(":")) "" else " "
     val maybeInstance = if (context != null) " ${show(context, "()")}" else ""
     fail(

--- a/assertk-common/src/main/kotlin/assertk/failure.kt
+++ b/assertk-common/src/main/kotlin/assertk/failure.kt
@@ -91,11 +91,21 @@ fun fail(error: AssertionError): Nothing {
     throw error
 }
 
+internal val NONE: Any = Any()
+
 /**
  * Fail the test with the given message.
  */
-fun fail(message: String, expected: Any? = null, actual: Any? = null): Nothing {
-    throw AssertionFailedError(message, expected, actual, null)
+fun fail(message: String, expected: Any? = NONE, actual: Any? = NONE): Nothing {
+    if (expected === NONE && actual === NONE) {
+        throw AssertionFailedError(message)
+    } else {
+        throw AssertionFailedError(
+            message,
+            if (expected === NONE) null else expected,
+            if (actual === NONE) null else actual
+        )
+    }
 }
 
 fun notifyFailure(e: Throwable) {

--- a/assertk-common/src/test/kotlin/test/assertk/FailureTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/FailureTest.kt
@@ -1,0 +1,35 @@
+package test.assertk
+
+import assertk.fail
+import com.willowtreeapps.opentest4k.*
+import kotlin.test.*
+
+
+class FailureTest {
+
+    @Test fun fail_throws_assertion_failed_error_with_actual_and_expected_present_and_defined() {
+        val error = assertFails {
+            fail("message", "expected", "actual")
+        }
+
+        assertEquals(AssertionFailedError::class, error::class)
+        error as AssertionFailedError
+        assertEquals("expected" as Any?, error.expected?.value)
+        assertEquals("actual" as Any?, error.actual?.value)
+        assertTrue(error.isExpectedDefined)
+        assertTrue(error.isActualDefined)
+    }
+
+    @Test fun fail_throws_assertion_failed_error_with_actual_and_expected_not_defined() {
+        val error = assertFails {
+            fail("message")
+        }
+
+        assertEquals(AssertionFailedError::class, error::class)
+        error as AssertionFailedError
+        assertNull(error.expected)
+        assertNull(error.actual)
+        assertFalse(error.isExpectedDefined)
+        assertFalse(error.isActualDefined)
+    }
+}

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/support/SupportTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/support/SupportTest.kt
@@ -1,8 +1,10 @@
 package test.assertk.assertions.support
 
+import assertk.assertThat
+import assertk.assertions.support.expected
 import assertk.assertions.support.show
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import com.willowtreeapps.opentest4k.*
+import kotlin.test.*
 
 class SupportTest {
     //region show
@@ -83,6 +85,34 @@ class SupportTest {
 
     @Test fun show_different_wrapper() {
         assertEquals("{42}", show(42, "{}"))
+    }
+    //endregion
+
+    //region expected
+    @Test fun expected_throws_assertion_failed_error_with_actual_and_expected_present_and_defined() {
+        val error = assertFails {
+            assertThat(0).expected("message", "expected", "actual")
+        }
+
+        assertEquals(AssertionFailedError::class, error::class)
+        error as AssertionFailedError
+        assertEquals("expected" as Any?, error.expected?.value)
+        assertEquals("actual" as Any?, error.actual?.value)
+        assertTrue(error.isExpectedDefined)
+        assertTrue(error.isActualDefined)
+    }
+
+    @Test fun expected_throws_assertion_failed_error_with_actual_and_expected_not_defined() {
+        val error = assertFails {
+            assertThat(0).expected("message")
+        }
+
+        assertEquals(AssertionFailedError::class, error::class)
+        error as AssertionFailedError
+        assertNull(error.expected)
+        assertNull(error.actual)
+        assertFalse(error.isExpectedDefined)
+        assertFalse(error.isActualDefined)
     }
     //endregion
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group 'com.willowtreeapps.assertk'
-    version '0.13'
+    version '0.14-SNAPSHOT'
 }
 
 buildscript {


### PR DESCRIPTION
This makes sure that intellij (and possibly others) don't show an
actual/expected diff when actual and expected values aren't provided.

Fixes #180