### PR TITLE
Assert failures throw AssertionError

### DIFF
--- a/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/AnyTest.kt
+++ b/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/AnyTest.kt
@@ -8,7 +8,7 @@ import assertk.coroutines.assertions.suspendCall
 import test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class AnyTest {
     val subject = BasicObject("test")
@@ -18,14 +18,14 @@ class AnyTest {
     }
 
     @Test fun suspendCall_includes_name_in_failure_message() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).suspendCall("str") { it.str() }.isEmpty()
         }
         assertEquals("expected [str] to be empty but was:<\"test\"> (test)", error.message)
     }
 
     @Test fun nested_suspendCall_include_names_in_failure_message() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).suspendCall("other") { it.other() }.suspendCall("str") { it?.str() }.isNotNull()
         }
         assertEquals("expected [other.str] to not be null (test)", error.message)

--- a/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/FlowTest.kt
+++ b/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/FlowTest.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.flowOf
 import test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class FlowTest {
     //region isEmpty
@@ -19,14 +19,14 @@ class FlowTest {
     }
 
     @Test fun isEmpty_non_empty_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf<Any?>(null)).isEmpty()
         }
         assertEquals("expected to be empty but received:<null>", error.message)
     }
 
     @Test fun isEmpty_non_empty_in_flow_that_doesnt_complete_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(nonCompletingFlowOf(null)).isEmpty()
         }
         assertEquals("expected to be empty but received:<null>", error.message)
@@ -39,7 +39,7 @@ class FlowTest {
     }
 
     @Test fun isNotEmpty_empty_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf<Any?>()).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
@@ -53,7 +53,7 @@ class FlowTest {
 
     @Test fun hasSize_wrong_size_fails() = runTest {
         val flow = flowOf<Any?>()
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flow).hasCount(1)
         }
         assertEquals("expected [count()]:<[1]> but was:<[0]> ${show(flow, "()")}", error.message)
@@ -70,7 +70,7 @@ class FlowTest {
     }
 
     @Test fun contains_element_missing_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf<Any?>()).contains(1)
         }
         assertEquals("expected to contain:<1> but received:<[]>", error.message)
@@ -83,14 +83,14 @@ class FlowTest {
     }
 
     @Test fun doesNotContain_element_present_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 2)).doesNotContain(2)
         }
         assertEquals("expected to not contain:<2> but received:<[1, 2]>", error.message)
     }
 
     @Test fun doesNotContain_element_present_in_flow_that_doesnt_complete_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(nonCompletingFlowOf(1, 2)).doesNotContain(2)
         }
         assertEquals("expected to not contain:<2> but received:<[1, 2]>", error.message)
@@ -103,7 +103,7 @@ class FlowTest {
     }
 
     @Test fun containsNone_present_element_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 2)).containsNone(2, 3)
         }
         assertEquals(
@@ -114,7 +114,7 @@ class FlowTest {
     }
 
     @Test fun containsNone_present_element_in_flow_that_doesnt_complete_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(nonCompletingFlowOf(1, 2)).containsNone(2, 3)
         }
         assertEquals(
@@ -135,7 +135,7 @@ class FlowTest {
     }
 
     @Test fun containsAll_some_elements_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1)).containsAll(1, 2)
         }
         assertEquals(
@@ -152,7 +152,7 @@ class FlowTest {
     }
 
     @Test fun containsOnly_more_elements_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 2, 3)).containsOnly(2, 1)
         }
         assertEquals(
@@ -163,7 +163,7 @@ class FlowTest {
     }
 
     @Test fun containsOnly_less_elements_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 2, 3)).containsOnly(2, 1, 3, 4)
         }
         assertEquals(
@@ -175,7 +175,7 @@ class FlowTest {
     }
 
     @Test fun containsOnly_different_elements_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1)).containsOnly(2)
         }
         assertEquals(
@@ -194,7 +194,7 @@ class FlowTest {
     }
 
     @Test fun containsExactly_all_elements_in_different_order_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 2)).containsExactly(2, 1)
         }
         assertEquals(
@@ -206,7 +206,7 @@ class FlowTest {
     }
 
     @Test fun containsExactly_elements_in_different_order_fails2() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf("1", "2", "3")).containsExactly("2", "3", "1")
         }
         assertEquals(
@@ -218,7 +218,7 @@ class FlowTest {
     }
 
     @Test fun containsExactly_same_indexes_are_together() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 1)).containsExactly(2, 2)
         }
         assertEquals(
@@ -232,7 +232,7 @@ class FlowTest {
     }
 
     @Test fun containsExactly_missing_element_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 2)).containsExactly(3)
         }
         assertEquals(
@@ -245,7 +245,7 @@ class FlowTest {
     }
 
     @Test fun containsExactly_extra_element_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 2)).containsExactly(1, 2, 3)
         }
         assertEquals(
@@ -256,7 +256,7 @@ class FlowTest {
     }
 
     @Test fun containsExactly_missing_element_in_middle_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 3)).containsExactly(1, 2, 3)
         }
         assertEquals(
@@ -267,7 +267,7 @@ class FlowTest {
     }
 
     @Test fun containsExactly_extra_element_in_middle_fails() = runTest {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(flowOf(1, 2, 3)).containsExactly(1, 3)
         }
         assertEquals(

--- a/assertk/src/commonTest/kotlin/test/assertk/AssertAllTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/AssertAllTest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.*
 import assertk.assertions.support.show
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class AssertAllTest {
@@ -18,7 +18,7 @@ class AssertAllTest {
     }
 
     @Test fun all_one_failure_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test", name = "test").all {
                 startsWith("t")
                 endsWith("g")
@@ -31,7 +31,7 @@ class AssertAllTest {
     }
 
     @Test fun all_both_failures_fails_with_both() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test", name = "test").all {
                 startsWith("w")
                 endsWith("g")
@@ -56,7 +56,7 @@ class AssertAllTest {
     }
 
     @Test fun assertAll_one_failure_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat("test1", name = "test1").isEqualTo("wrong1")
                 assertThat("test2", name = "test2").isEqualTo("test2")
@@ -69,7 +69,7 @@ class AssertAllTest {
     }
 
     @Test fun assertAll_both_failures_fails_with_both() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat("test1", name = "test1").isEqualTo("wrong1")
                 assertThat("test2", name = "test2").isEqualTo("wrong2")
@@ -85,7 +85,7 @@ class AssertAllTest {
     }
 
     @Test fun leaves_soft_assert_scope_properly_on_exception() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             @Suppress("SwallowedException")
             try {
                 assertThat("This").all {
@@ -100,7 +100,7 @@ class AssertAllTest {
     }
 
     @Test fun assertAll_fails_multiple_block_thrownError_assertions() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat { 1 + 1 }.isFailure()
                 assertThat { 2 + 3 }.isFailure()
@@ -116,7 +116,7 @@ class AssertAllTest {
     }
 
     @Test fun assertAll_fails_multiple_block_returnedValue_assertions() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat { throw Exception("error1") }.isSuccess()
                 assertThat { throw Exception("error2") }.isSuccess()
@@ -131,7 +131,7 @@ class AssertAllTest {
     }
 
     @Test fun assertAll_fails_multiple_block_doesNotThrowAnyException_assertions() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat { throw Exception("error1") }.isSuccess()
                 assertThat { throw Exception("error2") }.isSuccess()

--- a/assertk/src/commonTest/kotlin/test/assertk/AssertTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/AssertTest.kt
@@ -4,15 +4,12 @@ import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.fail
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFails
-import kotlin.test.assertFalse
+import kotlin.test.*
 
 class AssertTest {
     //region transform
     @Test fun transform_that_throws_always_fails_assertion() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat(0).transform { fail("error") }.isEqualTo(0)
             }
@@ -23,7 +20,7 @@ class AssertTest {
 
     @Test fun transform_does_not_run_after_throws() {
         var run = false
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat(0).transform { fail("error") }.transform { run = true }.isEqualTo(0)
             }
@@ -34,33 +31,31 @@ class AssertTest {
     }
 
     @Test fun transform_rethrows_thrown_exception() {
-        val error = assertFails {
+        val error = assertFailsWith<MyException> {
             assertAll {
                 assertThat(0).transform { throw MyException("error") }.isEqualTo(0)
             }
         }
 
-        assertEquals(MyException::class, error::class)
         assertEquals("error", error.message)
     }
     //endregion
 
     //region given
     @Test fun given_rethrows_thrown_exception() {
-        val error = assertFails {
+        val error = assertFailsWith<MyException> {
             assertAll {
                 assertThat(0).given { throw MyException("error") }
             }
         }
 
-        assertEquals(MyException::class, error::class)
         assertEquals("error", error.message)
     }
     //endregion
 
     //region assertThat
     @Test fun assertThat_inherits_name_of_parent_assertion_by_default() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0, name = "test").assertThat(1).isEqualTo(2)
         }
 
@@ -68,7 +63,7 @@ class AssertTest {
     }
 
     @Test fun assertThat_failing_transformed_assert_shows_original_by_displayActual_lambda() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0, name = "test", displayActual = { "Number:${it}" })
                 .assertThat(1).isEqualTo(2)
         }
@@ -77,7 +72,7 @@ class AssertTest {
     }
 
     @Test fun assertThat_on_failing_assert_is_ignored() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat(0, name = "test").transform { fail("error") }.assertThat(1, name = "ignored").isEqualTo(2)
             }

--- a/assertk/src/commonTest/kotlin/test/assertk/FailureTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/FailureTest.kt
@@ -8,12 +8,10 @@ import kotlin.test.*
 class FailureTest {
 
     @Test fun fail_throws_assertion_failed_error_with_actual_and_expected_present_and_defined() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionFailedError> {
             fail("message", "expected", "actual")
         }
 
-        assertEquals(AssertionFailedError::class, error::class)
-        error as AssertionFailedError
         assertEquals("expected" as Any?, error.expected?.value)
         assertEquals("actual" as Any?, error.actual?.value)
         assertTrue(error.isExpectedDefined)
@@ -21,12 +19,10 @@ class FailureTest {
     }
 
     @Test fun fail_throws_assertion_failed_error_with_actual_and_expected_not_defined() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionFailedError> {
             fail("message")
         }
 
-        assertEquals(AssertionFailedError::class, error::class)
-        error as AssertionFailedError
         assertNull(error.expected)
         assertNull(error.actual)
         assertFalse(error.isExpectedDefined)

--- a/assertk/src/commonTest/kotlin/test/assertk/NameTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/NameTest.kt
@@ -4,18 +4,18 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class NameTest {
     @Test fun with_no_name_fails_with_default_error_message() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("yes").isEqualTo("no")
         }
         assertEquals("expected:<\"[no]\"> but was:<\"[yes]\">", error.message)
     }
 
     @Test fun with_name_fails_with_name_prefixing_message() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("yes", name = "test").isEqualTo("no")
         }
         assertEquals("expected [test]:<\"[no]\"> but was:<\"[yes]\">", error.message)
@@ -25,7 +25,7 @@ class NameTest {
         data class Person(val name: String)
         val p = Person("Yoda")
 
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(p::name).isEqualTo("Darth")
         }
         assertEquals("expected [name]:<\"[Darth]\"> but was:<\"[Yoda]\">", error.message)
@@ -35,7 +35,7 @@ class NameTest {
         data class Person(val name: String)
         val p = Person("Yoda")
 
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(p::name, "test").isEqualTo("Darth")
         }
         assertEquals("expected [test]:<\"[Darth]\"> but was:<\"[Yoda]\">", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/TableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/TableTest.kt
@@ -6,7 +6,7 @@ import assertk.assertions.isTrue
 import assertk.tableOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class TableTest {
     @Test fun no_failures_runs_for_each_row_and_passes() {
@@ -24,7 +24,7 @@ class TableTest {
 
     @Test fun single_failure_fails_row() {
         var invokeCount = 0
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             tableOf("a", "b")
                 .row(1, 1)
                 .row(2, 3)
@@ -46,7 +46,7 @@ class TableTest {
 
     @Test fun multiple_failures_fails_with_all() {
         var invokeCount = 0
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             tableOf("a", "b")
                 .row(1, 2)
                 .row(2, 3)
@@ -71,7 +71,7 @@ class TableTest {
 
     @Test fun table_with_one_value_fails_row() {
         var invokeCount = 0
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             tableOf("a")
                 .row(false)
                 .forAll { a ->
@@ -92,7 +92,7 @@ class TableTest {
 
     @Test fun table_with_three_values_fails_row() {
         var invokeCount = 0
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             tableOf("a", "b", "c")
                 .row(1, 2, 4)
                 .forAll { a, b, c ->
@@ -113,7 +113,7 @@ class TableTest {
 
     @Test fun table_with_four_values_fails_row() {
         var invokeCount = 0
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             tableOf("a", "b", "c", "d")
                 .row(1, 2, 3, 4)
                 .forAll { a, b, c, d ->

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class AnyTest {
     val subject = BasicObject("test")
@@ -29,7 +30,7 @@ class AnyTest {
 
     @Test fun isEqualTo_non_equal_objects_fails() {
         val nonEqual = BasicObject("not test")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isEqualTo(nonEqual)
         }
         assertEquals("expected:<[not ]test> but was:<[]test>", error.message)
@@ -43,7 +44,7 @@ class AnyTest {
         assertThat(obj).isEqualTo(obj)
         assertThat(obj as TestObject).isEqualTo(obj)
         assertThat(obj).isEqualTo(obj as TestObject)
-        assertFails {
+        assertFailsWith<AssertionError> {
             assertThat(1).isEqualTo("string")
         }
     }
@@ -55,7 +56,7 @@ class AnyTest {
 
     @Test fun isNotEqualTo_equal_objects_fails() {
         val equal = BasicObject("test")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isNotEqualTo(equal)
         }
         assertEquals("expected to not be equal to:<test>", error.message)
@@ -79,7 +80,7 @@ class AnyTest {
     }
 
     @Test fun isNotSameAs_same_objects_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isNotSameAs(subject)
         }
         assertEquals("expected:<test> to not refer to the same object", error.message)
@@ -92,7 +93,7 @@ class AnyTest {
 
     @Test fun isIn_one_non_equal_item_fails() {
         val isOut1 = BasicObject("not test1")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isIn(isOut1)
         }
         assertEquals("expected:<[not test1]> to contain:<test>", error.message)
@@ -108,7 +109,7 @@ class AnyTest {
     @Test fun isIn_no_equal_items_in_may_fails() {
         val isOut1 = BasicObject("not test1")
         val isOut2 = BasicObject("not test2")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isIn(isOut1, isOut2)
         }
         assertEquals("expected:<[not test1, not test2]> to contain:<test>", error.message)
@@ -121,7 +122,7 @@ class AnyTest {
 
     @Test fun isNotIn_one_equal_item_fails() {
         val isIn = BasicObject("test")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isNotIn(isIn)
         }
         assertEquals("expected:<[test]> to not contain:<test>", error.message)
@@ -137,7 +138,7 @@ class AnyTest {
         val isOut1 = BasicObject("not test1")
         val isIn = BasicObject("test")
         val isOut2 = BasicObject("not test2")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isNotIn(isOut1, isIn, isOut2)
         }
         assertEquals("expected:<[not test1, test, not test2]> to not contain:<test>", error.message)
@@ -148,7 +149,7 @@ class AnyTest {
     }
 
     @Test fun hasToString_not_equal_string_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).hasToString("not test")
         }
         assertEquals("expected [toString]:<\"[not ]test\"> but was:<\"[]test\"> (test)", error.message)
@@ -159,7 +160,7 @@ class AnyTest {
     }
 
     @Test fun hasHashCode_not_equal_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).hasHashCode(1337)
         }
         assertEquals("expected [hashCode]:<[1337]> but was:<[42]> (test)", error.message)
@@ -169,7 +170,7 @@ class AnyTest {
     private val testObject = BasicObject("test", 99, 3.14)
 
     @Test fun isEqualToWithGivenProperties_regular_equals_fail() {
-        assertFails {
+        assertFailsWith<AssertionError> {
             assertThat(subject).isEqualTo(testObject)
         }
     }
@@ -184,7 +185,7 @@ class AnyTest {
     }
 
     @Test fun isEqualToWithGivenProperties_extract_prop_includes_name_in_failure_message() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isEqualToWithGivenProperties(testObject, BasicObject::int)
         }
         assertEquals("expected [int]:<[99]> but was:<[42]> (test)", error.message)
@@ -196,14 +197,14 @@ class AnyTest {
     }
 
     @Test fun prop_includes_name_in_failure_message() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).prop("str") { it.str }.isEmpty()
         }
         assertEquals("expected [str] to be empty but was:<\"test\"> (test)", error.message)
     }
 
     @Test fun nested_prop_include_names_in_failure_message() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).prop("other") { it.other }.prop("str") { it?.str }.isNotNull()
         }
         assertEquals("expected [other.str] to not be null (test)", error.message)
@@ -214,7 +215,7 @@ class AnyTest {
     }
 
     @Test fun prop_property1_extract_prop_includes_name_in_failure_message() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).prop(BasicObject::str).isEmpty()
         }
         assertEquals("expected [str] to be empty but was:<\"test\"> (test)", error.message)
@@ -232,14 +233,14 @@ class AnyTest {
     }
 
     @Test fun prop_callable_function_includes_name_in_failure_message() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).prop(BasicObject::funcA).isEqualTo(14)
         }
         assertEquals("expected [funcA]:<[14]> but was:<[\"A\"]> (test)", error.message)
     }
 
     @Test fun nested_prop_callable_function_include_names_in_failure_message() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).prop(BasicObject::funcB).prop(BasicObject::funcA).isNull()
         }
         assertEquals("expected [funcB.funcA] to be null but was:<\"A\"> (test)", error.message)
@@ -251,7 +252,7 @@ class AnyTest {
     }
 
     @Test fun isNull_non_null_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(nullableSubject).isNull()
         }
         assertEquals("expected to be null but was:<test>", error.message)
@@ -262,7 +263,7 @@ class AnyTest {
     }
 
     @Test fun isNotNull_null_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(null as String?).isNotNull()
         }
         assertEquals("expected to not be null", error.message)
@@ -274,14 +275,14 @@ class AnyTest {
 
     @Test fun isNotNull_non_null_and_non_equal_object_fails() {
         val unequal = BasicObject("not test")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(nullableSubject).isNotNull().isEqualTo(unequal)
         }
         assertEquals("expected:<[not ]test> but was:<[]test>", error.message)
     }
 
     @Test fun isNotNull_null_and_equal_object_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(null as String?).isNotNull().isEqualTo(null)
         }
         assertEquals("expected to not be null", error.message)
@@ -292,7 +293,7 @@ class AnyTest {
     }
 
     @Test fun hasClass_parent_class_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).hasClass(TestObject::class)
         }
         assertEquals(
@@ -306,7 +307,7 @@ class AnyTest {
     }
 
     @Test fun doesNotHaveClass_same_class_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).doesNotHaveClass(BasicObject::class)
         }
         assertEquals("expected to not have class:<${BasicObject::class}>", error.message)
@@ -321,7 +322,7 @@ class AnyTest {
     }
 
     @Test fun isInstanceOf_kclass_different_class_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isInstanceOf(DifferentObject::class)
         }
         assertEquals(
@@ -331,7 +332,7 @@ class AnyTest {
     }
 
     @Test fun isInstanceOf_kclass_run_block_when_passes() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject as TestObject).isInstanceOf(BasicObject::class).prop("str", BasicObject::str)
                 .isEqualTo("wrong")
         }
@@ -339,7 +340,7 @@ class AnyTest {
     }
 
     @Test fun isInstanceOf_kclass_doesnt_run_block_when_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject as TestObject).isInstanceOf(DifferentObject::class).isNull()
         }
         assertEquals(
@@ -353,14 +354,14 @@ class AnyTest {
     }
 
     @Test fun isNotInstanceOf_kclass_same_class_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isNotInstanceOf(BasicObject::class)
         }
         assertEquals("expected to not be instance of:<${BasicObject::class}>", error.message)
     }
 
     @Test fun isNotInstanceOf_kclass_parent_class_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isNotInstanceOf(TestObject::class)
         }
         assertEquals("expected to not be instance of:<${TestObject::class}>", error.message)
@@ -371,7 +372,7 @@ class AnyTest {
     }
 
     @Test fun corresponds_not_equivalent_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).corresponds(BasicObject("test")) { _, _ -> false }
         }
         assertEquals("expected:<test> but was:<test>", error.message)
@@ -382,7 +383,7 @@ class AnyTest {
     }
 
     @Test fun doesNotCorrespond_not_equivalent_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).doesNotCorrespond(BasicObject("different")) { _, _ -> true }
         }
         assertEquals("expected:<different> not to be equal to:<test>", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/ArrayTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/ArrayTest.kt
@@ -2,11 +2,10 @@ package test.assertk.assertions
 
 import assertk.assertThat
 import assertk.assertions.*
-import assertk.assertions.support.show
 import test.assertk.opentestPackageName
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class ArrayTest {
     //region isEqualTo
@@ -15,7 +14,7 @@ class ArrayTest {
     }
 
     @Test fun isEqualTo_different_contents_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf("one")).isEqualTo(arrayOf("two"))
         }
         assertEquals("expected:<[\"[two]\"]> but was:<[\"[one]\"]>", error.message)
@@ -28,7 +27,7 @@ class ArrayTest {
     }
 
     @Test fun isNotEqualTo_same_contents_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf("one")).isNotEqualTo(arrayOf("one"))
         }
         assertEquals("expected to not be equal to:<[\"one\"]>", error.message)
@@ -41,7 +40,7 @@ class ArrayTest {
     }
 
     @Test fun isEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf<Any?>(null)).isEmpty()
         }
         assertEquals("expected to be empty but was:<[null]>", error.message)
@@ -54,7 +53,7 @@ class ArrayTest {
     }
 
     @Test fun isNotEmpty_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf<Any?>()).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
@@ -71,7 +70,7 @@ class ArrayTest {
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf<Any?>(null)).isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<[null]>", error.message)
@@ -84,7 +83,7 @@ class ArrayTest {
     }
 
     @Test fun hasSize_wrong_size_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyArray<Any?>()).hasSize(1)
         }
         assertEquals("expected [size]:<[1]> but was:<[0]> ([])", error.message)
@@ -97,7 +96,7 @@ class ArrayTest {
     }
 
     @Test fun hasSameSizeAs_non_equal_sizes_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyArray<Any?>()).hasSameSizeAs(arrayOf<Any?>(null))
         }
         assertEquals("expected to have same size as:<[null]> (1) but was size:(0)", error.message)
@@ -110,7 +109,7 @@ class ArrayTest {
     }
 
     @Test fun contains_element_missing_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyArray<Any?>()).contains(1)
         }
         assertEquals("expected to contain:<1> but was:<[]>", error.message)
@@ -123,7 +122,7 @@ class ArrayTest {
     }
 
     @Test fun doesNotContain_element_present_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 2)).doesNotContain(2)
         }
         assertEquals("expected to not contain:<2> but was:<[1, 2]>", error.message)
@@ -136,7 +135,7 @@ class ArrayTest {
     }
 
     @Test fun containsNone_present_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 2)).containsNone(2, 3)
         }
         assertEquals(
@@ -157,7 +156,7 @@ class ArrayTest {
     }
 
     @Test fun containsAll_some_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1)).containsAll(1, 2)
         }
         assertEquals(
@@ -174,7 +173,7 @@ class ArrayTest {
     }
 
     @Test fun containsOnly_more_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 2, 3)).containsOnly(2, 1)
         }
         assertEquals(
@@ -185,7 +184,7 @@ class ArrayTest {
     }
 
     @Test fun containsOnly_less_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 2, 3)).containsOnly(2, 1, 3, 4)
         }
         assertEquals(
@@ -197,7 +196,7 @@ class ArrayTest {
     }
 
     @Test fun containsOnly_different_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1)).containsOnly(2)
         }
         assertEquals(
@@ -216,7 +215,7 @@ class ArrayTest {
     }
 
     @Test fun containsExactly_all_elements_in_different_order_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 2)).containsExactly(2, 1)
         }
         assertEquals(
@@ -228,7 +227,7 @@ class ArrayTest {
     }
 
     @Test fun containsExactly_missing_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 2)).containsExactly(3)
         }
         assertEquals(
@@ -241,7 +240,7 @@ class ArrayTest {
     }
 
     @Test fun containsExactly_same_indexes_are_together() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 1)).containsExactly(2, 2)
         }
         assertEquals(
@@ -255,7 +254,7 @@ class ArrayTest {
     }
 
     @Test fun containsExactly_extra_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 2)).containsExactly(1, 2, 3)
         }
         assertEquals(
@@ -266,7 +265,7 @@ class ArrayTest {
     }
 
     @Test fun containsExactly_missing_element_in_middle_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 3)).containsExactly(1, 2, 3)
         }
         assertEquals(
@@ -277,7 +276,7 @@ class ArrayTest {
     }
 
     @Test fun containsExactly_extra_element_in_middle_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 2, 3)).containsExactly(1, 3)
         }
         assertEquals(
@@ -298,7 +297,7 @@ class ArrayTest {
     }
 
     @Test fun each_non_matching_content_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(1, 2, 3)).each { it.isLessThan(2) }
         }
         assertEquals(
@@ -316,7 +315,7 @@ class ArrayTest {
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
         }
         assertEquals(
@@ -326,7 +325,7 @@ class ArrayTest {
     }
 
     @Test fun index_out_of_range_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
@@ -339,7 +338,7 @@ class ArrayTest {
     }
 
     @Test fun single_extracting_function_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf("one", "two")).extracting { it.length }.containsExactly(2, 2)
         }
         assertEquals(
@@ -359,7 +358,7 @@ class ArrayTest {
     }
 
     @Test fun pair_extracting_function_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(Thing("one", 1, '1'), Thing("two", 2, '2')))
                 .extracting(Thing::one, Thing::two)
                 .containsExactly("one" to 2, "two" to 1)
@@ -382,7 +381,7 @@ class ArrayTest {
     }
 
     @Test fun triple_extracting_function_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(arrayOf(Thing("one", 1, '1'), Thing("two", 2, '2')))
                 .extracting(Thing::one, Thing::two, Thing::three)
                 .containsExactly(Triple("one", 1, '2'), Triple("two", 2, '3'))

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/BooleanTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/BooleanTest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class BooleanTest {
     //region isTrue
@@ -14,7 +14,7 @@ class BooleanTest {
     }
 
     @Test fun isTrue_false_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(false).isTrue()
         }
         assertEquals("expected to be true", error.message)
@@ -27,7 +27,7 @@ class BooleanTest {
     }
 
     @Test fun isFalse_true_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(true).isFalse()
         }
         assertEquals("expected to be false", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/CharSequenceTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/CharSequenceTest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.*
 import assertk.assertions.support.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class CharSequenceTest {
     //region props
@@ -20,7 +20,7 @@ class CharSequenceTest {
     }
 
     @Test fun isEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").isEmpty()
         }
         assertEquals("expected to be empty but was:<\"test\">", error.message)
@@ -33,7 +33,7 @@ class CharSequenceTest {
     }
 
     @Test fun isNotEmpty_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("").isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
@@ -50,7 +50,7 @@ class CharSequenceTest {
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<\"test\">", error.message)
@@ -63,7 +63,7 @@ class CharSequenceTest {
     }
 
     @Test fun hasLength_wrong_length_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").hasLength(0)
         }
         assertEquals("expected [length]:<[0]> but was:<[4]> (\"test\")", error.message)
@@ -76,7 +76,7 @@ class CharSequenceTest {
     }
 
     @Test fun hasSameLengthAs_different_length_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").hasSameLengthAs("")
         }
         assertEquals("expected to have same length as:<\"\"> (0) but was:<\"test\"> (4)", error.message)
@@ -89,7 +89,7 @@ class CharSequenceTest {
     }
 
     @Test fun contains_value_not_substring_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").contains("not")
         }
         assertEquals("expected to contain:<\"not\"> but was:<\"test\">", error.message)
@@ -100,7 +100,7 @@ class CharSequenceTest {
     }
 
     @Test fun contains_value_not_substring_ignore_case_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("Test").contains("EST", false)
         }
         assertEquals("expected to contain:<\"EST\"> but was:<\"Test\">", error.message)
@@ -125,7 +125,7 @@ class CharSequenceTest {
     }
 
     @Test fun contains_value_not_contains_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").contains("foo", "bar")
         }
         assertEquals("expected to contain:<[\"foo\", \"bar\"]> but was:<\"test\">", error.message)
@@ -136,7 +136,7 @@ class CharSequenceTest {
     }
 
     @Test fun contains_value_not_contains_ignore_case_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("Test").contains("te", "ST", ignoreCase = false)
         }
         assertEquals("expected to contain:<[\"te\", \"ST\"]> but was:<\"Test\">", error.message)
@@ -150,14 +150,14 @@ class CharSequenceTest {
     }
 
     @Test fun doesNotContain_value_substring_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").doesNotContain("est")
         }
         assertEquals("expected to not contain:<\"est\"> but was:<\"test\">", error.message)
     }
 
     @Test fun doesNotContain_value_substring_ignore_case_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("Test").doesNotContain("EST", true)
         }
         assertEquals("expected to not contain:<\"EST\"> but was:<\"Test\">", error.message)
@@ -174,14 +174,14 @@ class CharSequenceTest {
     }
 
     @Test fun doesNotContain_multivalue_substring_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").doesNotContain("te", "st")
         }
         assertEquals("expected to not contain:<[\"te\", \"st\"]> but was:<\"test\">", error.message)
     }
 
     @Test fun doesNotContain_multivalue_substring_ignore_case_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("Test").doesNotContain("TE", "ST", ignoreCase = true)
         }
         assertEquals("expected to not contain:<[\"TE\", \"ST\"]> but was:<\"Test\">", error.message)
@@ -198,7 +198,7 @@ class CharSequenceTest {
     }
 
     @Test fun startsWith_value_not_prefix_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").startsWith("st")
         }
         assertEquals("expected to start with:<\"st\"> but was:<\"test\">", error.message)
@@ -209,7 +209,7 @@ class CharSequenceTest {
     }
 
     @Test fun startsWith_value_not_prefix_ignore_case_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").startsWith("TE", false)
         }
         assertEquals("expected to start with:<\"TE\"> but was:<\"test\">", error.message)
@@ -222,7 +222,7 @@ class CharSequenceTest {
     }
 
     @Test fun endsWith_value_not_suffix_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").endsWith("te")
         }
         assertEquals("expected to end with:<\"te\"> but was:<\"test\">", error.message)
@@ -233,7 +233,7 @@ class CharSequenceTest {
     }
 
     @Test fun endsWith_value_not_suffix_ignore_case_passes() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").endsWith("ST", false)
         }
         assertEquals("expected to end with:<\"ST\"> but was:<\"test\">", error.message)
@@ -250,7 +250,7 @@ class CharSequenceTest {
     }
 
     @Test fun hasLineCount_wrong_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test test").hasLineCount(2)
         }
         assertEquals("expected to have line count:<2> but was:<1>", error.message)
@@ -264,7 +264,7 @@ class CharSequenceTest {
 
     @Test fun matches_not_matching_value_fails() {
         val regex = Regex("\\d\\d\\d\\d")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("12345").matches(regex)
         }
         assertEquals("expected to match:${show(regex)} but was:<\"12345\">", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/CollectionTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/CollectionTest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class CollectionTest {
     //region isEmpty
@@ -13,7 +13,7 @@ class CollectionTest {
     }
 
     @Test fun isEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf<Any?>(null)).isEmpty()
         }
         assertEquals("expected to be empty but was:<[null]>", error.message)
@@ -26,7 +26,7 @@ class CollectionTest {
     }
 
     @Test fun isNotEmpty_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyList<Any?>()).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
@@ -43,7 +43,7 @@ class CollectionTest {
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf<Any?>(null)).isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<[null]>", error.message)
@@ -56,7 +56,7 @@ class CollectionTest {
     }
 
     @Test fun hasSize_wrong_size_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyList<Any?>()).hasSize(1)
         }
         assertEquals("expected [size]:<[1]> but was:<[0]> ([])", error.message)
@@ -69,7 +69,7 @@ class CollectionTest {
     }
 
     @Test fun hasSameSizeAs_non_equal_sizes_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyList<Any?>()).hasSameSizeAs(listOf<Any?>(null))
         }
         assertEquals("expected to have same size as:<[null]> (1) but was size:(0)", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/ComparableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/ComparableTest.kt
@@ -12,7 +12,7 @@ import assertk.assertions.isStrictlyBetween
 import assertk.assertions.support.show
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class ComparableTest {
     //region isGreaterThan
@@ -21,7 +21,7 @@ class ComparableTest {
     }
 
     @Test fun isGreaterThan_non_greater_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).isGreaterThan(0)
         }
         assertEquals("expected to be greater than:<0> but was:<0>", error.message)
@@ -34,7 +34,7 @@ class ComparableTest {
     }
 
     @Test fun isLessThan_non_lesser_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).isLessThan(0)
         }
         assertEquals("expected to be less than:<0> but was:<0>", error.message)
@@ -51,7 +51,7 @@ class ComparableTest {
     }
 
     @Test fun isGreaterThanOrEqualTo_lesser_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).isGreaterThanOrEqualTo(2)
         }
         assertEquals("expected to be greater than or equal to:<2> but was:<0>", error.message)
@@ -68,7 +68,7 @@ class ComparableTest {
     }
 
     @Test fun isLessThanOrEqualTo_greater_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(2).isLessThanOrEqualTo(0)
         }
         assertEquals("expected to be less than or equal to:<0> but was:<2>", error.message)
@@ -89,14 +89,14 @@ class ComparableTest {
     }
 
     @Test fun isBetween_below_lower_bound_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(-1).isBetween(0, 2)
         }
         assertEquals("expected to be between:<0> and <2> but was:<-1>", error.message)
     }
 
     @Test fun isBetween_above_upper_bound_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(3).isBetween(0, 2)
         }
         assertEquals("expected to be between:<0> and <2> but was:<3>", error.message)
@@ -109,28 +109,28 @@ class ComparableTest {
     }
 
     @Test fun isStrictlyBetween_lower_bound_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).isStrictlyBetween(0, 2)
         }
         assertEquals("expected to be strictly between:<0> and <2> but was:<0>", error.message)
     }
 
     @Test fun isStrictlyBetween_upper_bound_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(2).isStrictlyBetween(0, 2)
         }
         assertEquals("expected to be strictly between:<0> and <2> but was:<2>", error.message)
     }
 
     @Test fun isStrictlyBetween_below_lower_bound_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0 - 1).isStrictlyBetween(0, 2)
         }
         assertEquals("expected to be strictly between:<0> and <2> but was:<-1>", error.message)
     }
 
     @Test fun isStrictlyBetween_above_upper_bound_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(2 + 1).isStrictlyBetween(0, 2)
         }
         assertEquals("expected to be strictly between:<0> and <2> but was:<3>", error.message)
@@ -160,7 +160,7 @@ class ComparableTest {
 
     @Test
     fun isCloseToFloat_with_delta_out_of_range_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(10.1f).isCloseTo(15.0f, 3f)
         }
         assertEquals("expected ${show(10.1f)} to be close to ${show(15.0f)} with delta of ${show(3f)}, but was not", error.message)
@@ -168,7 +168,7 @@ class ComparableTest {
 
     @Test
     fun isCloseToDouble_with_delta_out_of_range_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(10.1).isCloseTo(15.0, 3.0)
         }
         assertEquals("expected ${show(10.1)} to be close to ${show(15.0)} with delta of ${show(3.0)}, but was not", error.message)
@@ -176,7 +176,7 @@ class ComparableTest {
 
     @Test
     fun isEqualByComparingTo_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Info("aaa")).isEqualByComparingTo(Info("bbbb"))
         }
         assertEquals("expected:<[bbbb]> but was:<[aaa]>", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
@@ -3,11 +3,10 @@ package test.assertk.assertions
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.*
-import assertk.assertions.support.fail
 import test.assertk.opentestPackageName
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class IterableTest {
     //region contains
@@ -16,7 +15,7 @@ class IterableTest {
     }
 
     @Test fun contains_element_missing_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyList<Any?>() as Iterable<Any?>).contains(1)
         }
         assertEquals("expected to contain:<1> but was:<[]>", error.message)
@@ -29,7 +28,7 @@ class IterableTest {
     }
 
     @Test fun doesNotContain_element_present_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2) as Iterable<Int>).doesNotContain(2)
         }
         assertEquals("expected to not contain:<2> but was:<[1, 2]>", error.message)
@@ -42,7 +41,7 @@ class IterableTest {
     }
 
     @Test fun containsNone_present_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2) as Iterable<Int>).containsNone(2, 3)
         }
         assertEquals(
@@ -59,7 +58,7 @@ class IterableTest {
     }
 
     @Test fun containsAll_some_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1) as Iterable<Int>).containsAll(1, 2)
         }
         assertEquals(
@@ -84,7 +83,7 @@ class IterableTest {
     }
 
     @Test fun containsOnly_more_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3) as Iterable<Int>).containsOnly(2, 1)
         }
         assertEquals(
@@ -95,7 +94,7 @@ class IterableTest {
     }
 
     @Test fun containsOnly_less_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3) as Iterable<Int>).containsOnly(2, 1, 3, 4)
         }
         assertEquals(
@@ -107,7 +106,7 @@ class IterableTest {
     }
 
     @Test fun containsOnly_different_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1) as Iterable<Int>).containsOnly(2)
         }
         assertEquals(
@@ -130,7 +129,7 @@ class IterableTest {
     }
 
     @Test fun containsExactlyInAnyOrder_duplicate_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 2) as Iterable<Int>).containsExactlyInAnyOrder(2, 1)
         }
         assertEquals(
@@ -141,7 +140,7 @@ class IterableTest {
     }
 
     @Test fun containsExactlyInAnyOrder_duplicate_elements_fails2() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2) as Iterable<Int>).containsExactlyInAnyOrder(2, 2, 1)
         }
         assertEquals(
@@ -152,7 +151,7 @@ class IterableTest {
     }
 
     @Test fun containsExactlyInAnyOrder_more_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3) as Iterable<Int>).containsExactlyInAnyOrder(2, 1)
         }
         assertEquals(
@@ -163,7 +162,7 @@ class IterableTest {
     }
 
     @Test fun containsExactlyInAnyOrder_less_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3) as Iterable<Int>).containsExactlyInAnyOrder(2, 1, 3, 4)
         }
         assertEquals(
@@ -175,7 +174,7 @@ class IterableTest {
     }
 
     @Test fun containsExactlyInAnyOrder_different_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1) as Iterable<Int>).containsExactlyInAnyOrder(2)
         }
         assertEquals(
@@ -198,7 +197,7 @@ class IterableTest {
     }
 
     @Test fun each_non_matching_content_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3) as Iterable<Int>).each { it.isLessThan(2) }
         }
         assertEquals(
@@ -216,7 +215,7 @@ class IterableTest {
     }
 
     @Test fun none_matching_content_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2) as Iterable<Int>).none { it.isGreaterThan(0) }
         }
         assertEquals(
@@ -231,7 +230,7 @@ class IterableTest {
 
     //region atLeast
     @Test fun atLeast_too_many_failures_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) { it.isGreaterThan(2) }
         }
         assertEquals(
@@ -257,7 +256,7 @@ class IterableTest {
 
     //region atMost
     @Test fun atMost_more_than_times_passed_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3) as Iterable<Int>).atMost(2) { it.isGreaterThan(0) }
         }
         assertEquals(
@@ -278,7 +277,7 @@ class IterableTest {
 
     //region exactly
     @Test fun exactly_too_few_passes_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3) as Iterable<Int>).exactly(2) { it.isGreaterThan(2) }
         }
         assertEquals(
@@ -290,7 +289,7 @@ class IterableTest {
     }
 
     @Test fun exactly_too_many_passes_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(5, 4, 3) as Iterable<Int>).exactly(2) { it.isGreaterThan(2) }
         }
         assertEquals(
@@ -299,7 +298,7 @@ class IterableTest {
     }
 
     @Test fun exactly_too_few_inside_all_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(5, 4, 3) as Iterable<Int>).all {
                 exactly(2) { it.isGreaterThan(2) }
             }
@@ -320,7 +319,7 @@ class IterableTest {
     }
 
     @Test fun any_fails_if_all_fail() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2)).any { it.isGreaterThan(3) }
         }
         assertEquals(
@@ -332,7 +331,7 @@ class IterableTest {
     }
 
     @Test fun any_multiple_assertions_fail() {
-        assertFails {
+        assertFailsWith<AssertionError> {
             assertThat(listOf("one")).any {
                 it.isEqualTo("two")
                 it.isEqualTo("two")
@@ -341,7 +340,7 @@ class IterableTest {
     }
 
     @Test fun any_multiple_items_fail() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3)).any {
                 it.isEqualTo(4)
             }
@@ -375,7 +374,7 @@ class IterableTest {
 
     @Test fun non_empty_iterable_fails_is_empty() {
         val nonEmpty: List<Int> = listOf(1)
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(nonEmpty as Iterable<Int>).isEmpty()
         }
         assertEquals("expected to be empty but was:<[1]>", error.message)
@@ -390,7 +389,7 @@ class IterableTest {
 
     @Test fun empty_iterable_fails_is_not_empty() {
         val empty: List<Int> = emptyList()
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(empty as Iterable<Int>).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
@@ -403,7 +402,7 @@ class IterableTest {
     }
 
     @Test fun single_extracting_function_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf("one", "two") as Iterable<String>).extracting { it.length }.containsExactly(2, 2)
         }
         assertEquals(
@@ -422,7 +421,7 @@ class IterableTest {
     }
 
     @Test fun pair_extracting_function_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(Thing("one", 1, '1'), Thing("two", 2, '2')) as Iterable<Thing>)
                 .extracting(Thing::one, Thing::two)
                 .containsExactly("one" to 2, "two" to 1)
@@ -444,7 +443,7 @@ class IterableTest {
     }
 
     @Test fun triple_extracting_function_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(Thing("one", 1, '1'), Thing("two", 2, '2')) as Iterable<Thing>)
                 .extracting(Thing::one, Thing::two, Thing::three)
                 .containsExactly(Triple("one", 1, '2'), Triple("two", 2, '3'))
@@ -466,14 +465,14 @@ class IterableTest {
     }
 
     @Test fun first_element_present_mismatch_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2)).first().isEqualTo(2)
         }
         assertEquals("expected [first]:<[2]> but was:<[1]> ([1, 2])", error.message)
     }
 
     @Test fun first_element_missing_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyList<Any?>()).first().isEqualTo(1)
         }
         assertEquals("expected to not be empty", error.message)
@@ -486,21 +485,21 @@ class IterableTest {
     }
 
     @Test fun single_single_element_mismatch_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1)).single().isEqualTo(2)
         }
         assertEquals("expected [single]:<[2]> but was:<[1]> ([1])", error.message)
     }
 
     @Test fun single_no_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyList<Any?>()).single().isEqualTo(1)
         }
         assertEquals("expected to have single element but was empty", error.message)
     }
 
     @Test fun single_multiple_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
         assertThat(listOf(1, 2)).single().isEqualTo(1)
         }
         assertEquals("expected to have single element but has 2: <[1, 2]>", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/ListTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/ListTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class ListTest {
     //region containsExactly
@@ -13,7 +14,7 @@ class ListTest {
     }
 
     @Test fun containsExactly_all_elements_in_different_order_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2)).containsExactly(2, 1)
         }
         assertEquals(
@@ -26,7 +27,7 @@ class ListTest {
 
     // https://github.com/willowtreeapps/assertk/issues/185
     @Test fun containsExactly_elements_in_different_order_fails2() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf("1", "2", "3")).containsExactly("2", "3", "1")
         }
         assertEquals(
@@ -38,7 +39,7 @@ class ListTest {
     }
 
     @Test fun containsExactly_same_indexes_are_together() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 1)).containsExactly(2, 2)
         }
         assertEquals(
@@ -52,7 +53,7 @@ class ListTest {
     }
 
     @Test fun containsExactly_missing_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2)).containsExactly(3)
         }
         assertEquals(
@@ -65,7 +66,7 @@ class ListTest {
     }
 
     @Test fun containsExactly_extra_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2)).containsExactly(1, 2, 3)
         }
         assertEquals(
@@ -76,7 +77,7 @@ class ListTest {
     }
 
     @Test fun containsExactly_missing_element_in_middle_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 3)).containsExactly(1, 2, 3)
         }
         assertEquals(
@@ -87,7 +88,7 @@ class ListTest {
     }
 
     @Test fun containsExactly_extra_element_in_middle_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf(1, 2, 3)).containsExactly(1, 3)
         }
         assertEquals(
@@ -108,7 +109,7 @@ class ListTest {
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf("one", "two"), name = "subject").index(0).isEqualTo("wrong")
         }
         assertEquals(
@@ -118,7 +119,7 @@ class ListTest {
     }
 
     @Test fun index_out_of_range_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(listOf("one", "two"), name = "subject").index(-1).isEqualTo(listOf("one"))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)
@@ -141,7 +142,7 @@ class ListTest {
     @Test fun containsSubList_fails_if_sublist_is_contained_in_actual_but_not_in_exact_order() {
         val actualList: List<String> = listOf("John", "Victoria", "Lee-Anne")
         val sublist: List<String> = listOf("John", "Lee-Anne", "Victoria")
-        val error = assertFails { assertThat(actualList).containsSubList(sublist) }
+        val error = assertFailsWith<AssertionError> { assertThat(actualList).containsSubList(sublist) }
         assertEquals(
                 """expected to contain the exact sublist (in the same order) as:<["John", "Lee-Anne", "Victoria"]>, but found none matching in:<["John", "Victoria", "Lee-Anne"]>""", error.message
         )
@@ -150,7 +151,7 @@ class ListTest {
     @Test fun containsSubList_fails_if_sublist_is_contained_in_actual_but_in_reverse_order() {
         val actualList: List<String> = listOf("John", "Victoria", "Lee-Anne")
         val sublist: List<String> = listOf("Lee-Anne", "Victoria", "John")
-        val error = assertFails { assertThat(actualList).containsSubList(sublist) }
+        val error = assertFailsWith<AssertionError> { assertThat(actualList).containsSubList(sublist) }
         assertEquals(
                 """expected to contain the exact sublist (in the same order) as:<["Lee-Anne", "Victoria", "John"]>, but found none matching in:<["John", "Victoria", "Lee-Anne"]>""", error.message
         )
@@ -196,7 +197,7 @@ class ListTest {
 
     @Test fun startsWith_fails_if_values_are_not_at_the_head_of_the_list() {
         val given: List<Int> = listOf(1, 2, 3, 4, 5)
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(given).startsWith(2, 4)
         }
 
@@ -208,7 +209,7 @@ class ListTest {
 
     @Test fun startsWith_fails_if_there_is_not_enough_elements_in_the_list() {
         val given: List<Int> = listOf(1, 2)
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(given).startsWith(1, 2, 3)
         }
 
@@ -220,7 +221,7 @@ class ListTest {
 
     @Test fun startsWith_fails_if_elements_order_do_not_match() {
         val given: List<String> = listOf("Jason", "Jane", "Anne")
-        assertFails { assertThat(given).startsWith("Jane", "Jason") }
+        assertFailsWith<AssertionError> { assertThat(given).startsWith("Jane", "Jason") }
     }
 
     @Test fun startsWith_pass_if_values_are_equal_to_the_list() {
@@ -237,7 +238,7 @@ class ListTest {
 
     @Test fun endsWith_fails_if_values_are_not_at_the_tail_of_the_list() {
         val given: List<Int> = listOf(1, 2, 3, 4, 5)
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(given).endsWith(4, 2)
         }
 
@@ -249,7 +250,7 @@ class ListTest {
 
     @Test fun endsWith_fails_if_there_is_not_enough_elements_in_the_list() {
         val given: List<Int> = listOf(2, 3)
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(given).endsWith(1, 2, 3)
         }
 
@@ -261,7 +262,7 @@ class ListTest {
 
     @Test fun endsWith_fails_if_elements_order_do_not_match() {
         val given: List<String> = listOf("Jason", "Jane", "Anne")
-        assertFails { assertThat(given).endsWith("Anne", "Jane") }
+        assertFailsWith<AssertionError> { assertThat(given).endsWith("Anne", "Jane") }
     }
 
     @Test fun endsWith_pass_if_values_are_equal_to_the_list() {

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/MapTest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class MapTest {
     //region contains
@@ -13,14 +13,14 @@ class MapTest {
     }
 
     @Test fun contains_element_missing_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyMap<String, Int>()).contains("one" to 1)
         }
         assertEquals("expected to contain:<{\"one\"=1}> but was:<{}>", error.message)
     }
 
     @Test fun contains_element_with_nullable_value_missing_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyMap<String, Int?>()).contains("one" to null)
         }
         assertEquals("expected to contain:<{\"one\"=null}> but was:<{}>", error.message)
@@ -37,7 +37,7 @@ class MapTest {
     }
 
     @Test fun doesNotContain_element_present_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf("one" to 1, "two" to 2)).doesNotContain("two" to 2)
         }
         assertEquals("expected to not contain:<{\"two\"=2}> but was:<{\"one\"=1, \"two\"=2}>", error.message)
@@ -54,7 +54,7 @@ class MapTest {
     }
 
     @Test fun containsNone_present_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf("one" to 1, "two" to 2)).containsNone("two" to 2, "three" to 3)
         }
         assertEquals(
@@ -76,7 +76,7 @@ class MapTest {
     }
 
     @Test fun containsAll_swapped_keys_and_values_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf("one" to 2, "two" to 1)).containsAll("two" to 2, "one" to 1)
         }
 
@@ -88,7 +88,7 @@ class MapTest {
     }
 
     @Test fun containsAll_nullable_values_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf<String, Any?>()).containsAll("key" to null)
         }
         assertEquals(
@@ -99,7 +99,7 @@ class MapTest {
     }
 
     @Test fun containsAll_some_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf("one" to 1)).containsAll("one" to 1, "two" to 2)
         }
         assertEquals(
@@ -117,7 +117,7 @@ class MapTest {
     }
 
     @Test fun containsOnly_swapped_keys_and_values_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf("one" to 2, "two" to 1)).containsOnly("two" to 2, "one" to 1)
         }
 
@@ -130,7 +130,7 @@ class MapTest {
     }
 
     @Test fun containsOnly_missing_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf("one" to 1, "two" to 2)).containsOnly("three" to 3)
         }
         assertEquals(
@@ -142,7 +142,7 @@ class MapTest {
     }
 
     @Test fun containsOnly_extra_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf("one" to 1, "two" to 2)).containsOnly("one" to 1)
         }
         assertEquals(
@@ -159,7 +159,7 @@ class MapTest {
     }
 
     @Test fun isEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf<Any?, Any?>(null to null)).isEmpty()
         }
         assertEquals("expected to be empty but was:<{null=null}>", error.message)
@@ -172,7 +172,7 @@ class MapTest {
     }
 
     @Test fun isNotEmpty_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf<Any?, Any?>()).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
@@ -189,7 +189,7 @@ class MapTest {
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf<Any?, Any?>(null to null)).isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<{null=null}>", error.message)
@@ -202,7 +202,7 @@ class MapTest {
     }
 
     @Test fun hasSize_wrong_size_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyMap<String, Int>()).hasSize(1)
         }
         assertEquals("expected [size]:<[1]> but was:<[0]> ({})", error.message)
@@ -215,7 +215,7 @@ class MapTest {
     }
 
     @Test fun hasSameSizeAs_non_equal_sizes_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyMap<String, Int>()).hasSameSizeAs(mapOf("one" to 1))
         }
         assertEquals("expected to have same size as:<{\"one\"=1}> (1) but was size:(0)", error.message)
@@ -228,14 +228,14 @@ class MapTest {
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf("one" to 1, "two" to 2), name = "subject").key("one").isEqualTo(2)
         }
         assertEquals("expected [subject[\"one\"]]:<[2]> but was:<[1]> ({\"one\"=1, \"two\"=2})", error.message)
     }
 
     @Test fun index_missing_key_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(mapOf("one" to 1, "two" to 2), name = "subject").key("wrong").isEqualTo(1)
         }
         assertEquals("expected [subject] to have key:<\"wrong\">", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/NumberTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/NumberTest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class NumberTest {
 
@@ -14,7 +14,7 @@ class NumberTest {
     }
 
     @Test fun isZero_value_non_zero_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(1).isZero()
         }
         assertEquals("expected to be 0 but was:<1>", error.message)
@@ -27,7 +27,7 @@ class NumberTest {
     }
 
     @Test fun isNonZero_value_zero_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).isNotZero()
         }
         assertEquals("expected to not be 0", error.message)
@@ -40,14 +40,14 @@ class NumberTest {
     }
 
     @Test fun isPositive_value_zero_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).isPositive()
         }
         assertEquals("expected to be positive but was:<0>", error.message)
     }
 
     @Test fun isPositive_value_negative_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(-1).isPositive()
         }
         assertEquals("expected to be positive but was:<-1>", error.message)
@@ -60,14 +60,14 @@ class NumberTest {
     }
 
     @Test fun isNegative_value_zero_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).isNegative()
         }
         assertEquals("expected to be negative but was:<0>", error.message)
     }
 
     @Test fun isNegative_value_positive_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(1).isNegative()
         }
         assertEquals("expected to be negative but was:<1>", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/PredicateTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/PredicateTest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.matchesPredicate
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class PredicateTest {
 
@@ -16,7 +16,7 @@ class PredicateTest {
 
     @Test fun matchesPredicate_false_predicate_fails() {
         val divisibleBy5: (Int) -> Boolean = { it % 5 == 0 }
-        val error = assertFails { assertThat(6).matchesPredicate(divisibleBy5) }
+        val error = assertFailsWith<AssertionError> { assertThat(6).matchesPredicate(divisibleBy5) }
 
         assertEquals("expected 6 to satisfy the predicate", error.message)
     }

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/ResultTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/ResultTest.kt
@@ -8,7 +8,7 @@ import assertk.assertions.isSuccess
 import test.assertk.exceptionPackageName
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class ResultTest {
     // region success
@@ -21,7 +21,7 @@ class ResultTest {
     }
 
     @Test fun success_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Result.failure<String>(Exception("error"))).isSuccess()
         }
         assertEquals(
@@ -35,7 +35,7 @@ class ResultTest {
     }
 
     @Test fun chained_success_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Result.success(1)).isSuccess().isEqualTo(2)
         }
         assertEquals("expected:<[2]> but was:<[1]> (Success(1))", error.message)
@@ -48,7 +48,7 @@ class ResultTest {
     }
 
     @Test fun failure_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Result.success(1)).isFailure()
         }
         assertEquals("expected failure but was success:<1>", error.message)
@@ -59,7 +59,7 @@ class ResultTest {
     }
 
     @Test fun chained_failure_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Result.failure<String>(Exception("error"))).isFailure().hasMessage("wrong")
         }
         assertEquals(

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/StringTest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class StringTest {
 
@@ -17,7 +17,7 @@ class StringTest {
 
     @Test
     fun isEqualTo_different_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("").isEqualTo("test")
         }
         assertEquals("expected:<\"[test]\"> but was:<\"[]\">", error.message)
@@ -25,7 +25,7 @@ class StringTest {
 
     @Test
     fun isEqualTo_different_null_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("null").isEqualTo(null)
         }
         assertEquals("expected:<null> but was:<\"null\">", error.message)
@@ -38,7 +38,7 @@ class StringTest {
 
     @Test
     fun isEqualTo_different_value_ignore_case_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("Test").isEqualTo("tesT", false)
         }
         assertEquals("expected:<\"[tesT]\"> but was:<\"[Test]\">", error.message)
@@ -46,7 +46,7 @@ class StringTest {
 
     @Test
     fun isEqualTo_renders_different_line_endings() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("Test\n").isEqualTo("Test\r\n")
         }
         assertEquals("expected:<\"Test[\\r]\n\"> but was:<\"Test[]\n\">", error.message)
@@ -54,7 +54,7 @@ class StringTest {
 
     @Test
     fun isEqual_renders_tabs_vs_spaces() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("\tTest").isEqualTo("    Test")
         }
         assertEquals("expected:<\"[    ]Test\"> but was:<\"[\\t]Test\">", error.message)
@@ -62,7 +62,7 @@ class StringTest {
 
     @Test
     fun isEqual_renders_newline_vs_not() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("Test\n").isEqualTo("Test")
         }
         assertEquals("expected:<\"Test[]\"> but was:<\"Test[\\n]\">", error.message)
@@ -72,7 +72,7 @@ class StringTest {
     //region isNotEqualTo
     @Test
     fun isNotEqualTo_same_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("test").isNotEqualTo("test")
         }
         assertEquals("expected to not be equal to:<\"test\">", error.message)
@@ -90,7 +90,7 @@ class StringTest {
 
     @Test
     fun isNotEqualTo_same_value_ignore_case_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat("Test").isNotEqualTo("tesT", true)
         }
         assertEquals("expected:<\"tesT\"> not to be equal to (ignoring case):<\"Test\">", error.message)

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/ThrowableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/ThrowableTest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.*
 import test.assertk.exceptionPackageName
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class ThrowableTest {
     val rootCause = Exception("rootCause")
@@ -30,7 +30,7 @@ class ThrowableTest {
     }
 
     @Test fun hasMessage_different_message_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).hasMessage("not test")
         }
         assertEquals("expected [message]:<\"[not ]test\"> but was:<\"[]test\"> ($subject)", error.message)
@@ -43,7 +43,7 @@ class ThrowableTest {
     }
 
     @Test fun messageContains_different_message_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).messageContains("not")
         }
         assertEquals("expected [message] to contain:<\"not\"> but was:<\"test\"> ($subject)", error.message)
@@ -58,7 +58,7 @@ class ThrowableTest {
 
     @Test fun hasCause_no_cause_fails() {
         val causeless = Exception("test")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(causeless).hasCause(cause)
         }
         assertEquals(
@@ -69,7 +69,7 @@ class ThrowableTest {
 
     @Test fun hasCause_different_message_fails() {
         val wrongCause = Exception("wrong")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).hasCause(wrongCause)
         }
         assertEquals(
@@ -80,7 +80,7 @@ class ThrowableTest {
 
     @Test fun hasCause_different_type_fails() {
         val wrongCause = IllegalArgumentException("cause")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).hasCause(wrongCause)
         }
         assertEquals(
@@ -97,7 +97,7 @@ class ThrowableTest {
     }
 
     @Test fun hasNoCause_cause_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).hasNoCause()
         }
         assertEquals("expected [cause] to be null but was:<$cause> ($subject)", error.message)
@@ -111,7 +111,7 @@ class ThrowableTest {
 
     @Test fun hasRootCause_wrong_cause_type_fails() {
         val wrongCause = IllegalArgumentException("rootCause")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).hasRootCause(wrongCause)
         }
         assertEquals(
@@ -122,7 +122,7 @@ class ThrowableTest {
 
     @Test fun hasRootCause_wrong_cause_message_fails() {
         val wrongCause = Exception("wrong")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).hasRootCause(wrongCause)
         }
         assertEquals(

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/support/SupportTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/support/SupportTest.kt
@@ -99,7 +99,7 @@ class SupportTest {
 
     //region fail
     @Test fun fail_expected_and_actual_the_same_shows_simple_message_without_diff() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).fail(1, 1)
         }
 
@@ -107,7 +107,7 @@ class SupportTest {
     }
 
     @Test fun fail_expected_null_shows_simple_message_without_diff() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).fail(null, 1)
         }
 
@@ -115,7 +115,7 @@ class SupportTest {
     }
 
     @Test fun fail_actual_null_shows_simple_message_without_diff() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).fail(1, null)
         }
 
@@ -123,7 +123,7 @@ class SupportTest {
     }
 
     @Test fun fail_short_expected_and_actual_different_shows_simple_diff() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).fail("test1", "test2")
         }
 
@@ -131,7 +131,7 @@ class SupportTest {
     }
 
     @Test fun fail_long_expected_and_actual_different_shows_compact_diff() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).fail(
                 "this is a long prefix 1 this is a long suffix",
                 "this is a long prefix 2 this is a long suffix"
@@ -147,7 +147,7 @@ class SupportTest {
 
     //region expected
     @Test fun expected_throws_assertion_failed_error_with_actual_and_expected_present_and_defined() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).expected("message", "expected", "actual")
         }
 
@@ -160,7 +160,7 @@ class SupportTest {
     }
 
     @Test fun expected_throws_assertion_failed_error_with_actual_and_expected_not_defined() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(0).expected("message")
         }
 

--- a/assertk/src/jvmTest/kotlin/test/assertk/JVMAssertAllTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/JVMAssertAllTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 
 class JVMAssertAllTest {
@@ -31,7 +31,7 @@ class JVMAssertAllTest {
     }
 
     @Test fun assert_all_includes_exceptions_as_suppressed() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat(1).isEqualTo(2)
                 assertThat(2).isEqualTo(1)
@@ -44,13 +44,12 @@ class JVMAssertAllTest {
 
     @Test fun assert_all_does_not_catch_out_of_memory_errors() {
         var runs = false
-        val error = assertFails {
+        assertFailsWith<OutOfMemoryError> {
             assertAll {
                 assertThat(1).given { throw OutOfMemoryError() }
                 runs = true
             }
         }
-        assertEquals(OutOfMemoryError::class, error::class)
         assertFalse(runs)
     }
 }

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/BigDecimalTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/BigDecimalTest.kt
@@ -5,12 +5,12 @@ import assertk.assertions.isEqualByComparingTo
 import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class BigDecimalTest {
     @Test
     fun isEqualByComparingTo_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(BigDecimal(20)).isEqualByComparingTo(BigDecimal(21))
         }
         assertEquals("expected:<2[1]> but was:<2[0]>", error.message)

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
@@ -19,7 +19,7 @@ class FileTest {
     @Test fun exists_with_nonexistent_file_fails() {
         val tempFile = File.createTempFile("exists", "txt")
         tempFile.delete()
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(tempFile).exists()
         }
         assertEquals("expected to exist", error.message)
@@ -32,7 +32,7 @@ class FileTest {
     }
 
     @Test fun isDirectory_value_file_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(file).isDirectory()
         }
         assertEquals("expected to be a directory", error.message)
@@ -45,7 +45,7 @@ class FileTest {
     }
 
     @Test fun isFile_value_directory_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(directory).isFile()
         }
         assertEquals("expected to be a file", error.message)
@@ -60,7 +60,7 @@ class FileTest {
 
     //region isHidden
     @Test fun isHidden_value_regular_file_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(file).isHidden()
         }
         assertEquals("expected to be hidden", error.message)
@@ -80,14 +80,14 @@ class FileTest {
     }
 
     @Test fun hasName_wrong_value_file_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(namedFile).hasName("file")
         }
         assertEquals("expected [name]:<\"file[]\"> but was:<\"file[.txt]\"> (assertKt${File.separator}file.txt)", error.message)
     }
 
     @Test fun hasName_wront_value_directory_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(namedDirectory).hasName("assertKt")
         }
         assertEquals(
@@ -105,7 +105,7 @@ class FileTest {
     }
 
     @Test fun hasPath_wrong_path_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(fileWithPath).hasPath("/directory")
         }
         assertEquals(
@@ -123,7 +123,7 @@ class FileTest {
     }
 
     @Test fun hasParent_wrong_parent_passes() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(fileWithParent).hasParent("directory")
         }
         val expected = "expected [parent]:<\"[]directory\"> but was:<\"[assertKt${File.separator}]directory\"> (assertKt${File.separator}directory${File.separator}file.txt)"
@@ -144,7 +144,7 @@ class FileTest {
     }
 
     @Test fun hasExtension_wrong_extension_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(fileWithExtension).hasExtension("png")
         }
         assertEquals("expected [extension]:<\"[png]\"> but was:<\"[${fileWithExtension.extension}]\"> (file.txt)", error.message)
@@ -166,7 +166,7 @@ class FileTest {
     }
 
     @Test fun hasText_wrong_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(fileWithText).hasText("Forty-two!")
         }
         assertTrue(error.message!!.startsWith("expected [text]:<\"[Forty-two!]\"> but was:<\"[$text]\">"))
@@ -180,7 +180,7 @@ class FileTest {
     }
 
     @Test fun contains_wrong_substring_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(fileWithText).text().contains("Forty-two!")
         }
         assertTrue(error.message!!.startsWith("expected [text] to contain:<\"Forty-two!\"> but was:<\"$text\">"))
@@ -203,7 +203,7 @@ class FileTest {
 
     @Test fun matches_wrong_regex_fails() {
         val incorrectRegexp = ".*d".toRegex()
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(matchingFile).text().matches(incorrectRegexp)
         }
         assertTrue(error.message!!.startsWith("expected [text] to match:</$incorrectRegexp/> but was:<\"$matchingText\">"))
@@ -221,7 +221,7 @@ class FileTest {
 
     @Test fun hasDirectChild_value_not_child_fails() {
         val newFile = File.createTempFile("file", ".txt")
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(directoryWithChild).hasDirectChild(newFile)
         }
         assertEquals("expected to have direct child <$newFile>", error.message)
@@ -229,7 +229,7 @@ class FileTest {
 
     @Test fun hasDirectChild_empty_directory_fails() {
         directoryWithChild.listFiles().forEach { it.delete() }
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(directory).hasDirectChild(file)
         }
         assertEquals("expected to have direct child <$file>", error.message)

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/InputStreamTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/InputStreamTest.kt
@@ -7,7 +7,7 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class InputStreamTest {
 
@@ -17,7 +17,7 @@ class InputStreamTest {
     }
 
     @Test fun hasSameContentAs_on_different_streams_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyStream()).hasSameContentAs(streamA())
         }
         assertEquals(
@@ -27,7 +27,7 @@ class InputStreamTest {
     }
 
     @Test fun hasSameContentAs_on_different_non_empty_streams_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(streamA()).hasSameContentAs(streamB())
         }
         assertEquals(
@@ -41,19 +41,19 @@ class InputStreamTest {
     }
 
     @Test fun hasSameContent_on_different_sized_streams_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(prefixOfStreamA()).hasSameContentAs(streamA())
         }
         assertEquals("expected to have the same size, but actual size (5) differs from other size (10)", error.message)
 
-        val error2 = assertFails {
+        val error2 = assertFailsWith<AssertionError> {
             assertThat(streamA()).hasSameContentAs(prefixOfStreamA())
         }
         assertEquals("expected to have the same size, but actual size (10) differs from other size (5)", error2.message)
     }
 
     @Test fun hasSameContentAs_streams_different_in_single_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(streamB()).hasSameContentAs(streamC())
         }
         assertEquals(
@@ -66,7 +66,7 @@ class InputStreamTest {
 
     //region hasNotSameContentAs
     @Test fun hasNotSameContentAs_on_empty_streams_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(emptyStream()).hasNotSameContentAs(emptyStream())
         }
         assertEquals("expected streams not to be equal, but they were equal", error.message)
@@ -77,7 +77,7 @@ class InputStreamTest {
     }
 
     @Test fun hasNotSameContentAs_on_same_streams_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(streamA()).hasNotSameContentAs(streamA())
         }
         assertEquals("expected streams not to be equal, but they were equal", error.message)

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/JVMResultTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/JVMResultTest.kt
@@ -5,14 +5,14 @@ import assertk.assertions.isSuccess
 import org.junit.Test
 import test.assertk.exceptionPackageName
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class JVMResultTest {
 
     @Test fun failure_result_fails_with_stacktrace() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Result.failure<String>(Exception("test"))).isSuccess()
         }
 

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -8,6 +8,7 @@ import kotlin.reflect.KCallable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class JavaAnyTest {
     val p: String = JavaAnyTest::class.java.name
@@ -29,7 +30,7 @@ class JavaAnyTest {
     }
 
     @Test fun isInstanceOf_jclass_different_class_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isInstanceOf(DifferentObject::class.java)
         }
         assertEquals(
@@ -39,7 +40,7 @@ class JavaAnyTest {
     }
 
     @Test fun isInstanceOf_jclass_run_block_when_passes() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject as TestObject)
                 .isInstanceOf(BasicObject::class.java)
                 .prop("str", BasicObject::str)
@@ -49,7 +50,7 @@ class JavaAnyTest {
     }
 
     @Test fun isInstanceOf_jclass_doesnt_run_block_when_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject as TestObject)
                 .isInstanceOf(DifferentObject::class.java)
                 .isNull()
@@ -67,14 +68,14 @@ class JavaAnyTest {
     }
 
     @Test fun isNotInstanceOf_jclass_same_class_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isNotInstanceOf(BasicObject::class.java)
         }
         assertEquals("expected to not be instance of:<$p\$BasicObject>", error.message)
     }
 
     @Test fun isNotInstanceOf_jclass_parent_class_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(subject).isNotInstanceOf(TestObject::class.java)
         }
         assertEquals("expected to not be instance of:<$p\$TestObject>", error.message)
@@ -88,7 +89,7 @@ class JavaAnyTest {
     }
 
     @Test fun prop_callable_extract_prop_includes_name_in_failure_message() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             @Suppress("DEPRECATION")
             assertThat(subject).prop(BasicObject::str  as KCallable<String>).isEmpty()
         }
@@ -111,7 +112,7 @@ class JavaAnyTest {
     }
 
     @Test fun isDataClassEqualTo_reports_all_properties_that_differ_on_failure() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(DataClass(InnerDataClass("test"), 1, 'a'))
                 .isDataClassEqualTo(DataClass(InnerDataClass("wrong"), 1, 'b'))
         }
@@ -124,7 +125,7 @@ class JavaAnyTest {
     }
 
     @Test fun isDataClassEqualTo_fails_on_null_property_in_actual() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(DataClass(null, 1, 'a'))
                 .isDataClassEqualTo(DataClass(InnerDataClass("wrong"), 1, 'b'))
         }
@@ -137,7 +138,7 @@ class JavaAnyTest {
     }
 
     @Test fun isDataClassEqualTo_fails_on_null_property_in_expected() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(DataClass(InnerDataClass("test"), 1, 'a'))
                 .isDataClassEqualTo(DataClass(null, 1, 'b'))
         }
@@ -156,7 +157,7 @@ class JavaAnyTest {
     }
 
     @Test fun isEqualToIgnoringGivenProperties_fails() {
-        assertFails {
+        assertFailsWith<AssertionError> {
             assertThat(BasicObject("Rarity", int = 42)).isEqualToIgnoringGivenProperties(BasicObject("notRarity", int = 1337), BasicObject::str, BasicObject::failing)
         }
     }

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaNullableStringTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaNullableStringTest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class JavaNullableStringTest {
 
@@ -15,7 +15,7 @@ class JavaNullableStringTest {
     }
 
     @Test fun isEqualTo_different_string_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(JavaNullableString.string()).isEqualTo("wrong")
         }
         assertEquals("expected:<\"wrong\"> but was:<null>", error.message)
@@ -28,7 +28,7 @@ class JavaNullableStringTest {
     }
 
     @Test fun isNotEqualTo_same_nullable_string_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(JavaNullableString.string()).isNotEqualTo(JavaNullableString.string())
         }
         assertEquals("expected to not be equal to:<null>", error.message)

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/OptionalTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/OptionalTest.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 import java.time.Month
 import java.util.*
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 internal class OptionalTest {
 
@@ -19,7 +19,7 @@ internal class OptionalTest {
 
     @Test
     fun isPresent_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Optional.empty<Any>()).isPresent()
         }
         assertEquals(
@@ -33,7 +33,7 @@ internal class OptionalTest {
     }
 
     @Test fun isEmpty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Optional.of("test")).isEmpty()
         }
         assertEquals(
@@ -47,7 +47,7 @@ internal class OptionalTest {
     }
 
     @Test fun hasValue_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Optional.empty<String>()).hasValue("test")
         }
         assertEquals(
@@ -57,7 +57,7 @@ internal class OptionalTest {
     }
 
     @Test fun hasValue_wrong_value_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(Optional.of("test")).hasValue("wrong")
         }
         assertEquals(

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/PathTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/PathTest.kt
@@ -35,7 +35,7 @@ class PathTest {
     }
 
     @Test fun isRegularFile_value_directory_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(directory!!).isRegularFile()
         }
         assertEquals("expected <$directory> to be a regular file, but it is not", error.message)
@@ -44,7 +44,7 @@ class PathTest {
 
     //region isDirectory
     @Test fun isDirectory_value_not_directory_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(regularFile!!).isDirectory()
         }
         assertEquals("expected <$regularFile> to be a directory, but it is not", error.message)
@@ -57,14 +57,14 @@ class PathTest {
 
     //region isHidden
     @Test fun isHidden_value_regular_file_not_hidden_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(regularFile!!).isHidden()
         }
         assertEquals("expected <$regularFile> to be hidden, but it is not", error.message)
     }
 
     @Test fun isHidden_value_directory_not_hidden_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(directory!!).isHidden()
         }
         assertEquals("expected <$directory> to be hidden, but it is not", error.message)
@@ -83,14 +83,14 @@ class PathTest {
 
     //region isSymbolicLink
     @Test fun isSymbolicLink_value_regular_file_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(regularFile!!).isSymbolicLink()
         }
         assertEquals("expected <$regularFile> to be a symbolic link, but it is not", error.message)
     }
 
     @Test fun isSymbolicLink_value_directory_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(directory!!).isSymbolicLink()
         }
         assertEquals("expected <$directory> to be a symbolic link, but it is not", error.message)
@@ -135,7 +135,7 @@ class PathTest {
     }
 
     @Test fun exists_value_not_exists_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(doesNotExist!!).exists()
         }
         assertEquals("expected <$doesNotExist> to exist, but it does not", error.message)

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/support/JavaNumberTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/support/JavaNumberTest.kt
@@ -8,8 +8,7 @@ import org.junit.Test
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
-
+import kotlin.test.assertFailsWith
 
 class BigDecimalSpecNumberOnIsZero {
 
@@ -20,7 +19,7 @@ class BigDecimalSpecNumberOnIsZero {
 
     @Test
     fun itGivenNoZeroTestShouldFail() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(BigDecimal.ONE).isZero()
         }
         assertEquals("expected to be 0 but was:<1>", error.message)
@@ -36,7 +35,7 @@ class BigIntegerSpecNumberOnIsZero {
 
     @Test
     fun it_Given_a_not_zero_test_should_fail() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(BigInteger.ONE).isZero()
         }
         assertEquals("expected to be 0 but was:<1>", error.message)
@@ -51,7 +50,7 @@ class BigDecimalSpecNumberOnIsPositive {
 
     @Test
     fun itGivenZeroNumberTestShouldFail() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(BigDecimal.ZERO).isPositive()
         }
         assertEquals("expected to be positive but was:<0>", error.message)
@@ -59,7 +58,7 @@ class BigDecimalSpecNumberOnIsPositive {
 
     @Test
     fun itGivenNegativeNumberTestShouldFail() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(BigDecimal.ONE.negate()).isPositive()
         }
         assertEquals("expected to be positive but was:<-1>", error.message)
@@ -69,7 +68,7 @@ class BigDecimalSpecNumberOnIsPositive {
 class NumberSpecNumberOnIsNegative {
     @Test
     fun itGivenZeroNumberTestShouldFail() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(BigDecimal.ZERO).isNegative()
         }
         assertEquals("expected to be negative but was:<0>", error.message)
@@ -77,7 +76,7 @@ class NumberSpecNumberOnIsNegative {
 
     @Test
     fun itGivePositiveNumberTestShouldFail() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat(BigDecimal.ONE).isNegative()
         }
         assertEquals("expected to be negative but was:<1>", error.message)

--- a/assertk/src/nativeTest/kotlin/test/assertk/NativeAssertAllTest.kt
+++ b/assertk/src/nativeTest/kotlin/test/assertk/NativeAssertAllTest.kt
@@ -9,10 +9,7 @@ import assertk.assertions.isEqualTo
 import kotlin.native.concurrent.Worker
 import kotlin.native.concurrent.Future
 import kotlin.native.concurrent.TransferMode
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFails
-import kotlin.test.assertFalse
+import kotlin.test.*
 
 class NativeAssertAllTest {
 
@@ -40,13 +37,12 @@ class NativeAssertAllTest {
 
     @Test fun assert_all_does_not_catch_out_of_memory_errors() {
         var runs = false
-        val error = assertFails {
+        assertFailsWith<OutOfMemoryError> {
             assertAll {
                 assertThat(1).given { throw OutOfMemoryError() }
                 runs = true
             }
         }
-        assertEquals(OutOfMemoryError::class, error::class)
         assertFalse(runs)
     }
 

--- a/assertk/src/testTemplate/test/assertk/assertions/FloatArrayContainsTest.kt
+++ b/assertk/src/testTemplate/test/assertk/assertions/FloatArrayContainsTest.kt
@@ -6,7 +6,7 @@ import test.assertk.opentestPackageName
 import assertk.assertions.support.show
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 $T:$N:$E = FloatArray:floatArray:Float, DoubleArray:doubleArray:Double
 
@@ -21,7 +21,7 @@ class $TContainsTest {
     }
 
     @Test fun contains_element_missing_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf()).contains(1.to$E())
         }
         assertEquals("expected to contain:<${show(1.to$E(), "")}> but was:<[]>", error.message)
@@ -34,14 +34,14 @@ class $TContainsTest {
     }
 
     @Test fun doesNotContain_element_present_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).doesNotContain(2.to$E())
         }
         assertEquals("expected to not contain:<${show(2.to$E(), "")}> but was:<[${show(1.to$E(), "")}, ${show(2.to$E(), "")}]>", error.message)
     }
 
     @Test fun doesNotContain_nan_present_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf($E.NaN)).doesNotContain($E.NaN)
         }
         assertEquals("expected to not contain:<${show($E.NaN, "")}> but was:<[${show($E.NaN, "")}]>", error.message)
@@ -54,7 +54,7 @@ class $TContainsTest {
     }
 
     @Test fun containsNone_present_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsNone(2.to$E(), 3.to$E())
         }
         assertEquals(
@@ -71,7 +71,7 @@ class $TContainsTest {
     }
 
     @Test fun containsAll_some_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E())).containsAll(1.to$E(), 2.to$E())
         }
         assertEquals(
@@ -96,7 +96,7 @@ class $TContainsTest {
     }
 
     @Test fun containsOnly_more_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsOnly(2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -107,7 +107,7 @@ class $TContainsTest {
     }
 
     @Test fun containsOnly_less_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsOnly(2.to$E(), 1.to$E(), 3.to$E(), 4.to$E())
         }
         assertEquals(
@@ -119,7 +119,7 @@ class $TContainsTest {
     }
 
     @Test fun containsOnly_different_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E())).containsOnly(2.to$E())
         }
         assertEquals(
@@ -138,7 +138,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_all_elements_in_different_order_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -150,7 +150,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_missing_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(3.to$E())
         }
         assertEquals(
@@ -163,7 +163,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_same_indexes_are_together() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 1.to$E())).containsExactly(2.to$E(), 2.to$E())
         }
         assertEquals(
@@ -177,7 +177,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_extra_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
         }
         assertEquals(
@@ -188,7 +188,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_missing_element_in_middle_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 3.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
         }
         assertEquals(
@@ -199,7 +199,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_extra_element_in_middle_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsExactly(1.to$E(), 3.to$E())
         }
         assertEquals(
@@ -220,7 +220,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_duplicate_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 2.to$E())).containsExactlyInAnyOrder(2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -231,7 +231,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_duplicate_elements_fails2() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsExactlyInAnyOrder(2.to$E(), 2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -242,7 +242,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_more_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsExactlyInAnyOrder(2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -253,7 +253,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_less_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsExactlyInAnyOrder(2.to$E(), 1.to$E(), 3.to$E(), 4.to$E())
         }
         assertEquals(
@@ -265,7 +265,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_different_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E())).containsExactlyInAnyOrder(2.to$E())
         }
         assertEquals(
@@ -288,7 +288,7 @@ class $TContainsTest {
     }
 
     @Test fun each_non_matching_content_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).each { it.isLessThan(2.to$E()) }
         }
         assertEquals(
@@ -306,7 +306,7 @@ class $TContainsTest {
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E()), name = "subject").index(0).isGreaterThan(2.to$E())
         }
         assertEquals(
@@ -316,7 +316,7 @@ class $TContainsTest {
     }
 
     @Test fun index_out_of_range_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1).isEqualTo(listOf(1.to$E()))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)

--- a/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayContainsTest.kt
+++ b/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayContainsTest.kt
@@ -6,7 +6,7 @@ import test.assertk.opentestPackageName
 import assertk.assertions.support.show
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 $T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArray:Short, LongArray:longArray:Long, CharArray:charArray:Char
 
@@ -17,7 +17,7 @@ class $TContainsTest {
     }
 
     @Test fun contains_element_missing_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf()).contains(1.to$E())
         }
         assertEquals("expected to contain:<${show(1.to$E(), "")}> but was:<[]>", error.message)
@@ -30,7 +30,7 @@ class $TContainsTest {
     }
 
     @Test fun doesNotContain_element_present_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).doesNotContain(2.to$E())
         }
         assertEquals("expected to not contain:<${show(2.to$E(), "")}> but was:<[${show(1.to$E(), "")}, ${show(2.to$E(), "")}]>", error.message)
@@ -43,7 +43,7 @@ class $TContainsTest {
     }
 
     @Test fun containsNone_present_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsNone(2.to$E(), 3.to$E())
         }
         assertEquals(
@@ -60,7 +60,7 @@ class $TContainsTest {
     }
 
     @Test fun containsAll_some_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E())).containsAll(1.to$E(), 2.to$E())
         }
         assertEquals(
@@ -85,7 +85,7 @@ class $TContainsTest {
     }
 
     @Test fun containsOnly_more_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsOnly(2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -96,7 +96,7 @@ class $TContainsTest {
     }
 
     @Test fun containsOnly_less_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsOnly(2.to$E(), 1.to$E(), 3.to$E(), 4.to$E())
         }
         assertEquals(
@@ -108,7 +108,7 @@ class $TContainsTest {
     }
 
     @Test fun containsOnly_different_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E())).containsOnly(2.to$E())
         }
         assertEquals(
@@ -127,7 +127,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_all_elements_in_different_order_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -139,7 +139,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_missing_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(3.to$E())
         }
         assertEquals(
@@ -152,7 +152,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_same_indexes_are_together() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 1.to$E())).containsExactly(2.to$E(), 2.to$E())
         }
         assertEquals(
@@ -166,7 +166,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_extra_element_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
         }
         assertEquals(
@@ -177,7 +177,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_missing_element_in_middle_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 3.to$E())).containsExactly(1.to$E(), 2.to$E(), 3.to$E())
         }
         assertEquals(
@@ -188,7 +188,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactly_extra_element_in_middle_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsExactly(1.to$E(), 3.to$E())
         }
         assertEquals(
@@ -209,7 +209,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_duplicate_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 2.to$E())).containsExactlyInAnyOrder(2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -220,7 +220,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_duplicate_elements_fails2() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E())).containsExactlyInAnyOrder(2.to$E(), 2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -231,7 +231,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_more_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsExactlyInAnyOrder(2.to$E(), 1.to$E())
         }
         assertEquals(
@@ -242,7 +242,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_less_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).containsExactlyInAnyOrder(2.to$E(), 1.to$E(), 3.to$E(), 4.to$E())
         }
         assertEquals(
@@ -254,7 +254,7 @@ class $TContainsTest {
     }
 
     @Test fun containsExactlyInAnyOrder_different_elements_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E())).containsExactlyInAnyOrder(2.to$E())
         }
         assertEquals(
@@ -277,7 +277,7 @@ class $TContainsTest {
     }
 
     @Test fun each_non_matching_content_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).each { it.isLessThan(2.to$E()) }
         }
         assertEquals(
@@ -295,7 +295,7 @@ class $TContainsTest {
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E()), name = "subject").index(0).isGreaterThan(2.to$E())
         }
         assertEquals(
@@ -305,7 +305,7 @@ class $TContainsTest {
     }
 
     @Test fun index_out_of_range_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1).isEqualTo(listOf(1.to$E()))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)

--- a/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
+++ b/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
@@ -6,7 +6,7 @@ import test.assertk.opentestPackageName
 import assertk.assertions.support.show
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 $T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArray:Short, LongArray:longArray:Long, FloatArray:floatArray:Float, DoubleArray:doubleArray:Double, CharArray:charArray:Char
 
@@ -17,7 +17,7 @@ class $TTest {
     }
 
 //    @Test fun isEqualTo_different_contents_fails() {
-//        val error = assertFails {
+//        val error = assertFailsWith<AssertionError> {
 //            assertThat($NOf(97.to$E())).isEqualTo($NOf(98.to$E()))
 //        }
 //        assertEquals("expected:<[[${show(98.to$E(), "")}]]> but was:<[[${show(97.to$E(), "")}]]>", error.message)
@@ -30,7 +30,7 @@ class $TTest {
     }
 
     @Test fun isNotEqualTo_same_contents_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(0.to$E())).isNotEqualTo($NOf(0.to$E()))
         }
         assertEquals("expected to not be equal to:<[${show(0.to$E(), "")}]>", error.message)
@@ -43,7 +43,7 @@ class $TTest {
     }
 
     @Test fun isEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(0.to$E())).isEmpty()
         }
         assertEquals("expected to be empty but was:<[${show(0.to$E(), "")}]>", error.message)
@@ -56,7 +56,7 @@ class $TTest {
     }
 
     @Test fun isNotEmpty_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf()).isNotEmpty()
         }
         assertEquals("expected to not be empty", error.message)
@@ -73,7 +73,7 @@ class $TTest {
     }
 
     @Test fun isNullOrEmpty_non_empty_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(0.to$E())).isNullOrEmpty()
         }
         assertEquals("expected to be null or empty but was:<[${show(0.to$E(), "")}]>", error.message)
@@ -86,7 +86,7 @@ class $TTest {
     }
 
     @Test fun hasSize_wrong_size_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf()).hasSize(1)
         }
         assertEquals("expected [size]:<[1]> but was:<[0]> ([])", error.message)
@@ -99,7 +99,7 @@ class $TTest {
     }
 
     @Test fun hasSameSizeAs_non_equal_sizes_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf()).hasSameSizeAs($NOf(0.to$E()))
         }
         assertEquals("expected to have same size as:<[${show(0.to$E(), "")}]> (1) but was size:(0)", error.message)
@@ -116,7 +116,7 @@ class $TTest {
     }
 
     @Test fun each_non_matching_content_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E(), 3.to$E())).each { it.isLessThan(2.to$E()) }
         }
         assertEquals(
@@ -134,7 +134,7 @@ class $TTest {
     }
 
     @Test fun index_unsuccessful_assertion_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E()), name = "subject").index(0).isGreaterThan(2.to$E())
         }
         assertEquals(
@@ -144,7 +144,7 @@ class $TTest {
     }
 
     @Test fun index_out_of_range_fails() {
-        val error = assertFails {
+        val error = assertFailsWith<AssertionError> {
             assertThat($NOf(1.to$E(), 2.to$E()), name = "subject").index(-1).isEqualTo(listOf(1.to$E()))
         }
         assertEquals("expected [subject] index to be in range:[0-2) but was:<-1>", error.message)


### PR DESCRIPTION
#410 Replace calls to assertFails{} with assertFailsWith<AssertionError>{}, which is more specific and avoids cases where assertk's code throws an unexpected exception. This also allows cleaning up a couple of cases where this was already being done by comparing the exception class to an expected class.