### PR TITLE
use 'given' to wrap multiple assertions

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assertions/iterable.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/iterable.kt
@@ -240,7 +240,14 @@ fun <E, T : Iterable<E>> Assert<T>.atMost(times: Int, f: (Assert<E>) -> Unit) {
 fun <E, T : Iterable<E>> Assert<T>.exactly(times: Int, f: (Assert<E>) -> Unit) {
     var count = 0
     all(message = "expected to pass exactly $times times",
-        body = { each { item -> count++; f(item) } },
+        body = {
+            given {
+                each { item ->
+                    count++
+                    f(item)
+                }
+            }
+        },
         failIf = { count - it.size != times })
 }
 

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
@@ -312,6 +312,22 @@ class IterableTest {
     @Test fun exactly_times_passed_passes() {
         assertThat(listOf(0, 1, 2) as Iterable<Int>).exactly(2) { it.isGreaterThan(0) }
     }
+
+    @Test fun exactly_with_multiple_assertions_function_passes() {
+        assertThat(listOf(2, -1, 4) as Iterable<Int>).exactly(2) {
+            it.isPositive()
+            it.isNotZero()
+        }
+    }
+
+    @Test fun exactly_with_multiple_assertions_function_fails() {
+        assertFails {
+            assertThat(listOf(2, -1, 4) as Iterable<Int>).exactly(1) {
+                it.isPositive()
+                it.isNotZero()
+            }
+        }
+    }
     //endregion
 
     //region any


### PR DESCRIPTION
Fix for #421 uses `given` to wrap multiple assertions. One potential issue here is if there are multiple failures in a block, only the first will be shown as a cause. I might suggest making a separate function to solve for this.