### PR TITLE
Assert that inline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,16 @@ kotlin {
     iosX64()
     macosX64('macos')
 
+    targets.all {
+        if (name != 'metadata') {
+            compilations.test.kotlinOptions {
+                freeCompilerArgs += ["-Xuse-experimental=kotlin.Experimental"]
+            }
+        }
+    }
+
+    def kotlin_coroutines_version = '1.2.1'
+
     sourceSets {
         commonMain {
             dependencies {
@@ -91,6 +101,7 @@ kotlin {
                 implementation project('java-interop')
                 implementation kotlin('test-junit')
                 implementation kotlin('reflect')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
             }
         }
         jsMain {
@@ -104,6 +115,7 @@ kotlin {
         jsTest {
             dependencies {
                 implementation kotlin('test-js')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$kotlin_coroutines_version"
             }
         }
         nativeMain {
@@ -117,6 +129,26 @@ kotlin {
         }
         [linuxTest, iosArm64Test, iosX64Test, macosTest].each {
             it.dependsOn(nativeTest)
+        }
+        linuxTest {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-linuxx64:$kotlin_coroutines_version"
+            }
+        }
+        iosArm64Test {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosarm64:$kotlin_coroutines_version"
+            }
+        }
+        iosX64Test {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:$kotlin_coroutines_version"
+            }
+        }
+        macosTest {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:$kotlin_coroutines_version"
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group 'com.willowtreeapps.assertk'
-    version '0.17'
+    version '0.18-SNAPSHOT'
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ kotlin {
         compilations.main.kotlinOptions {
             jvmTarget = "1.8"
         }
+        compilations.test.kotlinOptions {
+            jvmTarget = "1.8"
+        }
     }
     js {
         compilations.main.kotlinOptions {

--- a/src/commonMain/kotlin/assertk/table.kt
+++ b/src/commonMain/kotlin/assertk/table.kt
@@ -87,7 +87,7 @@ sealed class Table(internal val columnNames: Array<String>) {
     }
 
     protected fun forAll(f: TableFun) {
-        FailureContext.run(TableFailure(this)) {
+        TableFailure(this).run {
             for (i in 0 until rows.size) {
                 index = i
                 f(rows[i])

--- a/src/commonTest/kotlin/test/assertk/AssertBlockTest.kt
+++ b/src/commonTest/kotlin/test/assertk/AssertBlockTest.kt
@@ -29,7 +29,7 @@ class AssertBlockTest {
 
     @Test fun returnedValue_exception_in_block_fails() {
         val error = assertFails {
-            errorSubject.returnedValue {  }
+            errorSubject.returnedValue { }
         }
         assertEquals("expected value but threw:${show(Exception("test"))}", error.message!!.lineSequence().first())
     }
@@ -74,7 +74,10 @@ class AssertBlockTest {
             errorSubject.doesNotThrowAnyException()
         }
 
-        assertEquals("expected to not throw an exception but threw:${show(Exception("test"))}", error.message!!.lineSequence().first())
+        assertEquals(
+            "expected to not throw an exception but threw:${show(Exception("test"))}",
+            error.message!!.lineSequence().first()
+        )
     }
     //endregion
 }

--- a/src/jsTest/kotlin/test/assertk/JSAssertBlockTest.kt
+++ b/src/jsTest/kotlin/test/assertk/JSAssertBlockTest.kt
@@ -1,8 +1,13 @@
 package test.assertk
 
 import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
 import assertk.assertions.isPositive
 import assertk.assertions.support.show
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -11,7 +16,6 @@ class JSAssertBlockTest {
 
     private val errorSubject = assertThat { throw Exception("test") }
 
-    //region thrown error
     @Test fun returnedValue_exception_in_block_fails() {
         val error = assertFails {
             errorSubject.returnedValue {
@@ -31,5 +35,28 @@ class JSAssertBlockTest {
             error.message
         )
     }
-    //endregion
+
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @Test fun returnedValue_works_in_coroutine_test() = GlobalScope.promise {
+        assertThat {
+            asyncReturnValue()
+        }.returnedValue { isEqualTo(1) }
+    }
+
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @Test fun returnedValue_exception_works_in_coroutine_test() = GlobalScope.promise {
+        assertThat {
+            asyncThrows()
+        }.thrownError { hasMessage("test") }
+    }
+
+    @Suppress("RedundantSuspendModifier")
+    private suspend fun asyncReturnValue(): Int {
+        return 1
+    }
+
+    @Suppress("RedundantSuspendModifier")
+    private suspend fun asyncThrows() {
+        throw  Exception("test")
+    }
 }

--- a/src/nativeTest/kotlin/test/assertk/NativeAssertBlockTest.kt
+++ b/src/nativeTest/kotlin/test/assertk/NativeAssertBlockTest.kt
@@ -1,0 +1,39 @@
+package test.assertk
+
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+
+class NativeAssertBlockTest {
+
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @Test fun returnedValue_works_in_coroutine_test() {
+        runBlocking {
+            assertThat {
+                asyncReturnValue()
+            }.returnedValue { isEqualTo(1) }
+        }
+    }
+
+    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @Test fun returnedValue_exception_works_in_coroutine_test() {
+        runBlocking {
+            assertThat {
+                asyncThrows()
+            }.thrownError { hasMessage("test") }
+        }
+    }
+
+    @Suppress("RedundantSuspendModifier")
+    private suspend fun asyncReturnValue(): Int {
+        return 1
+    }
+
+    @Suppress("RedundantSuspendModifier")
+    private suspend fun asyncThrows() {
+        throw  Exception("test")
+    }
+}


### PR DESCRIPTION
Alternative to #201, making the existing `assertThat {}` inline so that it can work with existing coroutine testing functionally. While harder to write tests for multiplatform code, it should be more robust and side-steps the issues with the other solution. Hopefully the official tools for testing coroutines will improve (they are marked experimental now anyway).