### PR TITLE
Use a proper stack for soft failures so they compose correctly

### DIFF
--- a/src/commonMain/kotlin/assertk/assert.kt
+++ b/src/commonMain/kotlin/assertk/assert.kt
@@ -278,7 +278,7 @@ fun <T> Assert<T>.all(body: Assert<T>.() -> Unit) {
 internal fun <T> Assert<T>.all(
     message: String,
     body: Assert<T>.() -> Unit,
-    failIf: (List<AssertionError>) -> Boolean
+    failIf: (List<Throwable>) -> Boolean
 ) {
     SoftFailure(message, failIf).run {
         body()

--- a/src/commonMain/kotlin/assertk/table.kt
+++ b/src/commonMain/kotlin/assertk/table.kt
@@ -3,9 +3,9 @@ package assertk
 import assertk.assertions.support.show
 
 private class TableFailure(private val table: Table) : Failure {
-    private val failures: MutableMap<Int, MutableList<AssertionError>> = LinkedHashMap()
+    private val failures: MutableMap<Int, MutableList<Throwable>> = LinkedHashMap()
 
-    override fun fail(error: AssertionError) {
+    override fun fail(error: Throwable) {
         failures.getOrPut(table.index, { ArrayList() }).plusAssign(error)
     }
 
@@ -15,14 +15,14 @@ private class TableFailure(private val table: Table) : Failure {
         }
     }
 
-    private fun compositeErrorMessage(errors: Map<Int, List<AssertionError>>): AssertionError {
+    private fun compositeErrorMessage(errors: Map<Int, List<Throwable>>): AssertionError {
         return TableFailuresError(table, errors)
     }
 }
 
 internal class TableFailuresError(
     private val table: Table,
-    private val errors: Map<Int, List<AssertionError>>
+    private val errors: Map<Int, List<Throwable>>
 ) : AssertionError() {
     override val message: String?
         get() {

--- a/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
@@ -1,5 +1,6 @@
 package test.assertk.assertions
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
@@ -57,12 +58,12 @@ class IterableTest {
 
     //region none
     @Test fun none_empty_list_passes() {
-        assertThat(emptyList<Int>() as Iterable<Int>).none { it -> it.isEqualTo(1) }
+        assertThat(emptyList<Int>() as Iterable<Int>).none { it.isEqualTo(1) }
     }
 
     @Test fun none_matching_content_fails() {
         val error = assertFails {
-            assertThat(listOf(1, 2) as Iterable<Int>).none { it -> it.isGreaterThan(0) }
+            assertThat(listOf(1, 2) as Iterable<Int>).none { it.isGreaterThan(0) }
         }
         assertEquals(
             "expected none to pass", error.message
@@ -70,14 +71,14 @@ class IterableTest {
     }
 
     @Test fun each_non_matching_content_passes() {
-        assertThat(listOf(1, 2, 3) as Iterable<Int>).none { it -> it.isLessThan(2) }
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).none { it.isLessThan(2) }
     }
     //endregion
 
     //region atLeast
     @Test fun atLeast_too_many_failures_fails() {
         val error = assertFails {
-            assertThat(listOf(1, 2, 3)).atLeast(2) { it -> it.isGreaterThan(2) }
+            assertThat(listOf(1, 2, 3)).atLeast(2) { it.isGreaterThan(2) }
         }
         assertEquals(
             """expected to pass at least 2 times (2 failures)
@@ -88,18 +89,22 @@ class IterableTest {
     }
 
     @Test fun atLeast_no_failures_passes() {
-        assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(0) }
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it.isGreaterThan(0) }
     }
 
     @Test fun atLeast_less_than_times_failures_passes() {
-        assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it -> it.isGreaterThan(1) }
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it.isGreaterThan(1) }
+    }
+
+    @Test fun atLeast_works_in_a_soft_assert_context() {
+        assertThat(listOf(1, 2,3) as Iterable<Int>).all { atLeast(2) { it.isGreaterThan(1) } }
     }
     //endregion
 
     //region atMost
     @Test fun atMost_more_than_times_passed_fails() {
         val error = assertFails {
-            assertThat(listOf(1, 2, 3) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(0) }
+            assertThat(listOf(1, 2, 3) as Iterable<Int>).atMost(2) { it.isGreaterThan(0) }
         }
         assertEquals(
             """expected to pass at most 2 times""".trimMargin(), error.message
@@ -107,12 +112,12 @@ class IterableTest {
     }
 
     @Test fun atMost_exactly_times_passed_passes() {
-        assertThat(listOf(1, 2, 3) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(1) }
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).atMost(2) { it.isGreaterThan(1) }
     }
 
 
     @Test fun atMost_less_than_times_passed_passes() {
-        assertThat(listOf(1, 2) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(1) }
+        assertThat(listOf(1, 2) as Iterable<Int>).atMost(2) { it.isGreaterThan(1) }
     }
     //endregion
 
@@ -120,7 +125,7 @@ class IterableTest {
     //region exactly
     @Test fun exactly_too_few_passes_fails() {
         val error = assertFails {
-            assertThat(listOf(1, 2, 3)).exactly(2) { it -> it.isGreaterThan(2) }
+            assertThat(listOf(1, 2, 3)).exactly(2) { it.isGreaterThan(2) }
         }
         assertEquals(
             """expected to pass exactly 2 times (2 failures)
@@ -132,7 +137,7 @@ class IterableTest {
 
     @Test fun exactly_too_many_passes_fails() {
         val error = assertFails {
-            assertThat(listOf(5, 4, 3)).exactly(2) { it -> it.isGreaterThan(2) }
+            assertThat(listOf(5, 4, 3)).exactly(2) { it.isGreaterThan(2) }
         }
         assertEquals(
             """expected to pass exactly 2 times""".trimMargin(), error.message
@@ -140,7 +145,7 @@ class IterableTest {
     }
 
     @Test fun exactly_times_passed_passes() {
-        assertThat(listOf(1, 2) as Iterable<Int>).atMost(2) { it -> it.isGreaterThan(0) }
+        assertThat(listOf(1, 2) as Iterable<Int>).atMost(2) { it.isGreaterThan(0) }
     }
 
     //endregion

--- a/src/jsMain/kotlin/assertk/failure.kt
+++ b/src/jsMain/kotlin/assertk/failure.kt
@@ -1,7 +1,7 @@
 package assertk
 
 @Suppress("NOTHING_TO_INLINE")
-internal actual inline fun failWithNotInStacktrace(error: AssertionError): Nothing {
+internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
     throw error
 }
 

--- a/src/jvmMain/kotlin/assertk/failure.kt
+++ b/src/jvmMain/kotlin/assertk/failure.kt
@@ -3,7 +3,7 @@
 package assertk
 
 @Suppress("NOTHING_TO_INLINE")
-internal actual inline fun failWithNotInStacktrace(error: AssertionError): Nothing {
+internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
     val filtered = error.stackTrace
         .dropWhile { it.className.startsWith("assertk") }
         .toTypedArray()

--- a/src/nativeMain/kotlin/assertk/failure.kt
+++ b/src/nativeMain/kotlin/assertk/failure.kt
@@ -4,7 +4,7 @@ import kotlin.native.concurrent.ThreadLocal
 import kotlin.native.concurrent.AtomicInt
 
 @Suppress("NOTHING_TO_INLINE")
-internal actual inline fun failWithNotInStacktrace(error: AssertionError): Nothing {
+internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
     throw error
 }
 


### PR DESCRIPTION
Before pushing a soft failure when there was none would be ignored. This
causes a problem when using the failIf feature as that condition will be
ignored too.

Fixes #253