### PR TITLE
Re-implement collection assertions: none,atLeast,atMost,exactly,any

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assert.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assert.kt
@@ -188,7 +188,9 @@ fun <T> assertThat(getter: KProperty0<T>, name: String? = null): Assert<T> =
  * @param body The body to execute.
  */
 fun <T> Assert<T>.all(message: String, body: Assert<T>.() -> Unit) {
-    all(message, { body() }, { it.isNotEmpty() })
+    SoftFailure(message).run {
+        body()
+    }
 }
 
 /**
@@ -203,37 +205,8 @@ fun <T> Assert<T>.all(message: String, body: Assert<T>.() -> Unit) {
  * @param body The body to execute.
  */
 fun <T> Assert<T>.all(body: Assert<T>.() -> Unit) {
-    all(SoftFailure.defaultMessage, { body() }, { it.isNotEmpty() })
-}
-
-/**
- * All assertions in the given lambda are run, with their failures collected. If `failIf` returns true then a failure
- * happens, otherwise they are ignored.
- *
- * ```
- * assert("test", name = "test").all(
- *   message = "my message",
- *   body = {
- *     startsWith("t")
- *     endsWith("t")
- *   }, {
- *     it.size > 1
- *   }
- * )
- * ```
- *
- * @param message An optional message to show before all failures.
- * @param body The body to execute.
- * @param failIf Fails if this returns true, ignores failures otherwise.
- */
-// Hide for now, not sure if happy with api.
-internal fun <T> Assert<T>.all(
-    message: String,
-    body: Assert<T>.(failure: SoftFailure) -> Unit,
-    failIf: (List<Throwable>) -> Boolean
-) {
-    SoftFailure(message, failIf).run {
-        body(this)
+    SoftFailure().run {
+        body()
     }
 }
 

--- a/assertk/src/commonMain/kotlin/assertk/collection.kt
+++ b/assertk/src/commonMain/kotlin/assertk/collection.kt
@@ -1,0 +1,90 @@
+package assertk
+
+import assertk.assertions.support.appendName
+import assertk.assertions.support.show
+import com.willowtreeapps.opentest4k.AssertionFailedError
+import com.willowtreeapps.opentest4k.MultipleFailuresError
+
+private class CollectionFailure<T>(
+    private val check: CollectionCheck<T>.() -> Unit
+) : Failure {
+
+    var index = 0
+    val collectedItems = ArrayList<T>()
+
+    private val failures: MutableMap<Int, MutableList<Throwable>> = LinkedHashMap()
+
+    override fun fail(error: Throwable) {
+        failures.getOrPut(index, { ArrayList() }).plusAssign(error)
+    }
+
+    override fun invoke() {
+        CollectionCheck<T>(collectedItems, failures).check()
+    }
+}
+
+internal class CollectionCheck<T>(
+    private val items: List<T>,
+    private val result: Map<Int, List<Throwable>>,
+) {
+    val size: Int
+        get() = items.size
+
+    val failureSize: Int
+        get() = result.size
+
+    fun results(): List<Result<T>> {
+        return items.mapIndexed { i, item ->
+            val failures = result[i]
+            if (failures != null) {
+                Result.failure(compositeErrorMessage(failures))
+            } else {
+                Result.success(item)
+            }
+        }
+    }
+
+    fun success(): List<T> {
+        return items.filterIndexed { index, _ -> index !in result }
+    }
+
+    fun fail(error: Throwable) {
+        FailureContext.fail(error)
+    }
+
+    fun fail(message: String, results: List<Result<T>> = results()) {
+        FailureContext.fail(compositeErrorMessage(results.mapNotNull { it.exceptionOrNull() }, message))
+    }
+
+    companion object {
+        const val defaultMessage = "The following assertions failed"
+    }
+
+    private fun compositeErrorMessage(errors: List<Throwable>, message: String = defaultMessage): Throwable {
+        return when (errors.size) {
+            0 -> AssertionFailedError(message)
+            1 -> errors.first()
+            else -> MultipleFailuresError(message, errors).apply {
+                errors.forEach(this::addSuppressed)
+            }
+        }
+    }
+}
+
+/**
+ * A custom check on a collection. Used to implement any/none/exactly etc.
+ */
+@Suppress("TooGenericExceptionCaught")
+internal fun <T> Assert<Iterable<T>>.collection(check: CollectionCheck<T>.() -> Unit, f: (Assert<T>) -> Unit) = given { actual ->
+    CollectionFailure(check).run {
+        actual.forEachIndexed { i, item ->
+            index = i
+            collectedItems.add(item)
+            try {
+                f(assertThat(item, name = appendName(show(i, "[]"))))
+            } catch (e: Throwable) {
+                fail(e)
+            }
+        }
+    }
+}

--- a/assertk/src/commonMain/kotlin/assertk/failure.kt
+++ b/assertk/src/commonMain/kotlin/assertk/failure.kt
@@ -97,11 +97,7 @@ internal object SimpleFailure : Failure {
 /**
  * Failure that collects all failures and displays them at once.
  */
-internal class SoftFailure(
-    val message: String = defaultMessage,
-    val failIf: (List<Throwable>) -> Boolean = { it.isNotEmpty() }
-) :
-    Failure {
+internal class SoftFailure(val message: String = defaultMessage) : Failure {
     private val failures: MutableList<Throwable> = ArrayList()
 
     override fun fail(error: Throwable) {
@@ -113,11 +109,8 @@ internal class SoftFailure(
         }
     }
 
-    val count: Int
-        get() = failures.size
-
     override fun invoke() {
-        if (failIf(failures)) {
+        if (failures.isNotEmpty()) {
             FailureContext.fail(compositeErrorMessage(failures))
         }
     }

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/IterableTest.kt
@@ -2,8 +2,28 @@ package test.assertk.assertions
 
 import assertk.all
 import assertk.assertThat
-import assertk.assertions.*
-import assertk.assertions.support.fail
+import assertk.assertions.any
+import assertk.assertions.atLeast
+import assertk.assertions.atMost
+import assertk.assertions.contains
+import assertk.assertions.containsAll
+import assertk.assertions.containsExactly
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.containsNone
+import assertk.assertions.containsOnly
+import assertk.assertions.doesNotContain
+import assertk.assertions.each
+import assertk.assertions.exactly
+import assertk.assertions.extracting
+import assertk.assertions.first
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotEmpty
+import assertk.assertions.none
+import assertk.assertions.single
 import test.assertk.opentestPackageName
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -220,12 +240,33 @@ class IterableTest {
             assertThat(listOf(1, 2) as Iterable<Int>).none { it.isGreaterThan(0) }
         }
         assertEquals(
-            "expected none to pass", error.message
+            """expected none to pass
+            | at index:0 passed:<1>
+            | at index:1 passed:<2>
+            """.trimMargin().lines(), error.message!!.lines()
         )
     }
 
-    @Test fun each_non_matching_content_passes() {
-        assertThat(listOf(1, 2, 3) as Iterable<Int>).none { it.isLessThan(2) }
+    @Test fun none_matching_some_content_fails() {
+        val error = assertFails {
+            assertThat(listOf(1, 2, 3) as Iterable<Int>).none { it.isGreaterThanOrEqualTo(3) }
+        }
+        assertEquals(
+            """expected none to pass
+            | at index:2 passed:<3>
+            """.trimMargin().lines(), error.message!!.lines()
+        )
+    }
+
+    @Test fun none_all_non_matching_content_passes() {
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).none { it.isLessThan(0) }
+    }
+
+    @Test fun none_multiple_failures_passes() {
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).none {
+            it.isLessThan(2)
+            it.isGreaterThan(2)
+        }
     }
     //endregion
 
@@ -252,6 +293,13 @@ class IterableTest {
 
     @Test fun atLeast_works_in_a_soft_assert_context() {
         assertThat(listOf(1, 2, 3) as Iterable<Int>).all { atLeast(2) { it.isGreaterThan(1) } }
+    }
+
+    @Test fun atLeast_multiple_failures_passes() {
+        assertThat(listOf(1, 2, 3) as Iterable<Int>).atLeast(2) {
+            it.isGreaterThan(1)
+            it.isGreaterThan(1)
+        }
     }
     //endregion
 
@@ -311,6 +359,13 @@ class IterableTest {
 
     @Test fun exactly_times_passed_passes() {
         assertThat(listOf(0, 1, 2) as Iterable<Int>).exactly(2) { it.isGreaterThan(0) }
+    }
+
+    @Test fun exactly_times_passed_passes_multiple_assertions() {
+        assertThat(listOf(0, 1, 2) as Iterable<Int>).exactly(2) {
+            it.isGreaterThan(0)
+            it.isGreaterThan(0)
+        }
     }
     //endregion
 
@@ -501,7 +556,7 @@ class IterableTest {
 
     @Test fun single_multiple_fails() {
         val error = assertFails {
-        assertThat(listOf(1, 2)).single().isEqualTo(1)
+            assertThat(listOf(1, 2)).single().isEqualTo(1)
         }
         assertEquals("expected to have single element but has 2: <[1, 2]>", error.message)
     }


### PR DESCRIPTION
to properly handle multiple assertions in the block. Also improves the failure message for none to include which passed.