### PR TITLE
Convert Assert<String> extensions into Assert<CharSequence> extensions.

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assertions/charsequence.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/charsequence.kt
@@ -53,3 +53,94 @@ fun Assert<CharSequence>.hasSameLengthAs(other: CharSequence) = given { actual -
     if (actualLength == otherLength) return
     expected("to have same length as:${show(other)} ($otherLength) but was:${show(actual)} ($actualLength)")
 }
+
+/**
+ * Asserts the char sequence has the expected number of lines.
+ */
+fun Assert<CharSequence>.hasLineCount(lineCount: Int) = given { actual ->
+    val actualLineCount = actual.lines().size
+    if (actualLineCount == lineCount) return
+    expected("to have line count:${show(lineCount)} but was:${show(actualLineCount)}")
+}
+
+/**
+ * Asserts the char sequence contains the expected subsequence.
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<CharSequence>.contains(expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
+    if (actual.contains(expected, ignoreCase)) return
+    expected("to contain:${show(expected)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the char sequence contains the expected subsequence(s).
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<CharSequence>.contains(vararg expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
+    if (expected.all { actual.contains(it, ignoreCase) }) return
+    expected("to contain:${show(expected)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the char sequence contains the expected char sequences.
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<CharSequence>.contains(expected: Iterable<CharSequence>, ignoreCase: Boolean = false) = given { actual ->
+    if (expected.all { actual.contains(it, ignoreCase) }) return
+    expected("to contain:${show(expected)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the char sequence does not contain the specified char sequence.
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<CharSequence>.doesNotContain(expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
+    if (!actual.contains(expected, ignoreCase)) return
+    expected("to not contain:${show(expected)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the char sequence does not contain the specified char sequence(s).
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<CharSequence>.doesNotContain(vararg expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
+    if (expected.none { actual.contains(it, ignoreCase) }) return
+    expected("to not contain:${show(expected)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the char sequence does not contain the specified char sequences.
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ */
+fun Assert<CharSequence>.doesNotContain(expected: Iterable<CharSequence>, ignoreCase: Boolean = false) = given { actual ->
+    if (expected.none { actual.contains(it, ignoreCase) }) return
+    expected("to not contain:${show(expected)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the char sequence starts with the expected char sequence.
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ * @see [endsWith]
+ */
+fun Assert<CharSequence>.startsWith(other: CharSequence, ignoreCase: Boolean = false) = given { actual ->
+    if (actual.startsWith(other, ignoreCase)) return
+    expected("to start with:${show(other)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the char sequence ends with the expected char sequence.
+ * @param ignoreCase true to compare ignoring case, the default if false.
+ * @see [startsWith]
+ */
+fun Assert<CharSequence>.endsWith(other: CharSequence, ignoreCase: Boolean = false) = given { actual ->
+    if (actual.endsWith(other, ignoreCase)) return
+    expected("to end with:${show(other)} but was:${show(actual)}")
+}
+
+/**
+ * Asserts the char sequence matches the expected regular expression.
+ */
+fun Assert<CharSequence>.matches(regex: Regex) = given { actual ->
+    if (actual.matches(regex)) return
+    expected("to match:${show(regex)} but was:${show(actual)}")
+}

--- a/assertk/src/commonMain/kotlin/assertk/assertions/string.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/string.kt
@@ -6,15 +6,6 @@ import assertk.assertions.support.fail
 import assertk.assertions.support.show
 
 /**
- * Asserts the string has the expected number of lines.
- */
-fun Assert<String>.hasLineCount(lineCount: Int) = given { actual ->
-    val actualLineCount = actual.lines().size
-    if (actualLineCount == lineCount) return
-    expected("to have line count:${show(lineCount)} but was:${show(actualLineCount)}")
-}
-
-/**
  * Asserts the string is equal to the expected string.
  * @param ignoreCase true to compare ignoring case, the default if false.
  * @see [isNotEqualTo]
@@ -36,86 +27,4 @@ fun Assert<String?>.isNotEqualTo(other: String?, ignoreCase: Boolean = false) = 
     } else {
         expected("to not be equal to:${show(actual)}")
     }
-}
-
-/**
- * Asserts the string contains the expected substring.
- * @param ignoreCase true to compare ignoring case, the default if false.
- */
-fun Assert<String>.contains(expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
-    if (actual.contains(expected, ignoreCase)) return
-    expected("to contain:${show(expected)} but was:${show(actual)}")
-}
-
-/**
- * Asserts the string contains the expected substring(s).
- * @param ignoreCase true to compare ignoring case, the default if false.
- */
-fun Assert<String>.contains(vararg expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
-    if (expected.all { actual.contains(it, ignoreCase) }) return
-    expected("to contain:${show(expected)} but was:${show(actual)}")
-}
-
-/**
- * Asserts the string contains the expected strings.
- * @param ignoreCase true to compare ignoring case, the default if false.
- */
-fun Assert<String>.contains(expected: Iterable<CharSequence>, ignoreCase: Boolean = false) = given { actual ->
-    if (expected.all { actual.contains(it, ignoreCase) }) return
-    expected("to contain:${show(expected)} but was:${show(actual)}")
-}
-
-/**
- * Asserts the string does not contain the specified string.
- * @param ignoreCase true to compare ignoring case, the default if false.
- */
-fun Assert<String>.doesNotContain(expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
-    if (!actual.contains(expected, ignoreCase)) return
-    expected("to not contain:${show(expected)} but was:${show(actual)}")
-}
-
-/**
- * Asserts the string does not contain the specified string(s).
- * @param ignoreCase true to compare ignoring case, the default if false.
- */
-fun Assert<String>.doesNotContain(vararg expected: CharSequence, ignoreCase: Boolean = false) = given { actual ->
-    if (expected.none { actual.contains(it, ignoreCase) }) return
-    expected("to not contain:${show(expected)} but was:${show(actual)}")
-}
-
-/**
- * Asserts the string does not contain the specified strings.
- * @param ignoreCase true to compare ignoring case, the default if false.
- */
-fun Assert<String>.doesNotContain(expected: Iterable<CharSequence>, ignoreCase: Boolean = false) = given { actual ->
-    if (expected.none { actual.contains(it, ignoreCase) }) return
-    expected("to not contain:${show(expected)} but was:${show(actual)}")
-}
-
-/**
- * Asserts the string starts with the expected string.
- * @param ignoreCase true to compare ignoring case, the default if false.
- * @see [endsWith]
- */
-fun Assert<String>.startsWith(other: String, ignoreCase: Boolean = false) = given { actual ->
-    if (actual.startsWith(other, ignoreCase)) return
-    expected("to start with:${show(other)} but was:${show(actual)}")
-}
-
-/**
- * Asserts the string ends with the expected string.
- * @param ignoreCase true to compare ignoring case, the default if false.
- * @see [startsWith]
- */
-fun Assert<String>.endsWith(other: String, ignoreCase: Boolean = false) = given { actual ->
-    if (actual.endsWith(other, ignoreCase)) return
-    expected("to end with:${show(other)} but was:${show(actual)}")
-}
-
-/**
- * Asserts the string matches the expected regular expression.
- */
-fun Assert<String>.matches(regex: Regex) = given { actual ->
-    if (actual.matches(regex)) return
-    expected("to match:${show(regex)} but was:${show(actual)}")
 }

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/CharSequenceTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/CharSequenceTest.kt
@@ -2,6 +2,7 @@ package test.assertk.assertions
 
 import assertk.assertThat
 import assertk.assertions.*
+import assertk.assertions.support.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -79,6 +80,194 @@ class CharSequenceTest {
             assertThat("test").hasSameLengthAs("")
         }
         assertEquals("expected to have same length as:<\"\"> (0) but was:<\"test\"> (4)", error.message)
+    }
+    //endregion
+
+    //region contains single
+    @Test fun contains_value_substring_passes() {
+        assertThat("test").contains("est")
+    }
+
+    @Test fun contains_value_not_substring_fails() {
+        val error = assertFails {
+            assertThat("test").contains("not")
+        }
+        assertEquals("expected to contain:<\"not\"> but was:<\"test\">", error.message)
+    }
+
+    @Test fun contains_value_substring_ignore_case_passes() {
+        assertThat("Test").contains("EST", true)
+    }
+
+    @Test fun contains_value_not_substring_ignore_case_fails() {
+        val error = assertFails {
+            assertThat("Test").contains("EST", false)
+        }
+        assertEquals("expected to contain:<\"EST\"> but was:<\"Test\">", error.message)
+    }
+    //endregion
+
+    //region contains multi
+    @Test fun contains_empty_arg_passes() {
+        assertThat("test").contains()
+    }
+
+    @Test fun contains_value_contains_passes() {
+        assertThat("test").contains("te", "st")
+    }
+
+    @Test fun contains_list_contains_passes() {
+        assertThat("test").contains(listOf("te", "st"))
+    }
+
+    @Test fun contains_contains_unordered_passes() {
+        assertThat("test").contains("st", "te")
+    }
+
+    @Test fun contains_value_not_contains_fails() {
+        val error = assertFails {
+            assertThat("test").contains("foo", "bar")
+        }
+        assertEquals("expected to contain:<[\"foo\", \"bar\"]> but was:<\"test\">", error.message)
+    }
+
+    @Test fun contains_value_contains_ignore_case_passes() {
+        assertThat("Test").contains("te", "ST", ignoreCase = true)
+    }
+
+    @Test fun contains_value_not_contains_ignore_case_fails() {
+        val error = assertFails {
+            assertThat("Test").contains("te", "ST", ignoreCase = false)
+        }
+        assertEquals("expected to contain:<[\"te\", \"ST\"]> but was:<\"Test\">", error.message)
+    }
+    //endregion
+
+
+    //region doesNotContain single
+    @Test fun doesNotContain_value_not_substring_passes() {
+        assertThat("test").doesNotContain("not")
+    }
+
+    @Test fun doesNotContain_value_substring_fails() {
+        val error = assertFails {
+            assertThat("test").doesNotContain("est")
+        }
+        assertEquals("expected to not contain:<\"est\"> but was:<\"test\">", error.message)
+    }
+
+    @Test fun doesNotContain_value_substring_ignore_case_fails() {
+        val error = assertFails {
+            assertThat("Test").doesNotContain("EST", true)
+        }
+        assertEquals("expected to not contain:<\"EST\"> but was:<\"Test\">", error.message)
+    }
+
+    @Test fun doesNotContain_value_not_substring_ignore_case_passes() {
+        assertThat("Test").doesNotContain("EST", false)
+    }
+    //endregion
+
+    //region doesNotContain multi
+    @Test fun doesNotContain_multivalue_not_substring_passes() {
+        assertThat("test").doesNotContain("foo", "bar")
+    }
+
+    @Test fun doesNotContain_multivalue_substring_fails() {
+        val error = assertFails {
+            assertThat("test").doesNotContain("te", "st")
+        }
+        assertEquals("expected to not contain:<[\"te\", \"st\"]> but was:<\"test\">", error.message)
+    }
+
+    @Test fun doesNotContain_multivalue_substring_ignore_case_fails() {
+        val error = assertFails {
+            assertThat("Test").doesNotContain("TE", "ST", ignoreCase = true)
+        }
+        assertEquals("expected to not contain:<[\"TE\", \"ST\"]> but was:<\"Test\">", error.message)
+    }
+
+    @Test fun doesNotContain_multivalue_not_substring_ignore_case_passes() {
+        assertThat("Test").doesNotContain("TE", "ST", ignoreCase = false)
+    }
+    //endregion
+
+    //region startsWith
+    @Test fun startsWith_value_prefix_passes() {
+        assertThat("test").startsWith("te")
+    }
+
+    @Test fun startsWith_value_not_prefix_fails() {
+        val error = assertFails {
+            assertThat("test").startsWith("st")
+        }
+        assertEquals("expected to start with:<\"st\"> but was:<\"test\">", error.message)
+    }
+
+    @Test fun startsWith_value_prefix_ignore_case_passes() {
+        assertThat("test").startsWith("TE", true)
+    }
+
+    @Test fun startsWith_value_not_prefix_ignore_case_fails() {
+        val error = assertFails {
+            assertThat("test").startsWith("TE", false)
+        }
+        assertEquals("expected to start with:<\"TE\"> but was:<\"test\">", error.message)
+    }
+    //endregion
+
+    //region endsWith
+    @Test fun endsWith_value_suffix_passes() {
+        assertThat("test").endsWith("st")
+    }
+
+    @Test fun endsWith_value_not_suffix_fails() {
+        val error = assertFails {
+            assertThat("test").endsWith("te")
+        }
+        assertEquals("expected to end with:<\"te\"> but was:<\"test\">", error.message)
+    }
+
+    @Test fun endsWith_value_suffix_ignore_case_passes() {
+        assertThat("test").endsWith("ST", true)
+    }
+
+    @Test fun endsWith_value_not_suffix_ignore_case_passes() {
+        val error = assertFails {
+            assertThat("test").endsWith("ST", false)
+        }
+        assertEquals("expected to end with:<\"ST\"> but was:<\"test\">", error.message)
+    }
+    //endregion
+
+    //region hasLineCount
+    @Test fun hasLineCount_correct_value_passes() {
+        assertThat("").hasLineCount(1)
+        assertThat("test test").hasLineCount(1)
+        assertThat("test test\ntest test").hasLineCount(2)
+        assertThat("test test\r\ntest test").hasLineCount(2)
+        assertThat("test test\rtest test").hasLineCount(2)
+    }
+
+    @Test fun hasLineCount_wrong_value_fails() {
+        val error = assertFails {
+            assertThat("test test").hasLineCount(2)
+        }
+        assertEquals("expected to have line count:<2> but was:<1>", error.message)
+    }
+    //endregion
+
+    //region matches
+    @Test fun matches_matching_value_passes() {
+        assertThat("1234").matches(Regex("\\d\\d\\d\\d"))
+    }
+
+    @Test fun matches_not_matching_value_fails() {
+        val regex = Regex("\\d\\d\\d\\d")
+        val error = assertFails {
+            assertThat("12345").matches(regex)
+        }
+        assertEquals("expected to match:${show(regex)} but was:<\"12345\">", error.message)
     }
     //endregion
 }

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
@@ -1,8 +1,8 @@
 package test.assertk.assertions
 
 import assertk.assertThat
-import assertk.assertions.*
-import assertk.assertions.support.show
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -10,43 +10,58 @@ import kotlin.test.assertFails
 class StringTest {
 
     //region isEqualTo
-    @Test fun isEqualTo_same_value_passes() {
+    @Test
+    fun isEqualTo_same_value_passes() {
         assertThat("test").isEqualTo("test")
     }
 
-    @Test fun isEqualTo_different_value_fails() {
+    @Test
+    fun isEqualTo_different_value_fails() {
         val error = assertFails {
             assertThat("").isEqualTo("test")
         }
         assertEquals("expected:<\"[test]\"> but was:<\"[]\">", error.message)
     }
 
-    @Test fun isEqualTo_same_value_ignore_case_passes() {
+    @Test
+    fun isEqualTo_different_null_value_fails() {
+        val error = assertFails {
+            assertThat("null").isEqualTo(null)
+        }
+        assertEquals("expected:<null> but was:<\"null\">", error.message)
+    }
+
+    @Test
+    fun isEqualTo_same_value_ignore_case_passes() {
         assertThat("Test").isEqualTo("tesT", true)
     }
 
-    @Test fun isEqualTo_different_value_ignore_case_fails() {
+    @Test
+    fun isEqualTo_different_value_ignore_case_fails() {
         val error = assertFails {
             assertThat("Test").isEqualTo("tesT", false)
         }
         assertEquals("expected:<\"[tesT]\"> but was:<\"[Test]\">", error.message)
     }
 
-    @Test fun isEqualTo_renders_different_line_endings() {
+    @Test
+    fun isEqualTo_renders_different_line_endings() {
         val error = assertFails {
             assertThat("Test\n").isEqualTo("Test\r\n")
         }
         assertEquals("expected:<\"Test[\\r]\n\"> but was:<\"Test[]\n\">", error.message)
     }
 
-    @Test fun isEqual_renders_tabs_vs_spaces() {
+    @Test
+    fun isEqual_renders_tabs_vs_spaces() {
         val error = assertFails {
             assertThat("\tTest").isEqualTo("    Test")
         }
         assertEquals("expected:<\"[    ]Test\"> but was:<\"[\\t]Test\">", error.message)
     }
 
-    @Test fun isEqual_renders_newline_vs_not() {
+    @Test
+    fun isEqual_renders_newline_vs_not() {
         val error = assertFails {
             assertThat("Test\n").isEqualTo("Test")
         }
@@ -55,214 +70,36 @@ class StringTest {
     //endregion
 
     //region isNotEqualTo
-    @Test fun isNotEqualTo_same_value_fails() {
+    @Test
+    fun isNotEqualTo_same_value_fails() {
         val error = assertFails {
             assertThat("test").isNotEqualTo("test")
         }
         assertEquals("expected to not be equal to:<\"test\">", error.message)
     }
 
-    @Test fun isNotEqualTo_different_value_passes() {
+    @Test
+    fun isNotEqualTo_different_value_passes() {
         assertThat("").isNotEqualTo("test")
     }
 
-    @Test fun isNotEqualTo_same_value_ignore_case_fails() {
+    @Test
+    fun isNotEqualTo_different_null_value_passes() {
+        assertThat("null").isNotEqualTo(null)
+    }
+
+    @Test
+    fun isNotEqualTo_same_value_ignore_case_fails() {
         val error = assertFails {
             assertThat("Test").isNotEqualTo("tesT", true)
         }
         assertEquals("expected:<\"tesT\"> not to be equal to (ignoring case):<\"Test\">", error.message)
     }
 
-    @Test fun isNotEqualTo_different_value_ignore_case_passes() {
+    @Test
+    fun isNotEqualTo_different_value_ignore_case_passes() {
         assertThat("Test").isNotEqualTo("tesT", false)
     }
     //endregion
 
-    //region contains single
-    @Test fun contains_value_substring_passes() {
-        assertThat("test").contains("est")
-    }
-
-    @Test fun contains_value_not_substring_fails() {
-        val error = assertFails {
-            assertThat("test").contains("not")
-        }
-        assertEquals("expected to contain:<\"not\"> but was:<\"test\">", error.message)
-    }
-
-    @Test fun contains_value_substring_ignore_case_passes() {
-        assertThat("Test").contains("EST", true)
-    }
-
-    @Test fun contains_value_not_substring_ignore_case_fails() {
-        val error = assertFails {
-            assertThat("Test").contains("EST", false)
-        }
-        assertEquals("expected to contain:<\"EST\"> but was:<\"Test\">", error.message)
-    }
-    //endregion
-
-    //region contains multi
-    @Test fun contains_empty_arg_passes() {
-        assertThat("test").contains()
-    }
-
-    @Test fun contains_value_contains_passes() {
-        assertThat("test").contains("te", "st")
-    }
-
-    @Test fun contains_list_contains_passes() {
-        assertThat("test").contains(listOf("te", "st"))
-    }
-
-    @Test fun contains_contains_unordered_passes() {
-        assertThat("test").contains("st", "te")
-    }
-
-    @Test fun contains_value_not_contains_fails() {
-        val error = assertFails {
-            assertThat("test").contains("foo", "bar")
-        }
-        assertEquals("expected to contain:<[\"foo\", \"bar\"]> but was:<\"test\">", error.message)
-    }
-
-    @Test fun contains_value_contains_ignore_case_passes() {
-        assertThat("Test").contains("te", "ST", ignoreCase = true)
-    }
-
-    @Test fun contains_value_not_contains_ignore_case_fails() {
-        val error = assertFails {
-            assertThat("Test").contains("te", "ST", ignoreCase = false)
-        }
-        assertEquals("expected to contain:<[\"te\", \"ST\"]> but was:<\"Test\">", error.message)
-    }
-    //endregion
-
-
-    //region doesNotContain single
-    @Test fun doesNotContain_value_not_substring_passes() {
-        assertThat("test").doesNotContain("not")
-    }
-
-    @Test fun doesNotContain_value_substring_fails() {
-        val error = assertFails {
-            assertThat("test").doesNotContain("est")
-        }
-        assertEquals("expected to not contain:<\"est\"> but was:<\"test\">", error.message)
-    }
-
-    @Test fun doesNotContain_value_substring_ignore_case_fails() {
-        val error = assertFails {
-            assertThat("Test").doesNotContain("EST", true)
-        }
-        assertEquals("expected to not contain:<\"EST\"> but was:<\"Test\">", error.message)
-    }
-
-    @Test fun doesNotContain_value_not_substring_ignore_case_passes() {
-        assertThat("Test").doesNotContain("EST", false)
-    }
-    //endregion
-
-    //region doesNotContain multi
-    @Test fun doesNotContain_multivalue_not_substring_passes() {
-        assertThat("test").doesNotContain("foo", "bar")
-    }
-
-    @Test fun doesNotContain_multivalue_substring_fails() {
-        val error = assertFails {
-            assertThat("test").doesNotContain("te", "st")
-        }
-        assertEquals("expected to not contain:<[\"te\", \"st\"]> but was:<\"test\">", error.message)
-    }
-
-    @Test fun doesNotContain_multivalue_substring_ignore_case_fails() {
-        val error = assertFails {
-            assertThat("Test").doesNotContain("TE", "ST", ignoreCase = true)
-        }
-        assertEquals("expected to not contain:<[\"TE\", \"ST\"]> but was:<\"Test\">", error.message)
-    }
-
-    @Test fun doesNotContain_multivalue_not_substring_ignore_case_passes() {
-        assertThat("Test").doesNotContain("TE", "ST", ignoreCase = false)
-    }
-    //endregion
-
-    //region startsWith
-    @Test fun startsWith_value_prefix_passes() {
-        assertThat("test").startsWith("te")
-    }
-
-    @Test fun startsWith_value_not_prefix_fails() {
-        val error = assertFails {
-            assertThat("test").startsWith("st")
-        }
-        assertEquals("expected to start with:<\"st\"> but was:<\"test\">", error.message)
-    }
-
-    @Test fun startsWith_value_prefix_ignore_case_passes() {
-        assertThat("test").startsWith("TE", true)
-    }
-
-    @Test fun startsWith_value_not_prefix_ignore_case_fails() {
-        val error = assertFails {
-            assertThat("test").startsWith("TE", false)
-        }
-        assertEquals("expected to start with:<\"TE\"> but was:<\"test\">", error.message)
-    }
-    //endregion
-
-    //region endsWith
-    @Test fun endsWith_value_suffix_passes() {
-        assertThat("test").endsWith("st")
-    }
-
-    @Test fun endsWith_value_not_suffix_fails() {
-        val error = assertFails {
-            assertThat("test").endsWith("te")
-        }
-        assertEquals("expected to end with:<\"te\"> but was:<\"test\">", error.message)
-    }
-
-    @Test fun endsWith_value_suffix_ignore_case_passes() {
-        assertThat("test").endsWith("ST", true)
-    }
-
-    @Test fun endsWith_value_not_suffix_ignore_case_passes() {
-        val error = assertFails {
-            assertThat("test").endsWith("ST", false)
-        }
-        assertEquals("expected to end with:<\"ST\"> but was:<\"test\">", error.message)
-    }
-    //endregion
-
-    //region hasLineCount
-    @Test fun hasLineCount_correct_value_passes() {
-        assertThat("").hasLineCount(1)
-        assertThat("test test").hasLineCount(1)
-        assertThat("test test\ntest test").hasLineCount(2)
-        assertThat("test test\r\ntest test").hasLineCount(2)
-        assertThat("test test\rtest test").hasLineCount(2)
-    }
-
-    @Test fun hasLineCount_wrong_value_fails() {
-        val error = assertFails {
-            assertThat("test test").hasLineCount(2)
-        }
-        assertEquals("expected to have line count:<2> but was:<1>", error.message)
-    }
-    //endregion
-
-    //region matches
-    @Test fun matches_matching_value_passes() {
-        assertThat("1234").matches(Regex("\\d\\d\\d\\d"))
-    }
-
-    @Test fun matches_not_matching_value_fails() {
-        val regex = Regex("\\d\\d\\d\\d")
-        val error = assertFails {
-            assertThat("12345").matches(regex)
-        }
-        assertEquals("expected to match:${show(regex)} but was:<\"12345\">", error.message)
-    }
-    //endregion
 }


### PR DESCRIPTION
Most of the diff is a simple cut-paste from `strings.kt` and `StringTest.kt` to `charsequence.kt` and `CharSequence.kt`.
Slight modifications were required for `isEqualTo` and `isNotEqualTo`, as they both relied on the `String?` extension of `.equals` in the standard lib.
Also adds two tests that caught a bug I introduced with this change, specifically when comparing `null` to `"null"`

Couple thoughts:
1. Is there anything I'm missing that might cause a maintenance headache with this change?
2. Are there cases where this will break compilation for consumers?