### PR TITLE
Fix typo in documentation for containsExactly()

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assertions/list.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/list.kt
@@ -26,9 +26,9 @@ fun <T> Assert<List<T>>.index(index: Int): Assert<T> =
  * Asserts the list contains exactly the expected elements. They must be in the same order and
  * there must not be any extra elements.
  *
- * [1, 2] containsOnly [2, 1] fails
- * [1, 2, 2] containsOnly [2, 1] fails
- * [1, 2] containsOnly [2, 2, 1] fails
+ * [1, 2] containsExactly [2, 1] fails
+ * [1, 2, 2] containsExactly [2, 1] fails
+ * [1, 2] containsExactly [2, 2, 1] fails
  *
  * @see [containsAll]
  * @see [containsOnly]


### PR DESCRIPTION
Fix an apparent copy-paste error which used containsOnly instead of containsExactly, which is a bit confusing.