### PR TITLE
add list first()

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assertions/list.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/list.kt
@@ -7,7 +7,16 @@ import assertk.assertions.support.expectedListDiff
 import assertk.assertions.support.show
 
 /**
- * Returns an assert that assertion on the value at the given index in the list.
+ * Returns an assert on the first value in the list.
+ *
+ * ```
+ * assertThat(listOf(0, 1, 2)).first().isPositive()
+ * ```
+ */
+fun <T> Assert<List<T>>.first(): Assert<T> = index(0)
+
+/**
+ * Returns an assert on the value at the given index in the list.
  *
  * ```
  * assertThat(listOf(0, 1, 2)).index(1).isPositive()

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/ListTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/ListTest.kt
@@ -102,6 +102,22 @@ class ListTest {
     }
     //endregion
 
+    //region first
+    @Test fun first_successful_assertion_passes() {
+        assertThat(listOf("one", "two"), name = "subject").first().isEqualTo("one")
+    }
+
+    @Test fun first_unsuccessful_assertion_fails() {
+        val error = assertFails {
+            assertThat(listOf("one", "two"), name = "subject").first().isEqualTo("wrong")
+        }
+        assertEquals(
+            "expected [subject[0]]:<\"[wrong]\"> but was:<\"[one]\"> ([\"one\", \"two\"])",
+            error.message
+        )
+    }
+    //endregion
+
     //region index
     @Test fun index_successful_assertion_passes() {
         assertThat(listOf("one", "two"), name = "subject").index(0).isEqualTo("one")


### PR DESCRIPTION
Convenient method that allow a user to use `first()` instead of `index(0)`. This is similar to Kotlin `first()`.

I also took the opportunity to rephrase documentation of `index()`.