### PR TITLE
Clean up gradle scripts to share code

### DIFF
--- a/assertk-coroutines/build.gradle
+++ b/assertk-coroutines/build.gradle
@@ -1,125 +1,31 @@
-import org.apache.tools.ant.taskdefs.condition.Os
-
 plugins {
     id 'maven-publish'
     id 'signing'
-    id 'org.jetbrains.kotlin.multiplatform' version '1.3.70'
-    id 'org.jetbrains.dokka' version '0.10.0'
-    id 'io.gitlab.arturbosch.detekt' version '1.5.0'
-    id 'org.ajoberstar.git-publish' version '2.1.1'
+    id 'org.jetbrains.kotlin.multiplatform'
+    id 'org.jetbrains.dokka'
+    id 'io.gitlab.arturbosch.detekt'
+    id 'org.ajoberstar.git-publish'
 }
 
-allprojects {
-    group 'com.willowtreeapps.assertk'
-    version '0.1-SNAPSHOT'
-}
-
-ext {
-    isReleaseVersion = !(project.version =~ /-SNAPSHOT$/)
-}
-
-configurations.all {
-    // Don't cache SNAPSHOT deps
-    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-}
-
-repositories {
-    mavenCentral()
-    jcenter()
-    if (!isReleaseVersion) {
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots'}
-    }
-}
+apply from: "$rootProject.projectDir/multiplatform.gradle"
 
 kotlin {
-    jvm {
-        compilations.main.kotlinOptions {
-            jvmTarget = "1.8"
-        }
-        compilations.test.kotlinOptions {
-            jvmTarget = "1.8"
-        }
-    }
-    js {
-        nodejs()
-        browser()
-        compilations.main.kotlinOptions {
-            sourceMap = true
-            moduleKind = "umd"
-        }
-        compilations.test.kotlinOptions {
-            moduleKind = "umd"
-        }
-    }
-    linuxX64('linux')
-    iosArm64()
-    iosX64()
-    macosX64('macos')
-
-    targets.all {
-        if (name != 'metadata') {
-            compilations.main.kotlinOptions {
-                allWarningsAsErrors = true
-            }
-            compilations.test.kotlinOptions {
-                allWarningsAsErrors = true
-                freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn"]
-            }
-        }
-    }
-
-    def kotlin_coroutines_version = '1.3.4'
-
     sourceSets {
         commonMain {
             dependencies {
-                implementation kotlin('stdlib-common')
                 implementation project(':assertk')
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$kotlin_coroutines_version"
             }
         }
-        commonTest {
-            dependencies {
-                implementation kotlin('test-common')
-                implementation kotlin('test-annotations-common')
-            }
-        }
         jvmMain {
             dependencies {
-                implementation kotlin('stdlib-jdk8')
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"
-            }
-        }
-        jvmTest {
-            dependencies {
-                implementation project(':java-interop')
-                implementation kotlin('test-junit')
-                implementation kotlin('reflect')
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
             }
         }
         jsMain {
             dependencies {
-                implementation kotlin('stdlib-js')
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$kotlin_coroutines_version"
             }
-        }
-        jsTest {
-            dependencies {
-                implementation kotlin('test-js')
-            }
-        }
-        nativeMain {
-            dependsOn(commonMain)
-        }
-        nativeTest {
-            dependsOn(commonTest)
-        }
-        [linuxMain, iosArm64Main, iosX64Main, macosMain].each {
-            it.dependsOn(nativeMain)
-        }
-        [linuxTest, iosArm64Test, iosX64Test, macosTest].each {
-            it.dependsOn(nativeTest)
         }
         linuxMain {
             dependencies {
@@ -142,195 +48,4 @@ kotlin {
             }
         }
     }
-}
-
-task nativeTest {
-    dependsOn(linuxTest, macosTest, iosX64Test)
-}
-
-task test {
-    dependsOn(jvmTest, jsTest, nativeTest)
-}
-
-task detektMain(type: io.gitlab.arturbosch.detekt.Detekt) {
-    setSource(files(kotlin.sourceSets.commonMain.kotlin, kotlin.sourceSets.jsMain.kotlin, kotlin.sourceSets.jvmMain.kotlin, kotlin.sourceSets.nativeMain.kotlin))
-    config.from(files("$rootProject.projectDir/detekt.yml"))
-    buildUponDefaultConfig = true
-    reports {
-        xml.destination = file("$buildDir/reports/detektMain/detekt.xml")
-        html.destination = file("$buildDir/reports/detektMain/detekt.html")
-    }
-}
-
-task detektTest(type: io.gitlab.arturbosch.detekt.Detekt) {
-    setSource(files(kotlin.sourceSets.commonTest.kotlin, kotlin.sourceSets.jsTest.kotlin, kotlin.sourceSets.jvmTest.kotlin, kotlin.sourceSets.nativeTest.kotlin))
-    config.from(files("$rootProject.projectDir/detekt-test.yml"))
-    buildUponDefaultConfig = true
-    reports {
-        xml.destination = file("$buildDir/reports/detektTest/detekt.xml")
-        html.destination = file("$buildDir/reports/detektTest/detekt.html")
-    }
-}
-
-tasks.detekt.dependsOn(detektMain, detektTest)
-
-dokka {
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/"
-    multiplatform {
-        common {}
-        js {}
-        jvm {}
-        linux {}
-        iosArm64 {}
-        iosX64 {}
-        macos {}
-    }
-}
-
-task dokkaCommon(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    impliedPlatforms = ["Common"]
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/common"
-    multiplatform {
-        common {}
-    }
-}
-
-task dokkaJs(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    impliedPlatforms = ["JS", "Common"]
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/js"
-    multiplatform {
-        common {}
-        js {}
-    }
-}
-
-task dokkaJvm(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    impliedPlatforms = ["JVM", "Common"]
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/jvm"
-    multiplatform {
-        common {}
-        jvm {}
-    }
-}
-
-task dokkaNative(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    impliedPlatforms = ["Native", "Common"]
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/native"
-    multiplatform {
-        common {}
-        linux {}
-        iosArm64 {}
-        iosX64 {}
-        macos {}
-    }
-}
-
-task dokkaJavadocCommonJar(type: Jar, dependsOn: dokkaCommon) {
-    archiveClassifier.set('javadoc')
-    from "$buildDir/javadoc/common"
-}
-
-task dokkaJavadocJsJar(type: Jar, dependsOn: dokkaJs) {
-    archiveClassifier.set('javadoc')
-    from "$buildDir/javadoc/js"
-}
-
-task dokkaJavadocJvmJar(type: Jar, dependsOn: dokkaJvm) {
-    archiveClassifier.set('javadoc')
-    from "$buildDir/javadoc/jvm"
-}
-
-task dokkaJavadocNativeJar(type: Jar, dependsOn: dokkaNative) {
-    archiveClassifier.set('javadoc')
-    from "$buildDir/javadoc/native"
-}
-
-task emptySourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-}
-
-publishing {
-    repositories {
-        maven {
-            if (project.ext.isReleaseVersion) {
-                url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            } else {
-                url 'https://oss.sonatype.org/content/repositories/snapshots/'
-            }
-
-            credentials {
-                username = project.findProperty('sonatype.username')
-                password = project.findProperty('sonatype.password')
-            }
-        }
-    }
-
-    publications {
-        js {
-            artifact dokkaJavadocJsJar
-        }
-        jvm {
-            artifact dokkaJavadocJvmJar
-        }
-        linux {
-            artifact dokkaJavadocNativeJar
-        }
-        // These aren't available if you aren't on macos
-        if (Os.isFamily(Os.FAMILY_MAC)) {
-            [iosArm64, iosX64, macos].each {
-                it.artifact dokkaJavadocNativeJar
-            }
-        }
-        metadata {
-            artifact dokkaJavadocCommonJar
-        }
-        kotlinMultiplatform {
-            // Source jars are only created for platforms, not the common artifact.
-            artifact emptySourcesJar
-            artifact dokkaJavadocCommonJar
-        }
-
-        all {
-            def siteUrl = 'https://github.com/willowtreeapps/assertk'
-            def gitUrl = 'https://github.com/willowtreeapps/assertk.git'
-
-            pom {
-                name = project.name
-                description = 'Assertions for Kotlin inspired by assertj - coroutine assertions'
-                url = siteUrl
-
-                scm {
-                    url = siteUrl
-                    connection = gitUrl
-                    developerConnection = gitUrl
-                }
-
-                licenses {
-                    license {
-                        name = 'The Apache Software License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution = 'repo'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'evant'
-                        name = 'Evan Tatarka'
-                    }
-                }
-            }
-        }
-    }
-}
-
-if (isReleaseVersion) {
-  signing {
-      publishing.publications.all { sign it }
-  }
 }

--- a/assertk/build.gradle
+++ b/assertk/build.gradle
@@ -1,35 +1,13 @@
-import org.apache.tools.ant.taskdefs.condition.Os
-
 plugins {
     id 'maven-publish'
     id 'signing'
-    id 'org.jetbrains.kotlin.multiplatform' version '1.3.70'
-    id 'org.jetbrains.dokka' version '0.10.0'
-    id 'io.gitlab.arturbosch.detekt' version '1.5.0'
-    id 'org.ajoberstar.git-publish' version '2.1.1'
+    id 'org.jetbrains.kotlin.multiplatform'
+    id 'org.jetbrains.dokka'
+    id 'io.gitlab.arturbosch.detekt'
+    id 'org.ajoberstar.git-publish'
 }
 
-allprojects {
-    group 'com.willowtreeapps.assertk'
-    version '0.23-SNAPSHOT'
-}
-
-ext {
-    isReleaseVersion = !(project.version =~ /-SNAPSHOT$/)
-}
-
-configurations.all {
-    // Don't cache SNAPSHOT deps
-    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-}
-
-repositories {
-    mavenCentral()
-    jcenter()
-    if (!isReleaseVersion) {
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots'}
-    }
-}
+apply from: "$rootProject.projectDir/multiplatform.gradle"
 
 task compileTemplates(type: TemplateTask) {
     inputDir = file('src/template')
@@ -42,72 +20,24 @@ task compileTestTemplates(type: TemplateTask) {
 }
 
 kotlin {
-    jvm {
-        compilations.main.kotlinOptions {
-            jvmTarget = "1.8"
-        }
-        compilations.test.kotlinOptions {
-            jvmTarget = "1.8"
-        }
-    }
-    js {
-        nodejs()
-        browser()
-        compilations.main.kotlinOptions {
-            sourceMap = true
-            moduleKind = "umd"
-        }
-        compilations.test.kotlinOptions {
-            moduleKind = "umd"
-        }
-    }
-    linuxX64('linux')
-    iosArm64()
-    iosX64()
-    macosX64('macos')
-
-    targets.all {
-        if (name != 'metadata') {
-            compilations.main.kotlinOptions {
-                allWarningsAsErrors = true
-            }
-            compilations.test.kotlinOptions {
-                allWarningsAsErrors = true
-                freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn"]
-            }
-        }
-    }
-
-    def opentest4k_version = '1.2.0'
-    def kotlin_coroutines_version = '1.3.4'
-
     sourceSets {
         commonMain {
             dependencies {
-                implementation kotlin('stdlib-common')
                 implementation "com.willowtreeapps.opentest4k:opentest4k:$opentest4k_version"
             }
             kotlin.srcDirs += files(compileTemplates)
         }
         commonTest {
-            dependencies {
-                implementation kotlin('test-common')
-                implementation kotlin('test-annotations-common')
-            }
             kotlin.srcDirs += files(compileTestTemplates)
         }
         jvmMain {
             dependencies {
-                implementation kotlin('stdlib-jdk8')
                 compileOnly kotlin('reflect')
             }
         }
         jvmTest {
             dependencies {
                 implementation project(':java-interop')
-                implementation kotlin('test-junit')
-                implementation kotlin('reflect')
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
             }
         }
         jsMain {
@@ -115,60 +45,13 @@ kotlin {
 		// kotlin-js doesn't handle this as a transitive dep correctly
 		// when it's scoped as runtime.
                 api "com.willowtreeapps.opentest4k:opentest4k-js:$opentest4k_version"
-                implementation kotlin('stdlib-js')
-            }
-        }
-        jsTest {
-            dependencies {
-                implementation kotlin('test-js')
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$kotlin_coroutines_version"
-            }
-        }
-        nativeMain {
-            dependsOn(commonMain)
-        }
-        nativeTest {
-            dependsOn(commonTest)
-        }
-        [linuxMain, iosArm64Main, iosX64Main, macosMain].each {
-            it.dependsOn(nativeMain)
-        }
-        [linuxTest, iosArm64Test, iosX64Test, macosTest].each {
-            it.dependsOn(nativeTest)
-        }
-        linuxTest {
-            dependencies {
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-linuxx64:$kotlin_coroutines_version"
-            }
-        }
-        iosArm64Test {
-            dependencies {
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosarm64:$kotlin_coroutines_version"
-            }
-        }
-        iosX64Test {
-            dependencies {
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:$kotlin_coroutines_version"
-            }
-        }
-        macosTest {
-            dependencies {
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:$kotlin_coroutines_version"
             }
         }
     }
 }
 
-[compileKotlinMetadata, compileKotlinJvm, compileKotlinJs].each { it.dependsOn(compileTemplates) }
+[compileKotlinJvm, compileKotlinJs].each { it.dependsOn(compileTemplates) }
 [compileTestKotlinJvm, compileTestKotlinJs].each { it.dependsOn(compileTestTemplates) }
-
-task nativeTest {
-    dependsOn(linuxTest, macosTest, iosX64Test)
-}
-
-task test {
-    dependsOn(jvmTest, jsTest, nativeTest)
-}
 
 gitPublish {
     repoUri = 'git@github.com:willowtreeapps/assertk.git'
@@ -180,186 +63,3 @@ gitPublish {
 }
 
 gitPublishCopy.dependsOn(dokka)
-
-task detektMain(type: io.gitlab.arturbosch.detekt.Detekt) {
-    setSource(files(kotlin.sourceSets.commonMain.kotlin, kotlin.sourceSets.jsMain.kotlin, kotlin.sourceSets.jvmMain.kotlin, kotlin.sourceSets.nativeMain.kotlin))
-    config.from(files("$rootProject.projectDir/detekt.yml"))
-    buildUponDefaultConfig = true
-    reports {
-        xml.destination = file("$buildDir/reports/detektMain/detekt.xml")
-        html.destination = file("$buildDir/reports/detektMain/detekt.html")
-    }
-}
-
-task detektTest(type: io.gitlab.arturbosch.detekt.Detekt) {
-    setSource(files(kotlin.sourceSets.commonTest.kotlin, kotlin.sourceSets.jsTest.kotlin, kotlin.sourceSets.jvmTest.kotlin, kotlin.sourceSets.nativeTest.kotlin))
-    config.from(files("$rootProject.projectDir/detekt-test.yml"))
-    buildUponDefaultConfig = true
-    reports {
-        xml.destination = file("$buildDir/reports/detektTest/detekt.xml")
-        html.destination = file("$buildDir/reports/detektTest/detekt.html")
-    }
-}
-
-tasks.detekt.dependsOn(detektMain, detektTest)
-
-dokka {
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/"
-    multiplatform {
-        common {}
-        js {}
-        jvm {}
-        linux {}
-        iosArm64 {}
-        iosX64 {}
-        macos {}
-    }
-}
-
-task dokkaCommon(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    impliedPlatforms = ["Common"]
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/common"
-    multiplatform {
-        common {}
-    }
-}
-
-task dokkaJs(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    impliedPlatforms = ["JS", "Common"]
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/js"
-    multiplatform {
-        common {}
-        js {}
-    }
-}
-
-task dokkaJvm(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    impliedPlatforms = ["JVM", "Common"]
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/jvm"
-    multiplatform {
-        common {}
-        jvm {}
-    }
-}
-
-task dokkaNative(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    impliedPlatforms = ["Native", "Common"]
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc/native"
-    multiplatform {
-        common {}
-        linux {}
-        iosArm64 {}
-        iosX64 {}
-        macos {}
-    }
-}
-
-task dokkaJavadocCommonJar(type: Jar, dependsOn: dokkaCommon) {
-    archiveClassifier.set('javadoc')
-    from "$buildDir/javadoc/common"
-}
-
-task dokkaJavadocJsJar(type: Jar, dependsOn: dokkaJs) {
-    archiveClassifier.set('javadoc')
-    from "$buildDir/javadoc/js"
-}
-
-task dokkaJavadocJvmJar(type: Jar, dependsOn: dokkaJvm) {
-    archiveClassifier.set('javadoc')
-    from "$buildDir/javadoc/jvm"
-}
-
-task dokkaJavadocNativeJar(type: Jar, dependsOn: dokkaNative) {
-    archiveClassifier.set('javadoc')
-    from "$buildDir/javadoc/native"
-}
-
-task emptySourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-}
-
-publishing {
-    repositories {
-        maven {
-            if (project.ext.isReleaseVersion) {
-                url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            } else {
-                url 'https://oss.sonatype.org/content/repositories/snapshots/'
-            }
-
-            credentials {
-                username = project.findProperty('sonatype.username')
-                password = project.findProperty('sonatype.password')
-            }
-        }
-    }
-
-    publications {
-        js {
-            artifact dokkaJavadocJsJar
-        }
-        jvm {
-            artifact dokkaJavadocJvmJar
-        }
-        linux {
-            artifact dokkaJavadocNativeJar
-        }
-        // These aren't available if you aren't on macos
-        if (Os.isFamily(Os.FAMILY_MAC)) {
-            [iosArm64, iosX64, macos].each {
-                it.artifact dokkaJavadocNativeJar
-            }
-        }
-        metadata {
-            artifact dokkaJavadocCommonJar
-        }
-        kotlinMultiplatform {
-            // Source jars are only created for platforms, not the common artifact.
-            artifact emptySourcesJar
-            artifact dokkaJavadocCommonJar
-        }
-
-        all {
-            def siteUrl = 'https://github.com/willowtreeapps/assertk'
-            def gitUrl = 'https://github.com/willowtreeapps/assertk.git'
-
-            pom {
-                name = project.name
-                description = 'Assertions for Kotlin inspired by assertj'
-                url = siteUrl
-
-                scm {
-                    url = siteUrl
-                    connection = gitUrl
-                    developerConnection = gitUrl
-                }
-
-                licenses {
-                    license {
-                        name = 'The Apache Software License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution = 'repo'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'evant'
-                        name = 'Evan Tatarka'
-                    }
-                }
-            }
-        }
-    }
-}
-
-if (isReleaseVersion) {
-  signing {
-      publishing.publications.all { sign it }
-  }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,222 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.dokka.gradle.DokkaTask
+
+plugins {
+    id 'org.jetbrains.kotlin.multiplatform' version '1.3.70' apply false
+    id 'org.jetbrains.dokka' version '0.10.0' apply false
+    id 'io.gitlab.arturbosch.detekt' version '1.5.0' apply false
+    id 'org.ajoberstar.git-publish' version '2.1.1' apply false
+}
+
+ext {
+    isReleaseVersion = !(project.version =~ /-SNAPSHOT$/)
+
+    opentest4k_version = '1.2.0'
+    kotlin_coroutines_version = '1.3.4'
+}
+
+subprojects {
+    group 'com.willowtreeapps.assertk'
+    version '0.23-SNAPSHOT'
+
+    configurations.all {
+        // Don't cache SNAPSHOT deps
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+
+    repositories {
+        mavenCentral()
+        jcenter()
+        if (!isReleaseVersion) {
+            maven { url 'https://oss.sonatype.org/content/repositories/snapshots'}
+        }
+    }
+}
+
+configure(subprojects.findAll({ it.name.startsWith('assertk') })) {
+    afterEvaluate {
+        task detektMain(type: Detekt) {
+            setSource(files(kotlin.sourceSets.commonMain.kotlin, kotlin.sourceSets.jsMain.kotlin, kotlin.sourceSets.jvmMain.kotlin, kotlin.sourceSets.nativeMain.kotlin))
+            config.from(files("$rootProject.projectDir/detekt.yml"))
+            buildUponDefaultConfig = true
+            reports {
+                xml.destination = file("$buildDir/reports/detektMain/detekt.xml")
+                html.destination = file("$buildDir/reports/detektMain/detekt.html")
+            }
+        }
+
+        task detektTest(type: Detekt) {
+            setSource(files(kotlin.sourceSets.commonTest.kotlin, kotlin.sourceSets.jsTest.kotlin, kotlin.sourceSets.jvmTest.kotlin, kotlin.sourceSets.nativeTest.kotlin))
+            config.from(files("$rootProject.projectDir/detekt-test.yml"))
+            buildUponDefaultConfig = true
+            reports {
+                xml.destination = file("$buildDir/reports/detektTest/detekt.xml")
+                html.destination = file("$buildDir/reports/detektTest/detekt.html")
+            }
+        }
+
+        tasks.detekt.dependsOn(detektMain, detektTest)
+
+        dokka {
+            outputFormat = 'html'
+            outputDirectory = "$buildDir/javadoc/"
+            multiplatform {
+                common {}
+                js {}
+                jvm {}
+                linux {}
+                iosArm64 {}
+                iosX64 {}
+                macos {}
+            }
+        }
+
+        task dokkaCommon(type: DokkaTask) {
+            impliedPlatforms = ["Common"]
+            outputFormat = 'html'
+            outputDirectory = "$buildDir/javadoc/common"
+            multiplatform {
+                common {}
+            }
+        }
+
+        task dokkaJs(type: DokkaTask) {
+            impliedPlatforms = ["JS", "Common"]
+            outputFormat = 'html'
+            outputDirectory = "$buildDir/javadoc/js"
+            multiplatform {
+                common {}
+                js {}
+            }
+        }
+
+        task dokkaJvm(type: DokkaTask) {
+            impliedPlatforms = ["JVM", "Common"]
+            outputFormat = 'html'
+            outputDirectory = "$buildDir/javadoc/jvm"
+            multiplatform {
+                common {}
+                jvm {}
+            }
+        }
+
+        task dokkaNative(type: DokkaTask) {
+            impliedPlatforms = ["Native", "Common"]
+            outputFormat = 'html'
+            outputDirectory = "$buildDir/javadoc/native"
+            multiplatform {
+                common {}
+                linux {}
+                iosArm64 {}
+                iosX64 {}
+                macos {}
+            }
+        }
+
+        task dokkaJavadocCommonJar(type: Jar, dependsOn: dokkaCommon) {
+            archiveClassifier.set('javadoc')
+            from "$buildDir/javadoc/common"
+        }
+
+        task dokkaJavadocJsJar(type: Jar, dependsOn: dokkaJs) {
+            archiveClassifier.set('javadoc')
+            from "$buildDir/javadoc/js"
+        }
+
+        task dokkaJavadocJvmJar(type: Jar, dependsOn: dokkaJvm) {
+            archiveClassifier.set('javadoc')
+            from "$buildDir/javadoc/jvm"
+        }
+
+        task dokkaJavadocNativeJar(type: Jar, dependsOn: dokkaNative) {
+            archiveClassifier.set('javadoc')
+            from "$buildDir/javadoc/native"
+        }
+
+        task emptySourcesJar(type: Jar) {
+            archiveClassifier.set('sources')
+        }
+
+        publishing {
+            repositories {
+                maven {
+                    if (rootProject.ext.isReleaseVersion) {
+                        url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                    } else {
+                        url 'https://oss.sonatype.org/content/repositories/snapshots/'
+                    }
+
+                    credentials {
+                        username = project.findProperty('sonatype.username')
+                        password = project.findProperty('sonatype.password')
+                    }
+                }
+            }
+
+            publications {
+                js {
+                    artifact dokkaJavadocJsJar
+                }
+                jvm {
+                    artifact dokkaJavadocJvmJar
+                }
+                linux {
+                    artifact dokkaJavadocNativeJar
+                }
+                // These aren't available if you aren't on macos
+                if (Os.isFamily(Os.FAMILY_MAC)) {
+                    [iosArm64, iosX64, macos].each {
+                        it.artifact dokkaJavadocNativeJar
+                    }
+                }
+                metadata {
+                    artifact dokkaJavadocCommonJar
+                }
+                kotlinMultiplatform {
+                    // Source jars are only created for platforms, not the common artifact.
+                    artifact emptySourcesJar
+                    artifact dokkaJavadocCommonJar
+                }
+
+                all {
+                    def siteUrl = 'https://github.com/willowtreeapps/assertk'
+                    def gitUrl = 'https://github.com/willowtreeapps/assertk.git'
+
+                    pom {
+                        name = project.name
+                        description = 'Assertions for Kotlin inspired by assertj'
+                        url = siteUrl
+
+                        scm {
+                            url = siteUrl
+                            connection = gitUrl
+                            developerConnection = gitUrl
+                        }
+
+                        licenses {
+                            license {
+                                name = 'The Apache Software License, Version 2.0'
+                                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                                distribution = 'repo'
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                id = 'evant'
+                                name = 'Evan Tatarka'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (isReleaseVersion) {
+            signing {
+                publishing.publications.all { sign it }
+            }
+        }
+    }
+}

--- a/multiplatform.gradle
+++ b/multiplatform.gradle
@@ -1,0 +1,115 @@
+kotlin {
+    jvm {
+        compilations.main.kotlinOptions {
+            jvmTarget = "1.8"
+        }
+        compilations.test.kotlinOptions {
+            jvmTarget = "1.8"
+        }
+    }
+    js {
+        nodejs()
+        browser()
+        compilations.main.kotlinOptions {
+            sourceMap = true
+            moduleKind = "umd"
+        }
+        compilations.test.kotlinOptions {
+            moduleKind = "umd"
+        }
+    }
+    linuxX64('linux')
+    iosArm64()
+    iosX64()
+    macosX64('macos')
+
+    targets.all {
+        if (name != 'metadata') {
+            compilations.main.kotlinOptions {
+                allWarningsAsErrors = true
+            }
+            compilations.test.kotlinOptions {
+                allWarningsAsErrors = true
+                freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn"]
+            }
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation kotlin('stdlib-common')
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation kotlin('test-common')
+                implementation kotlin('test-annotations-common')
+            }
+        }
+        jvmMain {
+            dependencies {
+                implementation kotlin('stdlib-jdk8')
+            }
+        }
+        jvmTest {
+            dependencies {
+                implementation kotlin('test-junit')
+                implementation kotlin('reflect')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
+            }
+        }
+        jsMain {
+            dependencies {
+                implementation kotlin('stdlib-js')
+            }
+        }
+        jsTest {
+            dependencies {
+                implementation kotlin('test-js')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$kotlin_coroutines_version"
+            }
+        }
+        nativeMain {
+            dependsOn(commonMain)
+        }
+        nativeTest {
+            dependsOn(commonTest)
+        }
+        [linuxMain, iosArm64Main, iosX64Main, macosMain].each {
+            it.dependsOn(nativeMain)
+        }
+        [linuxTest, iosArm64Test, iosX64Test, macosTest].each {
+            it.dependsOn(nativeTest)
+        }
+        linuxTest {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-linuxx64:$kotlin_coroutines_version"
+            }
+        }
+        iosArm64Test {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosarm64:$kotlin_coroutines_version"
+            }
+        }
+        iosX64Test {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:$kotlin_coroutines_version"
+            }
+        }
+        macosTest {
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-macosx64:$kotlin_coroutines_version"
+            }
+        }
+    }
+}
+
+task nativeTest {
+    dependsOn(linuxTest, macosTest, iosX64Test)
+}
+
+task test {
+    dependsOn(jvmTest, jsTest, nativeTest)
+}
+


### PR DESCRIPTION
Not super happy about the random split between `multiplatform.gradle` and the top-level `build.gradle` but couldn't figure out another way to do it.