### PR TITLE
Removes ci step modifying gradle.properties with extra jvmargs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,6 @@ jobs:
             gradle-{{ checksum "/tmp/gradle_cache_seed" }}-{{ checksum
             ".circleci/config.yml" }}-macos
       - run:
-          name: Set Gradle props
-          command: |
-            touch gradle.properties && echo "org.gradle.jvmargs=-Xmx2g" >> gradle.properties
-      - run:
           name: Run Tests
           command: ./gradlew macosTest iosX64Test
       - deploy:


### PR DESCRIPTION
Identical jvmargs are already defined in gradle.properties.

CircleCI is upset:
```
* What went wrong:
Unable to start the daemon process.
This problem might be caused by incorrect configuration of the daemon.
For example, an unrecognized jvm option is used.
Please refer to the User Manual chapter on the daemon at https://docs.gradle.org/6.2/userguide/gradle_daemon.html
Process command line: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/bin/java -Xmx2048morg.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -cp /Users/distiller/.gradle/wrapper/dists/gradle-6.2-bin/6zaomcc3lf3gnwxgkllci1muk/gradle-6.2/lib/gradle-launcher-6.2.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 6.2
Please read the following process output to find out more:
-----------------------
Invalid maximum heap size: -Xmx2048morg.gradle.jvmargs=-Xmx2g
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```