### PR TITLE
Set the Java and Kotlin bytecode targets

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 plugins {
     `kotlin-dsl`
 }
@@ -8,4 +11,13 @@ dependencies {
     implementation(libs.kotlin.gradle)
     // hack to access version catalogue https://github.com/gradle/gradle/issues/15383
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
+}
+
+tasks.withType<KotlinJvmCompile> {
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
 }


### PR DESCRIPTION
Otherwise the running JDK version is used, which is sometimes unsupported (e.g., today with JDK 20).

This is copied from the convention plugin which applies to the normal modules, but it also needs to happen in the `buildSrc` which is a separate Gradle build.

Today, with JDK 20, you get:
```
> Task :buildSrc:compileKotlin FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':buildSrc:compileKotlin'.
> Error while evaluating property 'compilerOptions.jvmTarget' of task ':buildSrc:compileKotlin'.
   > Failed to calculate the value of property 'jvmTarget'.
      > Unknown Kotlin JVM target: 20

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

...

Caused by: java.lang.IllegalArgumentException: Unknown Kotlin JVM target: 20
        at org.jetbrains.kotlin.gradle.dsl.JvmTarget$Companion.fromTarget(JvmTarget.kt:26)
        at org.jetbrains.kotlin.gradle.tasks.DefaultKotlinJavaToolchain$wireJvmTargetToToolchain$1$1.invoke(DefaultKotlinJavaToolchain.kt:78)
        at org.jetbrains.kotlin.gradle.tasks.DefaultKotlinJavaToolchain$wireJvmTargetToToolchain$1$1.invoke(DefaultKotlinJavaToolchain.kt:70)
        at org.jetbrains.kotlin.gradle.tasks.DefaultKotlinJavaToolchain$sam$org_gradle_api_Transformer$0.transform(DefaultKotlinJavaToolchain.kt)
        at org.gradle.api.internal.provider.ValueSupplier$Present.transform(ValueSupplier.java:541)
        at org.gradle.api.internal.provider.TransformBackedProvider.mapValue(TransformBackedProvider.java:91)
        at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:83)
        at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:108)
        at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:82)
        at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:108)
        at org.gradle.api.internal.provider.AbstractMinimalProvider.withFinalValue(AbstractMinimalProvider.java:164)
        at org.gradle.api.internal.provider.DefaultProperty.finalValue(DefaultProperty.java:133)
        at org.gradle.api.internal.provider.DefaultProperty.finalValue(DefaultProperty.java:26)
        at org.gradle.api.internal.provider.AbstractProperty.finalizeNow(AbstractProperty.java:245)
        ... 75 more
```