### PR TITLE
Fixes #354 any {} fails with example from docs

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assertions/iterable.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/iterable.kt
@@ -263,7 +263,7 @@ fun <E, T : Iterable<E>> Assert<T>.any(f: (Assert<E>) -> Unit) {
                     if (lastFailureCount == failure.count) {
                         itemPassed = true
                     }
-                    lastFailureCount += failure.count
+                    lastFailureCount = failure.count
                 }
             }
         },

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
@@ -319,6 +319,11 @@ class IterableTest {
         assertThat(listOf(1, 2) as Iterable<Int>).any { it.isGreaterThan(1) }
     }
 
+    @Test
+    fun example_from_docs() {
+        assertThat(listOf(-1, -2, 1)).any { it.isPositive() }
+    }
+
     @Test fun any_fails_if_all_fail() {
         val error = assertFails {
             assertThat(listOf(1, 2)).any { it.isGreaterThan(3) }


### PR DESCRIPTION
The `+=` in the assertion meant that any {} only passed if one of the first 2 items in the Iterable passed