### PR TITLE
Add unsigned arrays to array template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `first` and `single` assertion for `Iterable`
 - Added sequence assertions to mirror iterable
+- Added array assertions for `UByteArray`, `UShortArray`, `UIntArray`, and `ULongArray`.
 
 ### Fixed
 - Fixed iterable assertions that take a block that could have multiple assertions.

--- a/assertk/src/template/assertk/assertions/primativeArray.kt
+++ b/assertk/src/template/assertk/assertions/primativeArray.kt
@@ -8,7 +8,14 @@ import assertk.assertions.support.show
 import assertk.assertions.support.fail
 import assertk.assertions.support.appendName
 
-$T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArray:Short, LongArray:longArray:Long, FloatArray:floatArray:Float, DoubleArray:doubleArray:Double, CharArray:charArray:Char
+$T:$N:$E =
+    ByteArray:byteArray:Byte,
+    IntArray:intArray:Int,
+    ShortArray:shortArray:Short,
+    LongArray:longArray:Long,
+    FloatArray:floatArray:Float,
+    DoubleArray:doubleArray:Double,
+    CharArray:charArray:Char
 
 /**
  * Returns an assert on the $T's size.

--- a/assertk/src/template/assertk/assertions/primativeArray.kt
+++ b/assertk/src/template/assertk/assertions/primativeArray.kt
@@ -1,5 +1,6 @@
 package assertk.assertions
 
+import kotlin.ExperimentalUnsignedTypes
 import kotlin.jvm.JvmName
 import assertk.Assert
 import assertk.all
@@ -8,25 +9,31 @@ import assertk.assertions.support.show
 import assertk.assertions.support.fail
 import assertk.assertions.support.appendName
 
-$T:$N:$E =
-    ByteArray:byteArray:Byte,
-    IntArray:intArray:Int,
-    ShortArray:shortArray:Short,
-    LongArray:longArray:Long,
-    FloatArray:floatArray:Float,
-    DoubleArray:doubleArray:Double,
-    CharArray:charArray:Char
+$T:$N:$E:$A =
+    ByteArray:byteArray:Byte:,
+    IntArray:intArray:Int:,
+    ShortArray:shortArray:Short:,
+    LongArray:longArray:Long:,
+    FloatArray:floatArray:Float:,
+    DoubleArray:doubleArray:Double:,
+    CharArray:charArray:Char:,
+    UByteArray:ubyteArray:UByte:@ExperimentalUnsignedTypes,
+    UShortArray:ushortArray:UShort:@ExperimentalUnsignedTypes,
+    UIntArray:uintArray:UInt:@ExperimentalUnsignedTypes,
+    ULongArray:ulongArray:ULong:@ExperimentalUnsignedTypes
 
 /**
  * Returns an assert on the $T's size.
  */
 @JvmName("$NSize")
+$A
 fun Assert<$T>.size() = prop("size") { it.size }
 
 /**
  * Asserts the $T contents are equal to the expected one, using [contentDeepEquals].
  * @see isNotEqualTo
  */
+$A
 fun Assert<$T>.isEqualTo(expected: $T) = given { actual ->
     if (actual.contentEquals(expected)) return
     fail(expected, actual)
@@ -36,6 +43,7 @@ fun Assert<$T>.isEqualTo(expected: $T) = given { actual ->
  * Asserts the $T contents are not equal to the expected one, using [contentDeepEquals].
  * @see isEqualTo
  */
+$A
 fun Assert<$T>.isNotEqualTo(expected: $T) = given { actual ->
     if (!(actual.contentEquals(expected))) return
     val showExpected = show(expected)
@@ -54,6 +62,7 @@ fun Assert<$T>.isNotEqualTo(expected: $T) = given { actual ->
  * @see [isNullOrEmpty]
  */
 @JvmName("$NIsEmpty")
+$A
 fun Assert<$T>.isEmpty() = given { actual ->
     if (actual.isEmpty()) return
     expected("to be empty but was:${show(actual)}")
@@ -64,6 +73,7 @@ fun Assert<$T>.isEmpty() = given { actual ->
  * @see [isEmpty]
  */
 @JvmName("$NIsNotEmpty")
+$A
 fun Assert<$T>.isNotEmpty() = given { actual ->
     if (actual.isNotEmpty()) return
     expected("to not be empty")
@@ -74,6 +84,7 @@ fun Assert<$T>.isNotEmpty() = given { actual ->
  * @see [isEmpty]
  */
 @JvmName("$NIsNullOrEmpty")
+$A
 fun Assert<$T?>.isNullOrEmpty() = given { actual ->
     if (actual == null || actual.isEmpty()) return
     expected("to be null or empty but was:${show(actual)}")
@@ -83,6 +94,7 @@ fun Assert<$T?>.isNullOrEmpty() = given { actual ->
  * Asserts the $T has the expected size.
  */
 @JvmName("$NHasSize")
+$A
 fun Assert<$T>.hasSize(size: Int) {
     size().isEqualTo(size)
 }
@@ -91,6 +103,7 @@ fun Assert<$T>.hasSize(size: Int) {
  * Asserts the $T has the same size as the expected array.
  */
 @JvmName("$NHasSameSizeAs")
+$A
 fun Assert<$T>.hasSameSizeAs(other: $T) = given { actual ->
     val actualSize = actual.size
     val otherSize = other.size
@@ -106,6 +119,7 @@ fun Assert<$T>.hasSameSizeAs(other: $T) = given { actual ->
  * ```
  */
 @JvmName("$NIndex")
+$A
 fun Assert<$T>.index(index: Int): Assert<$E> =
     transform(appendName(show(index, "[]"))) { actual ->
         if (index in 0 until actual.size) {
@@ -125,6 +139,7 @@ fun Assert<$T>.index(index: Int): Assert<$E> =
  * ```
  */
 @JvmName("$NEach")
+$A
 fun Assert<$T>.each(f: (Assert<$E>) -> Unit) = given { actual ->
     all {
         actual.forEachIndexed { index, item ->

--- a/assertk/src/template/assertk/assertions/primativeArrayContains.kt
+++ b/assertk/src/template/assertk/assertions/primativeArrayContains.kt
@@ -1,5 +1,6 @@
 package assertk.assertions
 
+import kotlin.ExperimentalUnsignedTypes
 import kotlin.jvm.JvmName
 import assertk.Assert
 import assertk.all
@@ -9,18 +10,23 @@ import assertk.assertions.support.show
 import assertk.assertions.support.fail
 import assertk.assertions.support.appendName
 
-$T:$N:$E =
-    ByteArray:byteArray:Byte,
-    IntArray:intArray:Int,
-    ShortArray:shortArray:Short,
-    LongArray:longArray:Long,
-    CharArray:charArray:Char
+$T:$N:$E:$A =
+    ByteArray:byteArray:Byte:,
+    IntArray:intArray:Int:,
+    ShortArray:shortArray:Short:,
+    LongArray:longArray:Long:,
+    CharArray:charArray:Char:,
+    UByteArray:ubyteArray:UByte:@ExperimentalUnsignedTypes,
+    UShortArray:ushortArray:UShort:@ExperimentalUnsignedTypes,
+    UIntArray:uintArray:UInt:@ExperimentalUnsignedTypes,
+    ULongArray:ulongArray:ULong:@ExperimentalUnsignedTypes
 
 /**
  * Asserts the $T contains the expected element, using `in`.
  * @see [doesNotContain]
  */
 @JvmName("$NContains")
+$A
 fun Assert<$T>.contains(element: $E) = given { actual ->
     if (element in actual) return
     expected("to contain:${show(element)} but was:${show(actual)}")
@@ -31,6 +37,7 @@ fun Assert<$T>.contains(element: $E) = given { actual ->
  * @see [contains]
  */
 @JvmName("$NDoesNotContain")
+$A
 fun Assert<$T>.doesNotContain(element: $E) = given { actual ->
     if (element !in actual) return
     expected("to not contain:${show(element)} but was:${show(actual)}")
@@ -40,6 +47,7 @@ fun Assert<$T>.doesNotContain(element: $E) = given { actual ->
  * Asserts the $T does not contain any of the expected elements.
  * @see [containsAll]
  */
+$A
 fun Assert<$T>.containsNone(vararg elements: $E) = given { actual ->
     if (elements.none { it in actual }) {
         return
@@ -55,6 +63,7 @@ fun Assert<$T>.containsNone(vararg elements: $E) = given { actual ->
  * @see [containsExactly]
  */
 @JvmName("$NContainsAll")
+$A
 fun Assert<$T>.containsAll(vararg elements: $E) = given { actual ->
     if (elements.all { actual.contains(it) }) return
     val notFound = elements.filterNot { it in actual }
@@ -73,6 +82,7 @@ fun Assert<$T>.containsAll(vararg elements: $E) = given { actual ->
  * @see [containsExactly]
  * @see [containsAll]
  */
+$A
 fun Assert<$T>.containsOnly(vararg elements: $E) = given { actual ->
     val notInActual = elements.filterNot { it in actual }
     val notInExpected = actual.filterNot { it in elements }
@@ -100,6 +110,7 @@ fun Assert<$T>.containsOnly(vararg elements: $E) = given { actual ->
  * @see [containsAll]
  */
 @JvmName("$NContainsExactly")
+$A
 fun Assert<$T>.containsExactly(vararg elements: $E) = given { actual ->
     if (actual.contentEquals(elements)) return
 
@@ -120,6 +131,7 @@ fun Assert<$T>.containsExactly(vararg elements: $E) = given { actual ->
  * @see [containsOnly]
  */
 @JvmName("$NContainsExactlyInAnyOrder")
+$A
 fun Assert<$T>.containsExactlyInAnyOrder(vararg elements: $E) = given { actual ->
     val notInActual = elements.toMutableList()
     val notInExpected = actual.toMutableList()

--- a/assertk/src/template/assertk/assertions/primativeArrayContains.kt
+++ b/assertk/src/template/assertk/assertions/primativeArrayContains.kt
@@ -9,7 +9,12 @@ import assertk.assertions.support.show
 import assertk.assertions.support.fail
 import assertk.assertions.support.appendName
 
-$T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArray:Short, LongArray:longArray:Long, CharArray:charArray:Char
+$T:$N:$E =
+    ByteArray:byteArray:Byte,
+    IntArray:intArray:Int,
+    ShortArray:shortArray:Short,
+    LongArray:longArray:Long,
+    CharArray:charArray:Char
 
 /**
  * Asserts the $T contains the expected element, using `in`.

--- a/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayContainsTest.kt
+++ b/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayContainsTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.*
 import test.assertk.opentestPackageName
 import assertk.assertions.support.show
+import kotlin.ExperimentalUnsignedTypes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -13,8 +14,13 @@ $T:$N:$E =
     IntArray:intArray:Int,
     ShortArray:shortArray:Short,
     LongArray:longArray:Long,
-    CharArray:charArray:Char
+    CharArray:charArray:Char,
+    UByteArray:ubyteArray:UByte,
+    UShortArray:ushortArray:UShort,
+    UIntArray:uintArray:UInt,
+    ULongArray:ulongArray:ULong
 
+@OptIn(ExperimentalUnsignedTypes::class)
 class $TContainsTest {
     //region contains
     @Test fun contains_element_present_passes() {

--- a/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayContainsTest.kt
+++ b/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayContainsTest.kt
@@ -8,7 +8,12 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-$T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArray:Short, LongArray:longArray:Long, CharArray:charArray:Char
+$T:$N:$E =
+    ByteArray:byteArray:Byte,
+    IntArray:intArray:Int,
+    ShortArray:shortArray:Short,
+    LongArray:longArray:Long,
+    CharArray:charArray:Char
 
 class $TContainsTest {
     //region contains

--- a/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
+++ b/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.*
 import test.assertk.opentestPackageName
 import assertk.assertions.support.show
+import kotlin.ExperimentalUnsignedTypes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -15,8 +16,13 @@ $T:$N:$E =
     LongArray:longArray:Long,
     FloatArray:floatArray:Float,
     DoubleArray:doubleArray:Double,
-    CharArray:charArray:Char
+    CharArray:charArray:Char,
+    UByteArray:ubyteArray:UByte,
+    UShortArray:ushortArray:UShort,
+    UIntArray:uintArray:UInt,
+    ULongArray:ulongArray:ULong
 
+@OptIn(ExperimentalUnsignedTypes::class)
 class $TTest {
     //region isEqualTo
     @Test fun isEqualTo_same_contents_passes() {

--- a/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
+++ b/assertk/src/testTemplate/test/assertk/assertions/PrimativeArrayTest.kt
@@ -8,7 +8,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-$T:$N:$E = ByteArray:byteArray:Byte, IntArray:intArray:Int, ShortArray:shortArray:Short, LongArray:longArray:Long, FloatArray:floatArray:Float, DoubleArray:doubleArray:Double, CharArray:charArray:Char
+$T:$N:$E =
+    ByteArray:byteArray:Byte,
+    IntArray:intArray:Int,
+    ShortArray:shortArray:Short,
+    LongArray:longArray:Long,
+    FloatArray:floatArray:Float,
+    DoubleArray:doubleArray:Double,
+    CharArray:charArray:Char
 
 class $TTest {
     //region isEqualTo

--- a/buildSrc/src/main/kotlin/TemplateTask.kt
+++ b/buildSrc/src/main/kotlin/TemplateTask.kt
@@ -100,4 +100,4 @@ abstract class TemplateTask : DefaultTask() {
     }
 }
 
-private fun List<String>.cleanup(): List<String> = map { it.trim() }.filter { it.isNotEmpty() }
+private fun List<String>.cleanup(): List<String> = map { it.trim() }


### PR DESCRIPTION
These are still experimental and so an annotation propagating that is added to the codegen for these types only.

I've modified the `TemplateTask` to support multiline declarations. I did it in a separate commit since it's technically orthogonal to the unsigned change.