### PR TITLE
Simplify generics of `isInstanceOf`

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assertions/any.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/any.kt
@@ -204,10 +204,10 @@ fun <T : Any> Assert<T>.isNotInstanceOf(kclass: KClass<out T>) = given { actual 
  * @see [isNotInstanceOf]
  * @see [hasClass]
  */
-fun <T : Any, S : T> Assert<T>.isInstanceOf(kclass: KClass<S>): Assert<S> = transform(name) { actual ->
+fun <T : Any> Assert<Any>.isInstanceOf(kclass: KClass<T>): Assert<T> = transform(name) { actual ->
     if (kclass.isInstance(actual)) {
         @Suppress("UNCHECKED_CAST")
-        actual as S
+        actual as T
     } else {
         expected("to be instance of:${show(kclass)} but had class:${show(actual::class)}")
     }


### PR DESCRIPTION
`S` is only used to limit the receiver which means we can replace it with its bound (`Any`) and let the `out` variance support any subtype (such as `Assert<String>`) remain valid.

As far as I can tell this second generic was introduced as part of b817dc3c8b7915b3bbb147a4d82144dd377a478a, where `S` is actually used to hold an instance. But when the lambda was eventually removed the extra generic stuck around until today.