### PR TITLE
Updated MacOS version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             ".circleci/config.yml" }}-linux
   build-macos:
     macos:
-      xcode: "12.3.0"
+      xcode: "14.0.0"
     <<: *defaults
     steps:
       - checkout


### PR DESCRIPTION
Following this (closed) PR, I realized that the CircleCI configuration needs to be updated:
https://github.com/willowtreeapps/assertk/pull/426

See https://app.circleci.com/pipelines/github/willowtreeapps/assertk/523/workflows/d454905d-6734-4e06-97a8-420604843aa8/jobs/1075