### PR TITLE
Deprected catch in favor of assertThat {}.isFailure()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ You can migrate by:
   2. Alt-enter on the deprecated version of above and choose replace with...
   3. If your expression only has 1 value, you can replace ex: `isSucess().all { isEqualTo(1) }` with `isSuccess().isEqualTo(1)`
 
+### Deprecated
+- Deprecated `catch` in favor of `assertThat {}.isFailure()`
+
 ## [0.17] 2019-05-29
 
 ### Fixed

--- a/src/commonMain/kotlin/assertk/assert.kt
+++ b/src/commonMain/kotlin/assertk/assert.kt
@@ -326,6 +326,7 @@ inline fun assertAll(f: () -> Unit) {
  * ```
  */
 @Suppress("TooGenericExceptionCaught")
+@Deprecated("Use assertThat { }.isFailure() instead")
 inline fun catch(f: () -> Unit): Throwable? {
     try {
         f()


### PR DESCRIPTION
 #219