### PR TITLE
Add none assertion for iterables

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/iterable.kt
@@ -2,7 +2,6 @@ package assertk.assertions
 
 import assertk.Assert
 import assertk.all
-import assertk.all
 import assertk.assertions.support.expected
 import assertk.assertions.support.show
 
@@ -38,6 +37,24 @@ fun <E> Assert<Iterable<E>>.each(f: (Assert<E>) -> Unit) = given { actual ->
         actual.forEachIndexed { index, item ->
             f(assertThat(item, name = "${name ?: ""}${show(index, "[]")}"))
         }
+    }
+}
+
+/**
+ * Asserts on each item in the iterable, passing if none of the items pass.
+ * The given lambda will be run for each item.
+ *
+ * ```
+ * assertThat(listOf("one", "two")).none {
+ *   it.hasLength(2)
+ * }
+ * ```
+ */
+fun <E> Assert<Iterable<E>>.none(f: (Assert<E>) -> Unit) = given { actual ->
+    if (actual.count() > 0) {
+        all(message = "expected none to pass",
+                body = { each { item -> f(item) } },
+                failIf = { it.isEmpty() })
     }
 }
 

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/IterableTest.kt
@@ -55,6 +55,24 @@ class IterableTest {
     }
     //endregion
 
+    //region none
+    @Test fun none_empty_list_passes() {
+        assertThat(emptyList<Int>() as Iterable<Int>).none { it -> it.isEqualTo(1) }
+    }
+
+    @Test fun none_matching_content_fails() {
+        val error = assertFails {
+            assertThat(listOf(1, 2) as Iterable<Int>).none { it -> it.isGreaterThan(0) }
+        }
+        assertEquals("expected none to pass", error.message
+        )
+    }
+
+    @Test fun each_non_matching_content_passes() {
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).none { it -> it.isLessThan(2) }
+    }
+    //endregion
+
     //region atLeast
     @Test fun atLeast_too_many_failures_fails() {
         val error = assertFails {


### PR DESCRIPTION
I've added a none assertion for iterables and some tests. The behaviour should be the same as `noneMatch` in AssertJ.