### PR TITLE
Better display of pairs and triples

### DIFF
--- a/src/commonMain/kotlin/assertk/assertions/support/support.kt
+++ b/src/commonMain/kotlin/assertk/assertions/support/support.kt
@@ -36,6 +36,8 @@ internal fun display(value: Any?): String {
         is ShortArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is ByteArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
         is FloatArray -> value.joinToString(prefix = "[", postfix = "]", transform = ::display)
+        is Pair<*, *> -> "(${display(value.first)}, ${display(value.second)})"
+        is Triple<*, *, *> -> "(${display(value.first)}, ${display(value.second)}, ${display(value.third)})"
         else -> displayPlatformSpecific(value)
     }
 }

--- a/src/commonTest/kotlin/test/assertk/assertions/support/SupportTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/support/SupportTest.kt
@@ -77,6 +77,14 @@ class SupportTest {
         assertEquals("<{1=5, 2=6}>", show(mapOf(1 to 5, 2 to 6)))
     }
 
+    @Test fun show_pair() {
+        assertEquals("<(\"one\", '2')>", show("one" to '2'))
+    }
+
+    @Test fun show_triple() {
+        assertEquals("<(\"one\", '2', 3)>", show(Triple("one", '2', 3)))
+    }
+
     @Test fun show_custom_type() {
         val other = object : Any() {
             override fun toString(): String = "different"
@@ -130,7 +138,10 @@ class SupportTest {
             )
         }
 
-        assertEquals("expected:<...is is a long prefix [1] this is a long suff...> but was:<...is is a long prefix [2] this is a long suff...>", error.message)
+        assertEquals(
+            "expected:<...is is a long prefix [1] this is a long suff...> but was:<...is is a long prefix [2] this is a long suff...>",
+            error.message
+        )
     }
     //endregion
 


### PR DESCRIPTION
Like lists and maps, it'll display the contentens inside to make your
types more clear, so for `"one" to '2'` you'll now get `("one", '2')`
isntead of `(one, 2)`.