### PR TITLE
Add multi-value support for String contains assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Add `Assert<String>.containsAll()` assertions
+- Add `Assert<String>.containsSubstrings()` assertions
 
 ## [0.21] 2020-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add `Assert<String>.containsAll()` assertions
+
 ## [0.21] 2020-01-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Add `Assert<String>.containsSubstrings()` assertions
+- Add multi-value support for `Assert<String>.contains()` and `doesNotContain()`
 
 ## [0.21] 2020-01-22
 

--- a/src/commonMain/kotlin/assertk/assertions/string.kt
+++ b/src/commonMain/kotlin/assertk/assertions/string.kt
@@ -1,6 +1,7 @@
 package assertk.assertions
 
 import assertk.Assert
+import assertk.assertAll
 import assertk.assertions.support.expected
 import assertk.assertions.support.fail
 import assertk.assertions.support.show
@@ -51,15 +52,15 @@ fun Assert<String>.contains(other: CharSequence, ignoreCase: Boolean = false) = 
  * Asserts the string contains the expected strings.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
-fun Assert<String>.containsAll(expected: List<String>, ignoreCase: Boolean = false) {
-    containsAll(*expected.toTypedArray(), ignoreCase)
+fun Assert<String>.containsSubstrings(vararg expected: String, ignoreCase: Boolean = false) {
+    containsSubstrings(expected.toList(), ignoreCase)
 }
 
 /**
  * Asserts the string contains the expected strings.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
-fun Assert<String>.containsAll(vararg expected: String, ignoreCase: Boolean = false) {
+fun Assert<String>.containsSubstrings(expected: List<String>, ignoreCase: Boolean = false) {
     assertAll {
         expected.forEach {
             contains(it, ignoreCase)

--- a/src/commonMain/kotlin/assertk/assertions/string.kt
+++ b/src/commonMain/kotlin/assertk/assertions/string.kt
@@ -48,6 +48,26 @@ fun Assert<String>.contains(other: CharSequence, ignoreCase: Boolean = false) = 
 }
 
 /**
+ * Asserts the string contains the expected strings.
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<String>.containsAll(expected: List<String>, ignoreCase: Boolean = false) {
+    containsAll(*expected.toTypedArray(), ignoreCase)
+}
+
+/**
+ * Asserts the string contains the expected strings.
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<String>.containsAll(vararg expected: String, ignoreCase: Boolean = false) {
+    assertAll {
+        expected.forEach {
+            contains(it, ignoreCase)
+        }
+    }
+}
+
+/**
  * Asserts the string does not contain the specified string.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */

--- a/src/commonMain/kotlin/assertk/assertions/string.kt
+++ b/src/commonMain/kotlin/assertk/assertions/string.kt
@@ -39,7 +39,7 @@ fun Assert<String?>.isNotEqualTo(other: String?, ignoreCase: Boolean = false) = 
 }
 
 /**
- * Asserts the string contains the expected substring(s).
+ * Asserts the string contains the expected substring.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
 fun Assert<String>.contains(expected: CharSequence, ignoreCase: Boolean = false) {
@@ -69,9 +69,25 @@ fun Assert<String>.contains(expected: Iterable<CharSequence>, ignoreCase: Boolea
  * Asserts the string does not contain the specified string.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
-fun Assert<String>.doesNotContain(other: CharSequence, ignoreCase: Boolean = false) = given { actual ->
-    if (!actual.contains(other, ignoreCase)) return
-    expected("to not contain:${show(other)}")
+fun Assert<String>.doesNotContain(expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
+    doesNotContain(listOf(expected), ignoreCase)
+}
+
+/**
+ * Asserts the string does not contain the specified string(s).
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<String>.doesNotContain(vararg expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
+    doesNotContain(expected.toList(), ignoreCase)
+}
+
+/**
+ * Asserts the string does not contain the specified strings.
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<String>.doesNotContain(expected: Iterable<CharSequence>, ignoreCase: Boolean = false) = given { actual ->
+    if (expected.none { actual.contains(it, ignoreCase) }) return
+    expected("to not contain:${show(expected)} but was:${show(actual)}")
 }
 
 /**

--- a/src/commonMain/kotlin/assertk/assertions/string.kt
+++ b/src/commonMain/kotlin/assertk/assertions/string.kt
@@ -1,7 +1,6 @@
 package assertk.assertions
 
 import assertk.Assert
-import assertk.assertAll
 import assertk.assertions.support.expected
 import assertk.assertions.support.fail
 import assertk.assertions.support.show
@@ -40,31 +39,29 @@ fun Assert<String?>.isNotEqualTo(other: String?, ignoreCase: Boolean = false) = 
 }
 
 /**
- * Asserts the string contains the expected string.
+ * Asserts the string contains the expected substring(s).
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
-fun Assert<String>.contains(other: CharSequence, ignoreCase: Boolean = false) = given { actual ->
-    if (actual.contains(other, ignoreCase)) return
-    expected("to contain:${show(other)} but was:${show(actual)}")
+fun Assert<String>.contains(expected: CharSequence, ignoreCase: Boolean = false) {
+    contains(listOf(expected), ignoreCase)
+}
+
+/**
+ * Asserts the string contains the expected substring(s).
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<String>.contains(vararg expected: CharSequence, ignoreCase: Boolean = false) {
+    contains(expected.toList(), ignoreCase)
 }
 
 /**
  * Asserts the string contains the expected strings.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
-fun Assert<String>.containsSubstrings(vararg expected: String, ignoreCase: Boolean = false) {
-    containsSubstrings(expected.toList(), ignoreCase)
-}
-
-/**
- * Asserts the string contains the expected strings.
- * @param ignoreCase true to compare ignoring case, the default if false.
- */
-fun Assert<String>.containsSubstrings(expected: List<String>, ignoreCase: Boolean = false) {
-    assertAll {
-        expected.forEach {
-            contains(it, ignoreCase)
-        }
+fun Assert<String>.contains(expected: Iterable<CharSequence>, ignoreCase: Boolean = false) {
+    given { actual ->
+        if (expected.all { actual.contains(it, ignoreCase) }) return
+        expected("to contain:${show(expected)} but was:${show(actual)}")
     }
 }
 

--- a/src/commonMain/kotlin/assertk/assertions/string.kt
+++ b/src/commonMain/kotlin/assertk/assertions/string.kt
@@ -42,8 +42,9 @@ fun Assert<String?>.isNotEqualTo(other: String?, ignoreCase: Boolean = false) = 
  * Asserts the string contains the expected substring.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
-fun Assert<String>.contains(expected: CharSequence, ignoreCase: Boolean = false) {
-    contains(listOf(expected), ignoreCase)
+fun Assert<String>.contains(expected: CharSequence, ignoreCase: Boolean = false)= given { actual ->
+    if (actual.contains(expected, ignoreCase)) return
+    expected("to contain:${show(expected)} but was:${show(actual)}")
 }
 
 /**
@@ -58,11 +59,9 @@ fun Assert<String>.contains(vararg expected: CharSequence, ignoreCase: Boolean =
  * Asserts the string contains the expected strings.
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
-fun Assert<String>.contains(expected: Iterable<CharSequence>, ignoreCase: Boolean = false) {
-    given { actual ->
-        if (expected.all { actual.contains(it, ignoreCase) }) return
-        expected("to contain:${show(expected)} but was:${show(actual)}")
-    }
+fun Assert<String>.contains(expected: Iterable<CharSequence>, ignoreCase: Boolean = false) = given { actual ->
+    if (expected.all { actual.contains(it, ignoreCase) }) return
+    expected("to contain:${show(expected)} but was:${show(actual)}")
 }
 
 /**
@@ -70,7 +69,8 @@ fun Assert<String>.contains(expected: Iterable<CharSequence>, ignoreCase: Boolea
  * @param ignoreCase true to compare ignoring case, the default if false.
  */
 fun Assert<String>.doesNotContain(expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
-    doesNotContain(listOf(expected), ignoreCase)
+    if (!actual.contains(expected, ignoreCase)) return
+    expected("to not contain:${show(expected)} but was:${show(actual)}")
 }
 
 /**

--- a/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
@@ -87,7 +87,7 @@ class StringTest {
         val error = assertFails {
             assertThat("test").contains("not")
         }
-        assertEquals("expected to contain:<[\"not\"]> but was:<\"test\">", error.message)
+        assertEquals("expected to contain:<\"not\"> but was:<\"test\">", error.message)
     }
 
     @Test fun contains_value_substring_ignore_case_passes() {
@@ -98,7 +98,7 @@ class StringTest {
         val error = assertFails {
             assertThat("Test").contains("EST", false)
         }
-        assertEquals("expected to contain:<[\"EST\"]> but was:<\"Test\">", error.message)
+        assertEquals("expected to contain:<\"EST\"> but was:<\"Test\">", error.message)
     }
     //endregion
 
@@ -148,14 +148,14 @@ class StringTest {
         val error = assertFails {
             assertThat("test").doesNotContain("est")
         }
-        assertEquals("expected to not contain:<[\"est\"]> but was:<\"test\">", error.message)
+        assertEquals("expected to not contain:<\"est\"> but was:<\"test\">", error.message)
     }
 
     @Test fun doesNotContain_value_substring_ignore_case_fails() {
         val error = assertFails {
             assertThat("Test").doesNotContain("EST", true)
         }
-        assertEquals("expected to not contain:<[\"EST\"]> but was:<\"Test\">", error.message)
+        assertEquals("expected to not contain:<\"EST\"> but was:<\"Test\">", error.message)
     }
 
     @Test fun doesNotContain_value_not_substring_ignore_case_passes() {

--- a/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
@@ -102,6 +102,34 @@ class StringTest {
     }
     //endregion
 
+    //region containsAll
+    @Test fun containsAll_value_contains_passes() {
+        assertThat("test").containsAll("es", "st")
+    }
+
+    @Test fun containsAll_list_contains_passes() {
+        assertThat("test").containsAll(listOf("es", "st"))
+    }
+
+    @Test fun containsAll_value_not_contains_fails() {
+        val error = assertFails {
+            assertThat("test").containsAll("not")
+        }
+        assertEquals("expected to contain:<\"not\"> but was:<\"test\">", error.message)
+    }
+
+    @Test fun containsAll_value_contains_ignore_case_passes() {
+        assertThat("Test").containsAll("EST", true)
+    }
+
+    @Test fun containsAll_value_not_contains_ignore_case_fails() {
+        val error = assertFails {
+            assertThat("Test").containsAll("EST", false)
+        }
+        assertEquals("expected to contain:<\"EST\"> but was:<\"Test\">", error.message)
+    }
+    //endregion
+
     //region doesNotContain
     @Test fun doesNotContain_value_not_substring_passes() {
         assertThat("test").doesNotContain("not")

--- a/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
@@ -78,7 +78,7 @@ class StringTest {
     }
     //endregion
 
-    //region contains
+    //region contains single
     @Test fun contains_value_substring_passes() {
         assertThat("test").contains("est")
     }
@@ -87,7 +87,7 @@ class StringTest {
         val error = assertFails {
             assertThat("test").contains("not")
         }
-        assertEquals("expected to contain:<\"not\"> but was:<\"test\">", error.message)
+        assertEquals("expected to contain:<[\"not\"]> but was:<\"test\">", error.message)
     }
 
     @Test fun contains_value_substring_ignore_case_passes() {
@@ -98,35 +98,43 @@ class StringTest {
         val error = assertFails {
             assertThat("Test").contains("EST", false)
         }
-        assertEquals("expected to contain:<\"EST\"> but was:<\"Test\">", error.message)
+        assertEquals("expected to contain:<[\"EST\"]> but was:<\"Test\">", error.message)
     }
     //endregion
 
-    //region containsSubstrings
-    @Test fun containsSubstrings_value_contains_passes() {
-        assertThat("test").containsSubstrings("es", "st")
+    //region contains multi
+    @Test fun contains_empty_arg_passes() {
+        assertThat("test").contains()
     }
 
-    @Test fun containsSubstrings_list_contains_passes() {
-        assertThat("test").containsSubstrings(listOf("es", "st"))
+    @Test fun contains_value_contains_passes() {
+        assertThat("test").contains("te", "st")
     }
 
-    @Test fun containsSubstrings_value_not_contains_fails() {
+    @Test fun contains_list_contains_passes() {
+        assertThat("test").contains(listOf("te", "st"))
+    }
+
+    @Test fun contains_contains_unordered_passes() {
+        assertThat("test").contains("st", "te")
+    }
+
+    @Test fun contains_value_not_contains_fails() {
         val error = assertFails {
-            assertThat("test").containsSubstrings("not")
+            assertThat("test").contains("foo", "bar")
         }
-        assertEquals("expected to contain:<\"not\"> but was:<\"test\">", error.message)
+        assertEquals("expected to contain:<[\"foo\", \"bar\"]> but was:<\"test\">", error.message)
     }
 
-    @Test fun containsSubstrings_value_contains_ignore_case_passes() {
-        assertThat("Test").containsSubstrings("EST", ignoreCase = true)
+    @Test fun contains_value_contains_ignore_case_passes() {
+        assertThat("Test").contains("te", "ST", ignoreCase = true)
     }
 
-    @Test fun containsSubstrings_value_not_contains_ignore_case_fails() {
+    @Test fun contains_value_not_contains_ignore_case_fails() {
         val error = assertFails {
-            assertThat("Test").containsSubstrings("EST", ignoreCase = false)
+            assertThat("Test").contains("te", "ST", ignoreCase = false)
         }
-        assertEquals("expected to contain:<\"EST\"> but was:<\"Test\">", error.message)
+        assertEquals("expected to contain:<[\"te\", \"ST\"]> but was:<\"Test\">", error.message)
     }
     //endregion
 

--- a/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
@@ -139,7 +139,7 @@ class StringTest {
     //endregion
 
 
-    //region doesNotContain
+    //region doesNotContain single
     @Test fun doesNotContain_value_not_substring_passes() {
         assertThat("test").doesNotContain("not")
     }
@@ -148,18 +148,42 @@ class StringTest {
         val error = assertFails {
             assertThat("test").doesNotContain("est")
         }
-        assertEquals("expected to not contain:<\"est\">", error.message)
+        assertEquals("expected to not contain:<[\"est\"]> but was:<\"test\">", error.message)
     }
 
     @Test fun doesNotContain_value_substring_ignore_case_fails() {
         val error = assertFails {
             assertThat("Test").doesNotContain("EST", true)
         }
-        assertEquals("expected to not contain:<\"EST\">", error.message)
+        assertEquals("expected to not contain:<[\"EST\"]> but was:<\"Test\">", error.message)
     }
 
     @Test fun doesNotContain_value_not_substring_ignore_case_passes() {
         assertThat("Test").doesNotContain("EST", false)
+    }
+    //endregion
+
+    //region doesNotContain multi
+    @Test fun doesNotContain_multivalue_not_substring_passes() {
+        assertThat("test").doesNotContain("foo", "bar")
+    }
+
+    @Test fun doesNotContain_multivalue_substring_fails() {
+        val error = assertFails {
+            assertThat("test").doesNotContain("te", "st")
+        }
+        assertEquals("expected to not contain:<[\"te\", \"st\"]> but was:<\"test\">", error.message)
+    }
+
+    @Test fun doesNotContain_multivalue_substring_ignore_case_fails() {
+        val error = assertFails {
+            assertThat("Test").doesNotContain("TE", "ST", ignoreCase = true)
+        }
+        assertEquals("expected to not contain:<[\"TE\", \"ST\"]> but was:<\"Test\">", error.message)
+    }
+
+    @Test fun doesNotContain_multivalue_not_substring_ignore_case_passes() {
+        assertThat("Test").doesNotContain("TE", "ST", ignoreCase = false)
     }
     //endregion
 

--- a/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
+++ b/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
@@ -102,33 +102,34 @@ class StringTest {
     }
     //endregion
 
-    //region containsAll
-    @Test fun containsAll_value_contains_passes() {
-        assertThat("test").containsAll("es", "st")
+    //region containsSubstrings
+    @Test fun containsSubstrings_value_contains_passes() {
+        assertThat("test").containsSubstrings("es", "st")
     }
 
-    @Test fun containsAll_list_contains_passes() {
-        assertThat("test").containsAll(listOf("es", "st"))
+    @Test fun containsSubstrings_list_contains_passes() {
+        assertThat("test").containsSubstrings(listOf("es", "st"))
     }
 
-    @Test fun containsAll_value_not_contains_fails() {
+    @Test fun containsSubstrings_value_not_contains_fails() {
         val error = assertFails {
-            assertThat("test").containsAll("not")
+            assertThat("test").containsSubstrings("not")
         }
         assertEquals("expected to contain:<\"not\"> but was:<\"test\">", error.message)
     }
 
-    @Test fun containsAll_value_contains_ignore_case_passes() {
-        assertThat("Test").containsAll("EST", true)
+    @Test fun containsSubstrings_value_contains_ignore_case_passes() {
+        assertThat("Test").containsSubstrings("EST", ignoreCase = true)
     }
 
-    @Test fun containsAll_value_not_contains_ignore_case_fails() {
+    @Test fun containsSubstrings_value_not_contains_ignore_case_fails() {
         val error = assertFails {
-            assertThat("Test").containsAll("EST", false)
+            assertThat("Test").containsSubstrings("EST", ignoreCase = false)
         }
         assertEquals("expected to contain:<\"EST\"> but was:<\"Test\">", error.message)
     }
     //endregion
+
 
     //region doesNotContain
     @Test fun doesNotContain_value_not_substring_passes() {


### PR DESCRIPTION
hi, i am missing a few assertions in assertk, which for the time being reside in some privately hosted repository. i'd like to start sharing those with the community, as i think they are essential and should reside in the core project itself (rather get dusty in some private shared library).

sorry i haven't opened up an issue upfront to discuss this. i hope/guess it's simple enough to just go for it ;)

PS: this pull request was created due to the FOSDEM 2020 kotlin open source initiative (https://fosdem.org/2020/schedule/track/kotlin/).