### PR TITLE
Don't throw MultipleFailuresError if failure list is empty

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/failure.kt
+++ b/assertk/src/commonMain/kotlin/assertk/failure.kt
@@ -115,10 +115,10 @@ internal class SoftFailure(
     }
 
     private fun compositeErrorMessage(errors: List<Throwable>): Throwable {
-        return if (errors.size == 1) {
-            errors.first()
-        } else {
-            MultipleFailuresError(message, errors).apply {
+        return when(errors.size) {
+            0 -> AssertionFailedError(message)
+            1 -> errors.first()
+            else -> MultipleFailuresError(message, errors).apply {
                 errors.forEach(this::addSuppressed)
             }
         }

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
@@ -221,6 +221,17 @@ class IterableTest {
         )
     }
 
+    @Test fun exactly_too_few_inside_all_fails() {
+        val error = assertFails {
+            assertThat(listOf(5, 4, 3) as Iterable<Int>).all {
+                exactly(2) { it.isGreaterThan(2) }
+            }
+        }
+        assertEquals(
+                """expected to pass exactly 2 times""".trimMargin(), error.message
+        )
+    }
+
     @Test fun exactly_times_passed_passes() {
         assertThat(listOf(0, 1, 2) as Iterable<Int>).exactly(2) { it.isGreaterThan(0) }
     }


### PR DESCRIPTION
In a nested context this was causing failures to be dropped since it was
mapping to an empty list.

Fixes #314