### PR TITLE
Add implicit task dependency workaround

### DIFF
--- a/buildSrc/src/main/kotlin/assertk.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/assertk.publish.gradle.kts
@@ -91,3 +91,8 @@ signing {
     }
     publishing.publications.all { sign(this) }
 }
+
+// TODO: remove after https://youtrack.jetbrains.com/issue/KT-46466 is fixed
+project.tasks.withType(AbstractPublishToMaven::class.java).configureEach {
+    dependsOn(project.tasks.withType(Sign::class.java))
+}


### PR DESCRIPTION
This works around a Kotlin multiplatform publishing bug.

See https://youtrack.jetbrains.com/issue/KT-46466

Refs #443 