### PR TITLE
Add 'containsMatch' assertion for CharSequence

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assertions/charsequence.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/charsequence.kt
@@ -144,3 +144,11 @@ fun Assert<CharSequence>.matches(regex: Regex) = given { actual ->
     if (actual.matches(regex)) return
     expected("to match:${show(regex)} but was:${show(actual)}")
 }
+
+/**
+ * Asserts the char sequence contains a match of the regular expression.
+ */
+fun Assert<CharSequence>.containsMatch(regex: Regex) = given { actual ->
+    if (regex.containsMatchIn(actual)) return
+    expected("to contain match:${show(regex)} but was:${show(actual)}")
+}

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/CharSequenceTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/CharSequenceTest.kt
@@ -270,4 +270,18 @@ class CharSequenceTest {
         assertEquals("expected to match:${show(regex)} but was:<\"12345\">", error.message)
     }
     //endregion
+
+    //region contains match
+    @Test fun contains_match_matching_value_passes() {
+        assertThat("abc1234xyz").containsMatch(Regex("\\d\\d\\d\\d"))
+    }
+
+    @Test fun contains_match_not_matching_value_fails() {
+        val regex = Regex("\\d\\d\\d\\d")
+        val error = assertFailsWith<AssertionError> {
+            assertThat("abc123xyz").containsMatch(regex)
+        }
+        assertEquals("expected to contain match:${show(regex)} but was:<\"abc123xyz\">", error.message)
+    }
+    //endregion
 }


### PR DESCRIPTION
Unlike 'contains' this is a regex rather than a literal. Unlike 'matches' this looks for a subset of the charsequence to match rather than the entire contents.

Closes #452 