### PR TITLE
Started on addding coroutine assertions, particuarly flow

### DIFF
--- a/assertk-coroutines/build.gradle
+++ b/assertk-coroutines/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group 'com.willowtreeapps.assertk'
-    version '0.23-SNAPSHOT'
+    version '0.1-SNAPSHOT'
 }
 
 ext {
@@ -29,16 +29,6 @@ repositories {
     if (!isReleaseVersion) {
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots'}
     }
-}
-
-task compileTemplates(type: TemplateTask) {
-    inputDir = file('src/template')
-    outputDir = file("$buildDir/generated/template")
-}
-
-task compileTestTemplates(type: TemplateTask) {
-    inputDir = file('src/testTemplate')
-    outputDir = file("$buildDir/generated/testTemplate")
 }
 
 kotlin {
@@ -78,28 +68,26 @@ kotlin {
         }
     }
 
-    def opentest4k_version = '1.2.0'
     def kotlin_coroutines_version = '1.3.4'
 
     sourceSets {
         commonMain {
             dependencies {
                 implementation kotlin('stdlib-common')
-                implementation "com.willowtreeapps.opentest4k:opentest4k:$opentest4k_version"
+                implementation project(':assertk')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$kotlin_coroutines_version"
             }
-            kotlin.srcDirs += files(compileTemplates)
         }
         commonTest {
             dependencies {
                 implementation kotlin('test-common')
                 implementation kotlin('test-annotations-common')
             }
-            kotlin.srcDirs += files(compileTestTemplates)
         }
         jvmMain {
             dependencies {
                 implementation kotlin('stdlib-jdk8')
-                compileOnly kotlin('reflect')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"
             }
         }
         jvmTest {
@@ -112,16 +100,13 @@ kotlin {
         }
         jsMain {
             dependencies {
-		// kotlin-js doesn't handle this as a transitive dep correctly
-		// when it's scoped as runtime.
-                api "com.willowtreeapps.opentest4k:opentest4k-js:$opentest4k_version"
                 implementation kotlin('stdlib-js')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$kotlin_coroutines_version"
             }
         }
         jsTest {
             dependencies {
                 implementation kotlin('test-js')
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$kotlin_coroutines_version"
             }
         }
         nativeMain {
@@ -136,31 +121,28 @@ kotlin {
         [linuxTest, iosArm64Test, iosX64Test, macosTest].each {
             it.dependsOn(nativeTest)
         }
-        linuxTest {
+        linuxMain {
             dependencies {
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-linuxx64:$kotlin_coroutines_version"
             }
         }
-        iosArm64Test {
+        iosArm64Main {
             dependencies {
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosarm64:$kotlin_coroutines_version"
             }
         }
-        iosX64Test {
+        iosX64Main {
             dependencies {
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:$kotlin_coroutines_version"
             }
         }
-        macosTest {
+        macosMain {
             dependencies {
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:$kotlin_coroutines_version"
             }
         }
     }
 }
-
-[compileKotlinMetadata, compileKotlinJvm, compileKotlinJs].each { it.dependsOn(compileTemplates) }
-[compileTestKotlinJvm, compileTestKotlinJs].each { it.dependsOn(compileTestTemplates) }
 
 task nativeTest {
     dependsOn(linuxTest, macosTest, iosX64Test)
@@ -169,17 +151,6 @@ task nativeTest {
 task test {
     dependsOn(jvmTest, jsTest, nativeTest)
 }
-
-gitPublish {
-    repoUri = 'git@github.com:willowtreeapps/assertk.git'
-    branch = 'gh-pages'
-    contents {
-        from 'build/javadoc'
-        into 'javadoc'
-    }
-}
-
-gitPublishCopy.dependsOn(dokka)
 
 task detektMain(type: io.gitlab.arturbosch.detekt.Detekt) {
     setSource(files(kotlin.sourceSets.commonMain.kotlin, kotlin.sourceSets.jsMain.kotlin, kotlin.sourceSets.jvmMain.kotlin, kotlin.sourceSets.nativeMain.kotlin))
@@ -330,7 +301,7 @@ publishing {
 
             pom {
                 name = project.name
-                description = 'Assertions for Kotlin inspired by assertj'
+                description = 'Assertions for Kotlin inspired by assertj - coroutine assertions'
                 url = siteUrl
 
                 scm {

--- a/assertk-coroutines/src/commonMain/kotlin/assertk/coroutines/assertions/any.kt
+++ b/assertk-coroutines/src/commonMain/kotlin/assertk/coroutines/assertions/any.kt
@@ -1,0 +1,17 @@
+package assertk.coroutines.assertions
+
+import assertk.Assert
+import assertk.assertions.support.appendName
+
+/**
+ * Returns an assert that asserts on the result of the given suspend call.
+ *
+ * @param name The name of the suspend function you are calling.
+ * @param extract The suspend function to extract the property value out of the value of the current assert.
+ *
+ * ```
+ * assertThat(person).suspendCall("name()", { it.name() }).isEqualTo("Sue")
+ * ```
+ */
+suspend fun <T, P> Assert<T>.suspendCall(name: String, extract: suspend (T) -> P): Assert<P> =
+    transform(appendName(name, separator = ".")) { extract(it) }

--- a/assertk-coroutines/src/commonMain/kotlin/assertk/coroutines/assertions/flow.kt
+++ b/assertk-coroutines/src/commonMain/kotlin/assertk/coroutines/assertions/flow.kt
@@ -1,0 +1,171 @@
+package assertk.coroutines.assertions
+
+import assertk.Assert
+import assertk.assertions.*
+import assertk.assertions.support.expected
+import assertk.assertions.support.show
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.*
+
+@ExperimentalCoroutinesApi
+suspend fun Assert<Flow<*>>.count(): Assert<Int> = suspendCall("count()", Flow<*>::count)
+
+/**
+ * Asserts the flow is empty. Fails as soon as the flow delivers an element.
+ * @see isNotEmpty
+ * @see isNullOrEmpty
+ */
+suspend fun Assert<Flow<*>>.isEmpty() = given { actual ->
+    var count = 0
+    var firstValue: Any? = null
+    try {
+        actual.collect {
+            count++
+            firstValue = it
+            throw AbortFlowException()
+        }
+    } catch (e: AbortFlowException) {
+        // Do nothing
+    }
+    if (count == 0) return
+    expected("to be empty but received:${show(firstValue)}")
+}
+
+/**
+ * Asserts the flow is not empty.
+ * @see isEmpty
+ */
+suspend fun Assert<Flow<*>>.isNotEmpty() = given { actual ->
+    var count = 0
+    actual.collect {
+        count++
+    }
+    if (count != 0) return
+    expected("to not be empty")
+}
+
+@ExperimentalCoroutinesApi
+suspend fun Assert<Flow<*>>.hasCount(count: Int) {
+    count().isEqualTo(count)
+}
+
+/**
+ * Asserts the flow contains the expected element, using `in`. Succeeds as soon as that element is received.
+ * @see [doesNotContain]
+ */
+suspend fun Assert<Flow<*>>.contains(element: Any?) = given { actual ->
+    val receivedElements = mutableListOf<Any?>()
+    try {
+        actual.collect {
+            if (element == it) {
+                throw AbortFlowException()
+            }
+            receivedElements.add(it)
+        }
+    } catch (e: AbortFlowException) {
+        // Found element
+        return
+    }
+    expected("to contain:${show(element)} but received:${show(receivedElements)}")
+}
+
+/**
+ * Asserts the flow does not contain any of the expected elements. Fails as soon as that element is received.
+ * @see [containsAll]
+ */
+suspend fun Assert<Flow<*>>.doesNotContain(element: Any?) = given { actual ->
+    val receivedElements = mutableListOf<Any?>()
+    try {
+        actual.collect {
+            receivedElements.add(it)
+            if (element == it) {
+                throw AbortFlowException()
+            }
+        }
+    } catch (e: AbortFlowException) {
+        // Found element
+        expected("to not contain:${show(element)} but received:${show(receivedElements)}")
+    }
+}
+
+/**
+ * Asserts the collection does not contain any of the expected elements. Fails as soon as one of the expected elements
+ * is received.
+ * @see [containsAll]
+ */
+suspend fun Assert<Flow<*>>.containsNone(vararg elements: Any?) = given { actual ->
+    val receivedElements = mutableListOf<Any?>()
+    try {
+        actual.collect {
+            receivedElements.add(it)
+            if (it in elements) {
+                throw AbortFlowException()
+            }
+        }
+    } catch (e: AbortFlowException) {
+        // Found element
+        expected(
+            "to contain none of:${show(elements)} but received:${show(receivedElements)}\n element not expected:${show(
+                receivedElements.last()
+            )}"
+        )
+    }
+}
+
+/**
+ * Asserts the flow emits all the expected elements, in any order. The flow may also
+ * emit additional elements. Succeeds as soon as all expected elements are received.
+ * @see [containsNone]
+ * @see [containsExactly]
+ * @see [containsOnly]
+ */
+suspend fun Assert<Flow<*>>.containsAll(vararg elements: Any?) = given { actual ->
+    val remainingElements = MutableList(elements.size) { index -> elements[index] }
+    val receivedElements = mutableListOf<Any?>()
+    try {
+        actual.collect {
+            if (it in elements) {
+                remainingElements.remove(it)
+                if (remainingElements.isEmpty()) {
+                    throw AbortFlowException()
+                }
+            }
+            receivedElements.add(it)
+        }
+    } catch (e: AbortFlowException) {
+        // Found all elements
+        return
+    }
+    expected(
+        "to contain all:${show(elements)} but received:${show(receivedElements)}\n elements not found:${show(
+            remainingElements
+        )}"
+    )
+}
+
+/**
+ * Asserts the flow contains only the expected elements, in any order.
+ * @see [containsNone]
+ * @see [containsExactly]
+ * @see [containsAll]
+ */
+suspend fun Assert<Flow<*>>.containsOnly(vararg elements: Any?) = given { actual ->
+    val actualList = actual.toList()
+    val notInActual = elements.filterNot { it in actualList }
+    val notInExpected = actualList.filterNot { it in elements }
+    if (notInExpected.isEmpty() && notInActual.isEmpty()) {
+        return
+    }
+    expected(StringBuilder("to contain only:${show(elements)} but received:${show(actualList)}").apply {
+        if (notInActual.isNotEmpty()) {
+            append("\n elements not found:${show(notInActual)}")
+        }
+        if (notInExpected.isNotEmpty()) {
+            append("\n extra elements found:${show(notInExpected)}")
+        }
+    }.toString())
+}
+
+private class AbortFlowException :
+    CancellationException("Flow was aborted, no more elements needed")

--- a/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/AnyTest.kt
+++ b/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/AnyTest.kt
@@ -1,0 +1,52 @@
+package test.assertk.coroutines.assertions
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.coroutines.assertions.suspendCall
+import test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class AnyTest {
+    val subject = BasicObject("test")
+
+    @Test fun suspendCall_passes() = runTest {
+        assertThat(subject).suspendCall("str") { it.str() }.isEqualTo("test")
+    }
+
+    @Test fun suspendCall_includes_name_in_failure_message() = runTest {
+        val error = assertFails {
+            assertThat(subject).suspendCall("str") { it.str() }.isEmpty()
+        }
+        assertEquals("expected [str] to be empty but was:<\"test\"> (test)", error.message)
+    }
+
+    @Test fun nested_suspendCall_include_names_in_failure_message() = runTest {
+        val error = assertFails {
+            assertThat(subject).suspendCall("other") { it.other() }.suspendCall("str") { it?.str() }.isNotNull()
+        }
+        assertEquals("expected [other.str] to not be null (test)", error.message)
+    }
+
+    companion object {
+
+        class BasicObject(
+            private val str: String,
+            private val other: BasicObject? = null
+        ) {
+            suspend fun str() = str
+
+            suspend fun other() = other
+
+            override fun toString(): String = str
+
+            override fun equals(other: Any?): Boolean =
+                (other is BasicObject) && (str == other.str && this.other == other.other)
+
+            override fun hashCode(): Int = 42
+        }
+    }
+}

--- a/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/FlowTest.kt
+++ b/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/FlowTest.kt
@@ -1,0 +1,199 @@
+package test.assertk.coroutines.assertions
+
+import assertk.assertThat
+import assertk.assertions.support.show
+import assertk.coroutines.assertions.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOf
+import test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FlowTest {
+    //region isEmpty
+    @Test fun isEmpty_empty_passes() = runTest {
+        assertThat(flowOf<Any?>()).isEmpty()
+    }
+
+    @Test fun isEmpty_non_empty_fails() = runTest {
+        val error = assertFails {
+            assertThat(flowOf<Any?>(null)).isEmpty()
+        }
+        assertEquals("expected to be empty but received:<null>", error.message)
+    }
+
+    @Test fun isEmpty_non_empty_in_flow_that_doesnt_complete_fails() = runTest {
+        val error = assertFails {
+            assertThat(nonCompletingFlowOf(null)).isEmpty()
+        }
+        assertEquals("expected to be empty but received:<null>", error.message)
+    }
+    //endregion
+
+    //region isNotEmpty
+    @Test fun isNotEmpty_non_empty_passes() = runTest {
+        assertThat(flowOf<Any?>(null)).isNotEmpty()
+    }
+
+    @Test fun isNotEmpty_empty_fails() = runTest {
+        val error = assertFails {
+            assertThat(flowOf<Any?>()).isNotEmpty()
+        }
+        assertEquals("expected to not be empty", error.message)
+    }
+    //endregion
+
+    //region hasCount
+    @Test fun hasSize_correct_size_passes() = runTest {
+        assertThat(flowOf<Any?>()).hasCount(0)
+    }
+
+    @Test fun hasSize_wrong_size_fails() = runTest {
+        val flow = flowOf<Any?>()
+        val error = assertFails {
+            assertThat(flow).hasCount(1)
+        }
+        assertEquals("expected [count()]:<[1]> but was:<[0]> ${show(flow, "()")}", error.message)
+    }
+    //endregion
+
+    //region contains
+    @Test fun contains_element_present_passes() = runTest {
+        assertThat(flowOf(1, 2)).contains(2)
+    }
+
+    @Test fun contains_element_present_in_flow_that_doesnt_complete_passes() = runTest {
+        assertThat(nonCompletingFlowOf(1, 2)).contains(2)
+    }
+
+    @Test fun contains_element_missing_fails() = runTest {
+        val error = assertFails {
+            assertThat(flowOf<Any?>()).contains(1)
+        }
+        assertEquals("expected to contain:<1> but received:<[]>", error.message)
+    }
+    //endregion
+
+    //region doesNotContain
+    @Test fun doesNotContain_element_missing_passes() = runTest {
+        assertThat(flowOf<Any?>()).doesNotContain(1)
+    }
+
+    @Test fun doesNotContain_element_present_fails() = runTest {
+        val error = assertFails {
+            assertThat(flowOf(1, 2)).doesNotContain(2)
+        }
+        assertEquals("expected to not contain:<2> but received:<[1, 2]>", error.message)
+    }
+
+    @Test fun doesNotContain_element_present_in_flow_that_doesnt_complete_fails() = runTest {
+        val error = assertFails {
+            assertThat(nonCompletingFlowOf(1, 2)).doesNotContain(2)
+        }
+        assertEquals("expected to not contain:<2> but received:<[1, 2]>", error.message)
+    }
+    //endregion
+
+    //region containsNone
+    @Test fun containsNone_missing_elements_passes() = runTest {
+        assertThat(flowOf<Any?>()).containsNone(1)
+    }
+
+    @Test fun containsNone_present_element_fails() = runTest {
+        val error = assertFails {
+            assertThat(flowOf(1, 2)).containsNone(2, 3)
+        }
+        assertEquals(
+            """expected to contain none of:<[2, 3]> but received:<[1, 2]>
+                | element not expected:<2>
+            """.trimMargin(), error.message
+        )
+    }
+
+    @Test fun containsNone_present_element_in_flow_that_doesnt_complete_fails() = runTest {
+        val error = assertFails {
+            assertThat(nonCompletingFlowOf(1, 2)).containsNone(2, 3)
+        }
+        assertEquals(
+            """expected to contain none of:<[2, 3]> but received:<[1, 2]>
+                | element not expected:<2>
+            """.trimMargin(), error.message
+        )
+    }
+    //region
+
+    //region containsAll
+    @Test fun containsAll_all_elements_passes() = runTest {
+        assertThat(flowOf(1, 2)).containsAll(2, 1)
+    }
+
+    @Test fun containsAll_all_elements_in_flow_that_doesnt_complete_passes() = runTest {
+        assertThat(nonCompletingFlowOf(1, 2)).containsAll(2, 1)
+    }
+
+    @Test fun containsAll_some_elements_fails() = runTest {
+        val error = assertFails {
+            assertThat(flowOf(1)).containsAll(1, 2)
+        }
+        assertEquals(
+            """expected to contain all:<[1, 2]> but received:<[1]>
+                | elements not found:<[2]>
+            """.trimMargin(), error.message
+        )
+    }
+    //endregion
+
+    //region containsOnly
+    @Test fun containsOnly_only_elements_passes() = runTest {
+        assertThat(flowOf(1, 2)).containsOnly(2, 1)
+    }
+
+    @Test fun containsOnly_more_elements_fails() = runTest {
+        val error = assertFails {
+            assertThat(flowOf(1, 2, 3)).containsOnly(2, 1)
+        }
+        assertEquals(
+            """expected to contain only:<[2, 1]> but received:<[1, 2, 3]>
+                | extra elements found:<[3]>
+            """.trimMargin(), error.message
+        )
+    }
+
+    @Test fun containsOnly_less_elements_fails() = runTest {
+        val error = assertFails {
+            assertThat(flowOf(1, 2, 3)).containsOnly(2, 1, 3, 4)
+        }
+        assertEquals(
+            """expected to contain only:<[2, 1, 3, 4]> but received:<[1, 2, 3]>
+                | elements not found:<[4]>
+            """.trimMargin(),
+            error.message
+        )
+    }
+
+    @Test fun containsOnly_different_elements_fails() = runTest {
+        val error = assertFails {
+            assertThat(flowOf(1)).containsOnly(2)
+        }
+        assertEquals(
+            """expected to contain only:<[2]> but received:<[1]>
+                | elements not found:<[2]>
+                | extra elements found:<[1]>
+            """.trimMargin(),
+            error.message
+        )
+    }
+    //endregion
+}
+
+@ExperimentalCoroutinesApi
+private fun <T> nonCompletingFlowOf(vararg elements: T) = callbackFlow {
+    for (element in elements) {
+        send(element)
+    }
+    awaitClose { }
+}

--- a/assertk-coroutines/src/commonTest/kotlin/test/runTest.kt
+++ b/assertk-coroutines/src/commonTest/kotlin/test/runTest.kt
@@ -1,0 +1,8 @@
+package test
+
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Workaround to use suspending functions in unit tests
+ */
+expect fun runTest(block: suspend (scope: CoroutineScope) -> Unit)

--- a/assertk-coroutines/src/jsTest/kotlin/test/runTest.kt
+++ b/assertk-coroutines/src/jsTest/kotlin/test/runTest.kt
@@ -1,0 +1,10 @@
+package test
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+
+/**
+ * Workaround to use suspending functions in unit tests
+ */
+actual fun runTest(block: suspend (scope: CoroutineScope) -> Unit): dynamic = GlobalScope.promise { block(this) }

--- a/assertk-coroutines/src/jvmTest/kotlin/test/runTest.kt
+++ b/assertk-coroutines/src/jvmTest/kotlin/test/runTest.kt
@@ -1,0 +1,9 @@
+package test
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Workaround to use suspending functions in unit tests
+ */
+actual fun runTest(block: suspend (scope: CoroutineScope) -> Unit) = runBlocking { block(this) }

--- a/assertk-coroutines/src/nativeTest/kotlin/test/runTest.kt
+++ b/assertk-coroutines/src/nativeTest/kotlin/test/runTest.kt
@@ -1,0 +1,9 @@
+package test
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Workaround to use suspending functions in unit tests
+ */
+actual fun runTest(block: suspend (scope: CoroutineScope) -> Unit) = runBlocking { block(this) }

--- a/assertk/src/commonMain/kotlin/assertk/assertions/any.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/any.kt
@@ -2,6 +2,7 @@ package assertk.assertions
 
 import assertk.Assert
 import assertk.all
+import assertk.assertions.support.appendName
 import assertk.assertions.support.expected
 import assertk.assertions.support.fail
 import assertk.assertions.support.show
@@ -132,7 +133,7 @@ fun <T : Any> Assert<T?>.isNotNull(): Assert<T> = transform { actual ->
  * ```
  */
 fun <T, P> Assert<T>.prop(name: String, extract: (T) -> P): Assert<P> =
-    transform("${if (this.name != null) this.name + "." else ""}$name", extract)
+    transform(appendName(name, separator = "."), extract)
 
 /**
  * Asserts the value has the expected kotlin class. This is an exact match, so `assertThat("test").hasClass(String::class)`
@@ -226,7 +227,7 @@ fun <T, E> Assert<T>.doesNotCorrespond(expected: E, correspondence: (T, E) -> Bo
 fun <T> Assert<T>.isEqualToWithGivenProperties(other: T, vararg properties: KProperty1<T, Any?>) {
     all {
         for (prop in properties) {
-            transform("${if (this.name != null) this.name + "." else ""}${prop.name}", prop::get)
+            transform(appendName(prop.name, separator = "."), prop::get)
                 .isEqualTo(prop.get(other))
         }
     }

--- a/assertk/src/commonMain/kotlin/assertk/assertions/array.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/array.kt
@@ -2,6 +2,7 @@ package assertk.assertions
 
 import assertk.Assert
 import assertk.all
+import assertk.assertions.support.appendName
 import assertk.assertions.support.expected
 import assertk.assertions.support.fail
 import assertk.assertions.support.show
@@ -153,8 +154,8 @@ fun Assert<Array<*>>.containsOnly(vararg elements: Any?) = given { actual ->
  * ```
  */
 fun <T> Assert<Array<T>>.index(index: Int): Assert<T> =
-    transform("${name ?: ""}${show(index, "[]")}") { actual ->
-        if (index in 0 until actual.size) {
+    transform(appendName(show(index, "[]"))) { actual ->
+        if (index in actual.indices) {
             actual[index]
         } else {
             expected("index to be in range:[0-${actual.size}) but was:${show(index)}")
@@ -184,7 +185,7 @@ fun Assert<Array<*>>.containsExactly(vararg elements: Any?) = given { actual ->
 fun <T> Assert<Array<T>>.each(f: (Assert<T>) -> Unit) = given { actual ->
     all {
         actual.forEachIndexed { index, item ->
-            f(assertThat(item, name = "${name ?: ""}${show(index, "[]")}"))
+            f(assertThat(item, name = appendName(show(index, "[]"))))
         }
     }
 }

--- a/assertk/src/commonMain/kotlin/assertk/assertions/iterable.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/iterable.kt
@@ -2,6 +2,7 @@ package assertk.assertions
 
 import assertk.Assert
 import assertk.all
+import assertk.assertions.support.appendName
 import assertk.assertions.support.expected
 import assertk.assertions.support.show
 
@@ -84,7 +85,7 @@ fun Assert<Iterable<*>>.containsOnly(vararg elements: Any?) = given { actual ->
 fun <E> Assert<Iterable<E>>.each(f: (Assert<E>) -> Unit) = given { actual ->
     all {
         actual.forEachIndexed { index, item ->
-            f(assertThat(item, name = "${name ?: ""}${show(index, "[]")}"))
+            f(assertThat(item, name = appendName(show(index, "[]"))))
         }
     }
 }

--- a/assertk/src/commonMain/kotlin/assertk/assertions/list.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/list.kt
@@ -2,6 +2,7 @@ package assertk.assertions
 
 import assertk.Assert
 import assertk.assertions.support.ListDiffer
+import assertk.assertions.support.appendName
 import assertk.assertions.support.expected
 import assertk.assertions.support.show
 
@@ -13,8 +14,8 @@ import assertk.assertions.support.show
  * ```
  */
 fun <T> Assert<List<T>>.index(index: Int): Assert<T> =
-    transform("${name ?: ""}${show(index, "[]")}") { actual ->
-        if (index in 0 until actual.size) {
+    transform(appendName(show(index, "[]"))) { actual ->
+        if (index in actual.indices) {
             actual[index]
         } else {
             expected("index to be in range:[0-${actual.size}) but was:${show(index)}")

--- a/assertk/src/commonMain/kotlin/assertk/assertions/map.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/map.kt
@@ -1,6 +1,7 @@
 package assertk.assertions
 
 import assertk.Assert
+import assertk.assertions.support.appendName
 import assertk.assertions.support.expected
 import assertk.assertions.support.show
 
@@ -113,7 +114,11 @@ fun <K, V> Assert<Map<K, V>>.doesNotContain(element: Pair<K, V>) {
 fun <K, V> Assert<Map<K, V>>.containsNone(vararg elements: Pair<K, V>) = given { actual ->
     if (elements.all { (k, v) -> actual[k] != v }) return
     val notExpected = elements.filter { (k, v) -> actual[k] == v }
-    expected("to contain none of:${show(elements.toMap())} but was:${show(actual)}\n elements not expected:${show(notExpected.toMap())}")
+    expected(
+        "to contain none of:${show(elements.toMap())} but was:${show(actual)}\n elements not expected:${show(
+            notExpected.toMap()
+        )}"
+    )
 }
 
 /**
@@ -145,7 +150,7 @@ fun <K, V> Assert<Map<K, V>>.containsOnly(vararg elements: Pair<K, V>) = given {
  * assertThat(mapOf("key" to "value")).key("key").isEqualTo("value")
  * ```
  */
-fun <K, V> Assert<Map<K, V>>.key(key: K): Assert<V> = transform("${name ?: ""}${show(key, "[]")}") { actual ->
+fun <K, V> Assert<Map<K, V>>.key(key: K): Assert<V> = transform(appendName(show(key, "[]"))) { actual ->
     if (key in actual) {
         actual.getValue(key)
     } else {

--- a/assertk/src/commonMain/kotlin/assertk/assertions/support/support.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/support/support.kt
@@ -82,6 +82,14 @@ fun <T> Assert<T>.expected(message: String, expected: Any? = NONE, actual: Any? 
     )
 }
 
+/**
+ * Constructs a new name appending to the existing name if available using the given separator.
+ * @param name The new name to append to the current name, or the new name if there is no current one.
+ * @param separator The separator between the current name and the suffix if the current name exists.
+ */
+fun Assert<*>.appendName(name: String, separator: String = "") =
+    if (this.name != null) this.name + separator + name else name
+
 private fun formatName(name: String?): String {
     return if (name.isNullOrEmpty()) {
         ""

--- a/assertk/src/jvmMain/kotlin/assertk/assertions/any.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/any.kt
@@ -5,6 +5,7 @@ package assertk.assertions
 import assertk.Assert
 import assertk.all
 import assertk.assertions.support.expected
+import assertk.assertions.support.appendName
 import assertk.assertions.support.show
 import java.lang.reflect.InvocationTargetException
 import kotlin.reflect.KCallable
@@ -123,7 +124,7 @@ fun <T : Any> Assert<T>.isEqualToIgnoringGivenProperties(other: T, vararg proper
             if (prop is KProperty1<*, *> && !properties.contains(prop)) {
                 @Suppress("UNCHECKED_CAST")
                 val force = prop as KProperty1<T, Any?>
-                transform("${if (this.name != null) this.name + "." else ""}${prop.name}", force::get)
+                transform(appendName(prop.name, separator = "."), force::get)
                     .isEqualTo(prop.get(other))
             }
         }

--- a/assertk/src/template/assertk/assertions/primativeArray.kt
+++ b/assertk/src/template/assertk/assertions/primativeArray.kt
@@ -6,6 +6,7 @@ import assertk.all
 import assertk.assertions.support.expected
 import assertk.assertions.support.show
 import assertk.assertions.support.fail
+import assertk.assertions.support.appendName
 
 $T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArray:Short, LongArray:longArray:Long, FloatArray:floatArray:Float, DoubleArray:doubleArray:Double, CharArray:charArray:Char
 
@@ -166,7 +167,7 @@ fun Assert<$T>.containsOnly(vararg elements: $E) = given { actual ->
  */
 @JvmName("$NIndex")
 fun Assert<$T>.index(index: Int): Assert<$E> =
-    transform("${name ?: ""}${show(index, "[]")}") { actual ->
+    transform(appendName(show(index, "[]"))) { actual ->
         if (index in 0 until actual.size) {
             actual[index]
         } else {
@@ -199,7 +200,7 @@ fun Assert<$T>.containsExactly(vararg elements: $E) = given { actual ->
 fun Assert<$T>.each(f: (Assert<$E>) -> Unit) = given { actual ->
     all {
         actual.forEachIndexed { index, item ->
-            f(assertThat(item, name = "${name ?: ""}${show(index, "[]")}"))
+            f(assertThat(item, name = appendName(show(index, "[]"))))
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'assertk-project'
 
 include 'assertk'
+include 'assertk-coroutines'
 include 'java-interop'
 
 enableFeaturePreview('GRADLE_METADATA')


### PR DESCRIPTION
Some implementation decisions:

- Created a new artifact: `assertk-coroutines`
- The new flow assertions are all `suspend`. This allows you to use them on all supported platforms. In java, you are likely to be wrapping your coroutine tests in a `runBlockingTest`, this plays nicely with that.
- `transform` has been made inline. This allows you to call suspend functions inside of it.
- Unstable coroutine api's are avoided for the most part. Except for cases where it's wrapping an unstable method: `count()`.
- Care is taken to support flows that don't complete when it makes sense.