### PR TITLE
Configure languageVersion via toolchain

### DIFF
--- a/buildSrc/src/main/kotlin/assertk.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/assertk.multiplatform.gradle.kts
@@ -1,7 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import org.gradle.accessors.dm.LibrariesForLibs
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 
 plugins {
@@ -73,13 +71,8 @@ kotlin {
     }
 }
 
-tasks.withType<KotlinJvmCompile> {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
-}
-
-tasks.withType<JavaCompile> {
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(8))
 }
 
 // Run only the native tests

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
+}
+
 rootProject.name = "assertk-project"
 
 //includeBuild("build-src")


### PR DESCRIPTION
Follow up #439.

https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support