### PR TITLE
Add experimental support for asserting on suspend functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group 'com.willowtreeapps.assertk'
-    version '0.16'
+    version '0.17-SNAPSHOT'
 }
 
 ext {
@@ -47,6 +47,9 @@ kotlin {
         compilations.main.kotlinOptions {
             jvmTarget = "1.8"
         }
+        compilations.test.kotlinOptions {
+            freeCompilerArgs += ["-Xuse-experimental=kotlin.Experimental"]
+        }
     }
     js {
         compilations.main.kotlinOptions {
@@ -62,11 +65,14 @@ kotlin {
     iosX64()
     macosX64('macos')
 
+    def kotlin_coroutines_version = '1.2.1'
+
     sourceSets {
         commonMain {
             dependencies {
                 implementation kotlin('stdlib-common')
                 implementation 'com.willowtreeapps.opentest4k:opentest4k:1.1.2'
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$kotlin_coroutines_version"
             }
             kotlin.srcDirs += files(compileTemplates)
         }
@@ -81,6 +87,7 @@ kotlin {
             dependencies {
                 implementation kotlin('stdlib-jdk8')
                 compileOnly kotlin('reflect')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
             }
         }
         jvmTest {
@@ -90,9 +97,17 @@ kotlin {
                 implementation kotlin('reflect')
             }
         }
+        coroutinesTestLite {
+            dependsOn(commonMain)
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$kotlin_coroutines_version"
+            }
+        }
         jsMain {
+            dependsOn(coroutinesTestLite)
             dependencies {
                 implementation kotlin('stdlib-js')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$kotlin_coroutines_version"
             }
         }
         jsTest {
@@ -102,6 +117,10 @@ kotlin {
         }
         nativeMain {
             dependsOn(commonMain)
+            dependsOn(coroutinesTestLite)
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-native:$kotlin_coroutines_version"
+            }
         }
         nativeTest {
             dependsOn(commonTest)
@@ -111,6 +130,26 @@ kotlin {
         }
         [linuxTest, iosArm64Test, iosX64Test, macosTest].each {
             it.dependsOn(nativeTest)
+        }
+        linuxMain {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-linuxx64:$kotlin_coroutines_version"
+            }
+        }
+        iosArm64Main {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosarm64:$kotlin_coroutines_version"
+            }
+        }
+        iosX64Main {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:$kotlin_coroutines_version"
+            }
+        }
+        macosMain {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:$kotlin_coroutines_version"
+            }
         }
     }
 }

--- a/src/commonMain/kotlin/assertk/assert.kt
+++ b/src/commonMain/kotlin/assertk/assert.kt
@@ -60,7 +60,11 @@ sealed class Assert<out T>(val name: String?, internal val context: Any?) {
      * assert(true, name = "true").isTrue()
      * ```
      */
-    @Deprecated("Renamed assertThat", replaceWith = ReplaceWith("assertThat(actual, name)"), level = DeprecationLevel.ERROR)
+    @Deprecated(
+        "Renamed assertThat",
+        replaceWith = ReplaceWith("assertThat(actual, name)"),
+        level = DeprecationLevel.ERROR
+    )
     fun <R> assert(actual: R, name: String? = this.name): Assert<R> = assertThat(actual, name)
 
     /**
@@ -73,7 +77,10 @@ sealed class Assert<out T>(val name: String?, internal val context: Any?) {
     abstract fun <R> assertThat(actual: R, name: String? = this.name): Assert<R>
 
     @Suppress("DeprecatedCallableAddReplaceWith")
-    @Deprecated(message = "Use `given` or `transform` to access the actual value instead", level = DeprecationLevel.ERROR)
+    @Deprecated(
+        message = "Use `given` or `transform` to access the actual value instead",
+        level = DeprecationLevel.ERROR
+    )
     val actual: T
         get() = when (this) {
             is ValueAssert -> value
@@ -179,7 +186,8 @@ fun <T> assertThat(actual: T, name: String? = null): Assert<T> = ValueAssert(act
  * ```
  */
 fun <T> assertThat(getter: KProperty0<T>, name: String? = null): Assert<T> =
-        assertThat(getter.get(), name ?: getter.name)
+    assertThat(getter.get(), name ?: getter.name)
+
 
 /**
  * All assertions in the given lambda are run.

--- a/src/commonMain/kotlin/assertk/coroutines/assert.kt
+++ b/src/commonMain/kotlin/assertk/coroutines/assert.kt
@@ -1,0 +1,7 @@
+package assertk.coroutines
+
+import assertk.AssertBlock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@ExperimentalCoroutinesApi
+expect fun <T> assertThat(f: suspend () -> T): AssertBlock<T>

--- a/src/commonMain/kotlin/assertk/failure.kt
+++ b/src/commonMain/kotlin/assertk/failure.kt
@@ -16,6 +16,10 @@ internal object FailureContext {
      * created.
      */
     fun <T> run(failure: Failure, f: () -> T): T {
+        return runInline(failure, f)
+    }
+
+    inline fun <T> runInline(failure: Failure, f: () -> T): T {
         val currentFailure = failureRef.value
         if (currentFailure is SimpleFailure) {
             failureRef.value = failure

--- a/src/commonTest/kotlin/test/assertk/coroutines/AssertCoroutineTest.kt
+++ b/src/commonTest/kotlin/test/assertk/coroutines/AssertCoroutineTest.kt
@@ -1,0 +1,108 @@
+package test.assertk.coroutines
+
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNegative
+import assertk.assertions.message
+import assertk.assertions.support.show
+import assertk.coroutines.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+@UseExperimental(ExperimentalCoroutinesApi::class)
+class AssertCoroutineTest {
+
+    val returnSubject = assertThat {
+        suspendAndReturn(background = coroutineContext, main = coroutineContext)
+    }
+    val errorSubject = assertThat { suspendAndThrow() }
+
+    suspend fun suspendAndReturn(
+        background: CoroutineContext = Dispatchers.Default,
+        main: CoroutineContext = Dispatchers.Main
+    ): Int {
+        withContext(background) {
+            delay(10000)
+        }
+        return withContext(main) {
+            1 + 1
+        }
+    }
+
+    suspend fun suspendAndThrow(): Int {
+        delay(10000)
+        throw Exception("test")
+    }
+
+    //region returnedValue
+    @Test fun returnedValue_successful_assertion_passes() {
+        returnSubject.returnedValue { isEqualTo(2) }
+    }
+
+    @Test fun returnedValue_unsuccessful_assertion_fails() {
+        val error = assertFails {
+            returnSubject.returnedValue { isNegative() }
+        }
+        assertEquals("expected to be negative but was:<2>", error.message)
+    }
+
+    @Test fun returnedValue_exception_in_block_fails() {
+        val error = assertFails {
+            errorSubject.returnedValue { }
+        }
+        assertEquals("expected value but threw:${show(Exception("test"))}", error.message!!.lineSequence().first())
+    }
+    //endregion
+
+    //region thrownError
+    @Test fun thrownError_successful_assertion_passes() {
+        errorSubject.thrownError {
+            message().isEqualTo("test")
+        }
+    }
+
+    @Test fun thrownError_unsuccessful_assertion_fails() {
+        val error = assertFails {
+            errorSubject.thrownError {
+                message().isEqualTo("wrong")
+            }
+        }
+        assertEquals(
+            "expected [message]:<\"[wrong]\"> but was:<\"[test]\"> ${show(Exception("test"), "()")}",
+            error.message
+        )
+    }
+
+    @Test fun thrownError_no_exception_in_block_fails() {
+        val error = assertFails {
+            returnSubject.thrownError {
+                message().isEqualTo("error")
+            }
+        }
+        assertEquals("expected exception but was:<2>", error.message)
+    }
+    //endregion
+
+    //region doesNotThrowAnyException
+    @Test fun doesNotThrowAnyException_no_exception_passes() {
+        returnSubject.doesNotThrowAnyException()
+    }
+
+    @Test fun doesNotThrowAnyException_exception_fails() {
+        val error = assertFails {
+            errorSubject.doesNotThrowAnyException()
+        }
+
+        assertEquals(
+            "expected to not throw an exception but threw:${show(Exception("test"))}",
+            error.message!!.lineSequence().first()
+        )
+    }
+    //endregion
+}

--- a/src/coroutinesTestLite/kotlin/assertk/coroutines/assertk.kt
+++ b/src/coroutinesTestLite/kotlin/assertk/coroutines/assertk.kt
@@ -1,0 +1,84 @@
+package assertk.coroutines
+
+import assertk.AssertBlock
+import kotlinx.coroutines.*
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+@ExperimentalCoroutinesApi
+@UseExperimental(InternalCoroutinesApi::class)
+actual fun <T> assertThat(f: suspend () -> T): AssertBlock<T> {
+    val dispatcher = TestCoroutineDispatcher()
+    val job = SupervisorJob()
+    val context = EmptyCoroutineContext + dispatcher + job
+    val startingJobs = context.activeJobs()
+    val scope = CoroutineScope(context)
+    val deferred = scope.async {
+        f()
+    }
+
+    dispatcher.advanceUntilIdle()
+
+    val result: AssertBlock<T>
+
+    val error = deferred.getCompletionExceptionOrNull()
+
+    if (error != null) {
+        result = AssertBlock.Error(error)
+    } else {
+        result = AssertBlock.Value(deferred.getCompleted())
+    }
+
+    val endingJobs = context.activeJobs()
+    if ((endingJobs - startingJobs).isNotEmpty()) {
+        throw AssertionError("Test finished with active jobs: $endingJobs")
+    }
+
+    return result
+}
+
+private fun CoroutineContext.activeJobs(): Set<Job> {
+    return checkNotNull(this[Job]).children.filter { it.isActive }.toSet()
+}
+
+@InternalCoroutinesApi
+@ExperimentalCoroutinesApi
+private class TestCoroutineDispatcher : CoroutineDispatcher(), Delay {
+
+    private val queue = mutableListOf<Runnable>()
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        block.run()
+    }
+
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        queue.add(CancellableContinuationRunnable(continuation) { resumeUndispatched(Unit) })
+    }
+
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable): DisposableHandle {
+        queue.add(block)
+        return object : DisposableHandle {
+            override fun dispose() {
+                queue.remove(block)
+            }
+        }
+    }
+
+    fun advanceUntilIdle() {
+        for (block in queue) {
+            block.run()
+        }
+        queue.clear()
+    }
+}
+
+/**
+ * This class exists to allow cleanup code to avoid throwing for cancelled continuations scheduled
+ * in the future.
+ */
+private class CancellableContinuationRunnable<T>(
+    val continuation: CancellableContinuation<T>,
+    private val block: CancellableContinuation<T>.() -> Unit
+) : Runnable {
+    override fun run() = continuation.block()
+}

--- a/src/jvmMain/kotlin/assertk/coroutines/assertk.kt
+++ b/src/jvmMain/kotlin/assertk/coroutines/assertk.kt
@@ -1,0 +1,50 @@
+package assertk.coroutines
+
+import assertk.AssertBlock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineExceptionHandler
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.UncompletedCoroutinesError
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+@ExperimentalCoroutinesApi
+actual fun <T> assertThat(f: suspend () -> T): AssertBlock<T> {
+    val handler = TestCoroutineExceptionHandler()
+    val dispatcher = TestCoroutineDispatcher()
+    val job = SupervisorJob()
+    val context = EmptyCoroutineContext + dispatcher + handler + job
+    val startingJobs = context.activeJobs()
+    val scope = TestCoroutineScope(context)
+    val deferred = scope.async {
+        f()
+    }
+
+    dispatcher.advanceUntilIdle()
+
+    val result: AssertBlock<T>
+
+    val error = deferred.getCompletionExceptionOrNull()
+
+    if (error != null) {
+        result = AssertBlock.Error(error)
+    } else {
+        result = AssertBlock.Value(deferred.getCompleted())
+    }
+
+    scope.cleanupTestCoroutines()
+    val endingJobs = context.activeJobs()
+    if ((endingJobs - startingJobs).isNotEmpty()) {
+        throw UncompletedCoroutinesError("Test finished with active jobs: $endingJobs")
+    }
+
+    return result
+}
+
+private fun CoroutineContext.activeJobs(): Set<Job> {
+    return checkNotNull(this[Job]).children.filter { it.isActive }.toSet()
+}


### PR DESCRIPTION
If you have a function like
```kotlin
suspend fun doThing(): String = ...
```

There's a new variant of `assertThat` what can assert on it, running the coroutine implementation eagerly. It returns an `AssertBlock` so you can use the same validation methods as the `assertThat` that takes a lambda.
```kotlin
import assertk.coroutines.assertThat

assertThat { doThing() }.returnedValue { isEqualTo("test") }
```

Open questions:
1. Using the same name is nice visually but can cause ambiguities if you have both versions imported in the same class.
2. Should this be a separate artifact?
