### PR TITLE
Change the signature of `isEqualTo` from Any? to T

### DIFF
--- a/src/commonMain/kotlin/assertk/assertions/any.kt
+++ b/src/commonMain/kotlin/assertk/assertions/any.kt
@@ -28,7 +28,7 @@ fun Assert<Any>.hashCodeFun() = prop("hashCode", Any::hashCode)
  * @see [isNotEqualTo]
  * @see [isSameAs]
  */
-fun Assert<Any?>.isEqualTo(expected: Any?) = given { actual ->
+fun <T> Assert<T>.isEqualTo(expected: T) = given { actual ->
     if (actual == expected) return
     fail(expected, actual)
 }
@@ -120,7 +120,11 @@ fun Assert<Any?>.isNull() = given { actual ->
  * }
  * ```
  */
-@Deprecated(message = "Use isNotNull() instead", replaceWith = ReplaceWith("isNotNull().let(f)"), level = DeprecationLevel.ERROR)
+@Deprecated(
+    message = "Use isNotNull() instead",
+    replaceWith = ReplaceWith("isNotNull().let(f)"),
+    level = DeprecationLevel.ERROR
+)
 fun <T : Any> Assert<T?>.isNotNull(f: (Assert<T>) -> Unit) {
     isNotNull().let(f)
 }
@@ -189,7 +193,11 @@ fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) = given { actual 
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
-@Deprecated(message = "Use isInstanceOf(kclass) instead.", replaceWith = ReplaceWith("isInstanceOf(kclass).let(f)"), level = DeprecationLevel.ERROR)
+@Deprecated(
+    message = "Use isInstanceOf(kclass) instead.",
+    replaceWith = ReplaceWith("isInstanceOf(kclass).let(f)"),
+    level = DeprecationLevel.ERROR
+)
 fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>, f: (Assert<S>) -> Unit) {
     isInstanceOf(kclass).let(f)
 }

--- a/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
@@ -35,6 +35,19 @@ class AnyTest {
         assertEquals("expected:<[not ]test> but was:<[]test>", error.message)
     }
 
+    @Test fun isEqualTo_will_compile_comparing_various_types() {
+        assertThat(1).isEqualTo(1)
+        assertThat(1 as Int?).isEqualTo(1)
+        assertThat(1).isEqualTo(1 as Int?)
+        val obj = DifferentObject()
+        assertThat(obj).isEqualTo(obj)
+        assertThat(obj as TestObject).isEqualTo(obj)
+        assertThat(obj).isEqualTo(obj as TestObject)
+        assertFails {
+            assertThat(1).isEqualTo("string")
+        }
+    }
+
     @Test fun isNotEqualTo_non_equal_objects_passes() {
         val nonEqual = BasicObject("not test")
         assertThat(subject).isNotEqualTo(nonEqual)

--- a/src/commonTest/kotlin/test/assertk/assertions/NumberTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/NumberTest.kt
@@ -1,10 +1,7 @@
 package test.assertk.assertions
 
 import assertk.assertThat
-import assertk.assertions.isNegative
-import assertk.assertions.isNotZero
-import assertk.assertions.isPositive
-import assertk.assertions.isZero
+import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -74,6 +71,15 @@ class NumberTest {
             assertThat(1).isNegative()
         }
         assertEquals("expected to be negative but was:<1>", error.message)
+    }
+    //endregion
+
+    //region isEqualTo
+    @Test fun isEqualTo_number_literal_is_inferred_based_on_type() {
+        assertThat(1.toByte()).isEqualTo(1)
+        assertThat(1.toShort()).isEqualTo(1)
+        assertThat(1).isEqualTo(1)
+        assertThat(1L).isEqualTo(1)
     }
     //endregion
 }


### PR DESCRIPTION
You may think this wouldn't make a difference since T is covariant so
you can pass any anything as they share the same super-type `Any?`.
However, there _is_ a case where this is different and it has do with
kotliln's type inference on literal numbers.

If you have a literal number like `1` in the source code, kotlin will
try to infer it's type (byte, short, int, long) based on where it's
used. Ex: `val b: Byte = 1`. If it can't infer, it'll default to int.

By changing to use a generic type param instead of `Any?` for the
expected value, kotlin will now be able to infer the type.

Before this change:

```kotlin
assertThat(1L).isEqualTo(1)
```
would fail with `expected:<1[]> but was:<1[L]>`.

After this change:

```kotlin
assertThat(1L).isEqualTo(1)
```
passes.

I think this is worth doing because you don't have to worry about
specifying the type for the number literal in the common case that you
provide it directly. This matches other uses of them pretty well.