### PR TITLE
Make tests system-independent

### DIFF
--- a/assertk/src/commonTest/kotlin/test/assertk/AssertAllTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/AssertAllTest.kt
@@ -41,8 +41,8 @@ class AssertAllTest {
             """The following assertions failed (2 failures)
               |${"\t"}${opentestPackageName}AssertionFailedError: expected [test] to start with:<"w"> but was:<"test">
               |${"\t"}${opentestPackageName}AssertionFailedError: expected [test] to end with:<"g"> but was:<"test">
-            """.trimMargin(),
-            error.message
+            """.trimMargin().lines(),
+            error.message!!.lines()
         )
     }
     //endregion
@@ -79,8 +79,8 @@ class AssertAllTest {
             """The following assertions failed (2 failures)
               |${"\t"}${opentestPackageName}AssertionFailedError: expected [test1]:<"[wrong]1"> but was:<"[test]1">
               |${"\t"}${opentestPackageName}AssertionFailedError: expected [test2]:<"[wrong]2"> but was:<"[test]2">
-            """.trimMargin(),
-            error.message
+            """.trimMargin().lines(),
+            error.message!!.lines()
         )
     }
 
@@ -109,8 +109,8 @@ class AssertAllTest {
             """The following assertions failed (2 failures)
               |${"\t"}${opentestPackageName}AssertionFailedError: expected failure but was success:<2>
               |${"\t"}${opentestPackageName}AssertionFailedError: expected failure but was success:<5>
-            """.trimMargin(),
-            error.message
+            """.trimMargin().lines(),
+            error.message!!.lines()
         )
     }
 

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/ArrayTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/ArrayTest.kt
@@ -305,7 +305,7 @@ class ArrayTest {
             """The following assertions failed (2 failures)
               |${"\t"}${opentestPackageName}AssertionFailedError: expected [[1]] to be less than:<2> but was:<2> ([1, 2, 3])
               |${"\t"}${opentestPackageName}AssertionFailedError: expected [[2]] to be less than:<2> but was:<3> ([1, 2, 3])
-            """.trimMargin(), error.message
+            """.trimMargin().lines(), error.message!!.lines()
         )
     }
     //endregion

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
@@ -128,7 +128,7 @@ class IterableTest {
             """The following assertions failed (2 failures)
               |${"\t"}${opentestPackageName}AssertionFailedError: expected [[1]] to be less than:<2> but was:<2> ([1, 2, 3])
               |${"\t"}${opentestPackageName}AssertionFailedError: expected [[2]] to be less than:<2> but was:<3> ([1, 2, 3])
-            """.trimMargin(), error.message
+            """.trimMargin().lines(), error.message!!.lines()
         )
     }
     //endregion
@@ -161,7 +161,7 @@ class IterableTest {
             """expected to pass at least 2 times (2 failures)
             |${"\t"}${opentestPackageName}AssertionFailedError: expected [[0]] to be greater than:<2> but was:<1> ([1, 2, 3])
             |${"\t"}${opentestPackageName}AssertionFailedError: expected [[1]] to be greater than:<2> but was:<2> ([1, 2, 3])
-        """.trimMargin(), error.message
+        """.trimMargin().lines(), error.message!!.lines()
         )
     }
 
@@ -208,7 +208,7 @@ class IterableTest {
             """expected to pass exactly 2 times (2 failures)
             |${"\t"}${opentestPackageName}AssertionFailedError: expected [[0]] to be greater than:<2> but was:<1> ([1, 2, 3])
             |${"\t"}${opentestPackageName}AssertionFailedError: expected [[1]] to be greater than:<2> but was:<2> ([1, 2, 3])
-            """.trimMargin(), error.message
+            """.trimMargin().lines(), error.message!!.lines()
         )
     }
 
@@ -239,7 +239,7 @@ class IterableTest {
             """expected any item to pass (2 failures)
 	        |${"\t"}${opentestPackageName}AssertionFailedError: expected [[0]] to be greater than:<3> but was:<1> ([1, 2])
 	        |${"\t"}${opentestPackageName}AssertionFailedError: expected [[1]] to be greater than:<3> but was:<2> ([1, 2])
-            """.trimMargin(), error.message
+            """.trimMargin().lines(), error.message!!.lines()
         )
     }
     //endregion

--- a/assertk/src/jvmMain/kotlin/assertk/assertions/file.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/file.kt
@@ -93,7 +93,7 @@ fun Assert<File>.hasName(expected: String) {
  * Asserts the file has the expected path.
  */
 fun Assert<File>.hasPath(expected: String) {
-    path().isEqualTo(expected)
+    path().isEqualTo(File(expected).path)
 }
 
 /**

--- a/assertk/src/jvmMain/kotlin/assertk/assertions/file.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/file.kt
@@ -100,7 +100,7 @@ fun Assert<File>.hasPath(expected: String) {
  * Asserts the file has the expected parent path.
  */
 fun Assert<File>.hasParent(expected: String) {
-    parent().isEqualTo(expected)
+    parent().isEqualTo(File(expected).path)
 }
 
 /**

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
@@ -116,18 +116,21 @@ class FileTest {
     //endregion
 
     //region hasParent
-    val fileWithParent = File("assertKt/file.txt")
+    val fileWithParent = File("assertKt/directory/file.txt")
 
     @Test fun hasParent_correct_parent_passes() {
-        assertThat(fileWithParent).hasParent("assertKt")
+        assertThat(fileWithParent).hasParent("assertKt/directory")
     }
 
     @Test fun hasParent_wrong_parent_passes() {
         val error = assertFails {
             assertThat(fileWithParent).hasParent("directory")
         }
+        val expected = "expected [parent]:<\"[]directory\"> but was:<\"[assertKt${File.separator}]directory\"> (assertKt${File.separator}directory${File.separator}file.txt)"
+        println(expected)
+        println(error.message)
         assertEquals(
-            "expected [parent]:<\"[directory]\"> but was:<\"[${fileWithParent.parent}]\"> (assertKt${File.separator}file.txt)",
+            expected,
             error.message
         )
     }

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
@@ -83,7 +83,7 @@ class FileTest {
         val error = assertFails {
             assertThat(namedFile).hasName("file")
         }
-        assertEquals("expected [name]:<\"file[]\"> but was:<\"file[.txt]\"> (assertKt/file.txt)", error.message)
+        assertEquals("expected [name]:<\"file[]\"> but was:<\"file[.txt]\"> (assertKt${File.separator}file.txt)", error.message)
     }
 
     @Test fun hasName_wront_value_directory_fails() {
@@ -91,7 +91,7 @@ class FileTest {
             assertThat(namedDirectory).hasName("assertKt")
         }
         assertEquals(
-            "expected [name]:<\"[assertKt]\"> but was:<\"[${namedDirectory.name}]\"> (assertKt/directory)",
+            "expected [name]:<\"[assertKt]\"> but was:<\"[${namedDirectory.name}]\"> (assertKt${File.separator}directory)",
             error.message
         )
     }
@@ -109,7 +109,7 @@ class FileTest {
             assertThat(fileWithPath).hasPath("/directory")
         }
         assertEquals(
-            "expected [path]:<\"[/directory]\"> but was:<\"[${fileWithPath.path}]\"> (assertKt/file.txt)",
+            "expected [path]:<\"[${File.separator}directory]\"> but was:<\"[${fileWithPath.path}]\"> (assertKt${File.separator}file.txt)",
             error.message
         )
     }
@@ -127,7 +127,7 @@ class FileTest {
             assertThat(fileWithParent).hasParent("directory")
         }
         assertEquals(
-            "expected [parent]:<\"[directory]\"> but was:<\"[${fileWithParent.parent}]\"> (assertKt/file.txt)",
+            "expected [parent]:<\"[directory]\"> but was:<\"[${fileWithParent.parent}]\"> (assertKt${File.separator}file.txt)",
             error.message
         )
     }

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/JVMResultTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/JVMResultTest.kt
@@ -20,7 +20,7 @@ class JVMResultTest {
         }
 
         assertNotNull(error.message)
-        val errorLines = error.message!!.split("\n")
+        val errorLines = error.message!!.lines()
         assertTrue(errorLines.size > 1)
         assertEquals("expected success but was failure:<${exceptionPackageName}Exception: test>", errorLines[0])
         assertEquals("${exceptionPackageName}Exception: test", errorLines[1])

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -115,7 +115,7 @@ class JavaAnyTest {
             """The following assertions failed (2 failures)
             |${"\t"}${opentestPackageName}AssertionFailedError: expected [one.inner]:<"[wrong]"> but was:<"[test]"> (DataClass(one=InnerDataClass(inner=test), two=1, three=a))
             |${"\t"}${opentestPackageName}AssertionFailedError: expected [three]:<'[b]'> but was:<'[a]'> (DataClass(one=InnerDataClass(inner=test), two=1, three=a))
-        """.trimMargin(), error.message
+        """.trimMargin().lines(), error.message!!.lines()
         )
     }
     //endregion

--- a/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
+++ b/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
@@ -303,7 +303,7 @@ class $TTest {
             """The following assertions failed (2 failures)
                 |	${opentestPackageName}AssertionFailedError: expected [[1]] to be less than:<${show(2.to$E(), "")}> but was:<${show(2.to$E(), "")}> ([${show(1.to$E(), "")}, ${show(2.to$E(), "")}, ${show(3.to$E(), "")}])
                 |	${opentestPackageName}AssertionFailedError: expected [[2]] to be less than:<${show(2.to$E(), "")}> but was:<${show(3.to$E(), "")}> ([${show(1.to$E(), "")}, ${show(2.to$E(), "")}, ${show(3.to$E(), "")}])
-            """.trimMargin(), error.message
+            """.trimMargin().lines(), error.message!!.lines()
         )
     }
     //endregion


### PR DESCRIPTION
Fixes tests to work on Windows, and be generally more system-independent:

- Use `File.separator` to be separator-agnostic
- Compare error messages using `lines()` to be line separator-agnostic

One change to the actual library behavior: `assert(file).hasPath(path)` originally would fail on Windows to consider that a file `File("assertKt/file.txt")` has a path `"assertKt/file.txt"` because the `/` is replaced with a `\`. So that the tests using assertk are also system-independent, the `hasPath` method is revised to compare the file to a file that also has the expected path.