### PR TITLE
Add Path.exists assertion

### DIFF
--- a/assertk/src/jvmMain/kotlin/assertk/assertions/path.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/path.kt
@@ -87,3 +87,15 @@ fun Assert<Path>.isSameFileAs(expected: Path) = given { actual ->
         expected("${show(actual)} to be the same file as ${show(actual)} but is not")
     }
 }
+
+/**
+ * Assert that the path exists.
+ *
+ * @param options indicating how symbolic links are handled
+ */
+@Suppress("SpreadOperator") // https://github.com/arturbosch/detekt/issues/391
+fun Assert<Path>.exists(vararg options: LinkOption) = given { actual ->
+    if (!Files.exists(actual, *options)) {
+        expected("${show(actual)} to exist, but it does not")
+    }
+}

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/PathTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/PathTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.*
 private var regularFile: Path? = null
 private var directory: Path? = null
 private var regularFileWithText: Path? = null
+private var doesNotExist: Path? = null
 
 class PathTest {
 
@@ -17,6 +18,7 @@ class PathTest {
         regularFile = createTempFile()
         directory = createTempDir()
         regularFileWithText = createTempFileWithText()
+        doesNotExist = Path.of("/tmp/does_not_exist")
     }
 
     @AfterTest
@@ -119,6 +121,23 @@ class PathTest {
 
     @Test fun isSameFileAs_value_same_directory_different_path_passes() {
         assertThat(directory!!).isSameFileAs(directory!!.toAbsolutePath())
+    }
+    //endregion
+
+    //region exists
+    @Test fun exists_value_regularFile_passes() {
+        assertThat(regularFile!!).exists()
+    }
+
+    @Test fun exists_value_directory_passes() {
+        assertThat(directory!!).exists()
+    }
+
+    @Test fun exists_value_not_exists_fails() {
+        val error = assertFails {
+            assertThat(doesNotExist!!).exists()
+        }
+        assertEquals("expected <$doesNotExist> to exist, but it does not", error.message)
     }
     //endregion
 


### PR DESCRIPTION
gives a better error message and reads better than 
```kotlin
assertThat(Files.exists(regularFile)).isTrue()
```