### PR TITLE
Add optional equivalent function for isEqualTo/isNotEqualTo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group 'com.willowtreeapps.assertk'
-    version '0.19'
+    version '0.20-SNAPSHOT'
 }
 
 ext {
@@ -324,8 +324,8 @@ publishing {
         }
 
         all {
-            def siteUrl = 'https://github.com/willowtreeapps/opentest4k'
-            def gitUrl = 'https://github.com/willowtreeapps/opentest4k.git'
+            def siteUrl = 'https://github.com/willowtreeapps/assertk'
+            def gitUrl = 'https://github.com/willowtreeapps/assertk.git'
 
             pom {
                 name = project.name

--- a/src/commonMain/kotlin/assertk/assertions/any.kt
+++ b/src/commonMain/kotlin/assertk/assertions/any.kt
@@ -121,7 +121,11 @@ fun <T : Any> Assert<T?>.isNull() = given { actual ->
  * }
  * ```
  */
-@Deprecated(message = "Use isNotNull() instead", replaceWith = ReplaceWith("isNotNull().let(f)"), level = DeprecationLevel.ERROR)
+@Deprecated(
+    message = "Use isNotNull() instead",
+    replaceWith = ReplaceWith("isNotNull().let(f)"),
+    level = DeprecationLevel.ERROR
+)
 fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit) {
     isNotNull().let(f)
 }
@@ -190,7 +194,11 @@ fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) = given { actual 
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
-@Deprecated(message = "Use isInstanceOf(kclass) instead.", replaceWith = ReplaceWith("isInstanceOf(kclass).let(f)"), level = DeprecationLevel.ERROR)
+@Deprecated(
+    message = "Use isInstanceOf(kclass) instead.",
+    replaceWith = ReplaceWith("isInstanceOf(kclass).let(f)"),
+    level = DeprecationLevel.ERROR
+)
 fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: (Assert<S>) -> Unit) {
     isInstanceOf(kclass).let(f)
 }
@@ -207,6 +215,37 @@ fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>) = transform(name)
         actual as S
     } else {
         expected("to be instance of:${show(kclass)} but had class:${show(actual::class)}")
+    }
+}
+
+/**
+ * Asserts the value corresponds to the expected one using the given correspondence function to compare them. This is
+ * useful when the objects don't have an [equals] implementation.
+ *
+ * @see [isEqualTo]
+ * @see [doesNotCorrespond]
+ */
+fun <T, E> Assert<T>.corresponds(expected: E, correspondence: (T, E) -> Boolean) = given { actual ->
+    if (correspondence(actual, expected)) return
+    fail(expected, actual)
+}
+
+/**
+ * Asserts the value does not correspond to the expected one using the given correspondence function to compare them.
+ * This is useful when the objects don't have an [equals] implementation.
+ *
+ * @see [corresponds]
+ * @see [isNotEqualTo]
+ */
+fun <T, E> Assert<T>.doesNotCorrespond(expected: E, correspondence: (T, E) -> Boolean) = given { actual ->
+    if (!correspondence(actual, expected)) return
+    val showExpected = show(expected)
+    val showActual = show(actual)
+    // if they display the same, only show one.
+    if (showExpected == showActual) {
+        expected("to not be equal to:$showActual")
+    } else {
+        expected(":$showExpected not to be equal to:$showActual")
     }
 }
 

--- a/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
@@ -314,6 +314,28 @@ class AnyTest {
         assertEquals("expected to not be instance of:<${TestObject::class}>", error.message)
     }
 
+    @Test fun corresponds_equivalent_passes() {
+        assertThat(subject).corresponds(BasicObject("different")) { _, _ -> true }
+    }
+
+    @Test fun corresponds_not_equivalent_fails() {
+        val error = assertFails {
+            assertThat(subject).corresponds(BasicObject("test")) { _, _ -> false }
+        }
+        assertEquals("expected:<test> but was:<test>", error.message)
+    }
+
+    @Test fun doesNotCorrespond_equivalent_passes() {
+        assertThat(subject).doesNotCorrespond(BasicObject("different")) { _, _ -> false }
+    }
+
+    @Test fun doesNotCorrespond_not_equivalent_fails() {
+        val error = assertFails {
+            assertThat(subject).doesNotCorrespond(BasicObject("different")) { _, _ -> true }
+        }
+        assertEquals("expected:<different> not to be equal to:<test>", error.message)
+    }
+
     companion object {
         open class TestObject
 


### PR DESCRIPTION
Sometimes you want to compare objects that don't have a proper equals
implementation. This makes it simpler to implement this. Ex:

```kotlin
fun Assert<CharSequence>.isEqualTo(other: CharSequence) {
    isEqualTo(other) { a, b -> a.toString() == b.toString() }
}
```