### PR TITLE
Attempt to propagate a source throwable as a cause

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/failure.kt
+++ b/assertk/src/commonMain/kotlin/assertk/failure.kt
@@ -4,6 +4,7 @@ import assertk.Failure.Companion.soft
 import com.willowtreeapps.opentest4k.AssertionFailedError
 import com.willowtreeapps.opentest4k.MultipleFailuresError
 import com.willowtreeapps.opentest4k.failures
+import kotlin.DeprecationLevel.HIDDEN
 
 /**
  * Assertions are run in a failure context which captures failures to report them.
@@ -139,17 +140,29 @@ fun fail(error: AssertionError): Nothing {
 
 internal val NONE: Any = Any()
 
+// TODO Delete this before 1.0.
+@Deprecated("For binary compatibility", level = HIDDEN)
+fun fail(message: String, expected: Any? = NONE, actual: Any? = NONE): Nothing {
+    fail(message, expected, actual, null)
+}
+
 /**
  * Fail the test with the given message.
  */
-fun fail(message: String, expected: Any? = NONE, actual: Any? = NONE): Nothing {
+fun fail(
+    message: String,
+    expected: Any? = NONE,
+    actual: Any? = NONE,
+    cause: Throwable? = null,
+): Nothing {
     if (expected === NONE && actual === NONE) {
-        throw AssertionFailedError(message)
+        throw AssertionFailedError(message, cause)
     } else {
         throw AssertionFailedError(
             message,
             if (expected === NONE) null else expected,
-            if (actual === NONE) null else actual
+            if (actual === NONE) null else actual,
+            cause,
         )
     }
 }

--- a/assertk/src/commonTest/kotlin/test/assertk/FailureTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/FailureTest.kt
@@ -1,5 +1,9 @@
 package test.assertk
 
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isFailure
+import assertk.assertions.isInstanceOf
 import assertk.fail
 import com.willowtreeapps.opentest4k.*
 import kotlin.test.*
@@ -16,6 +20,7 @@ class FailureTest {
         assertEquals("actual" as Any?, error.actual?.value)
         assertTrue(error.isExpectedDefined)
         assertTrue(error.isActualDefined)
+        assertNull(error.cause)
     }
 
     @Test fun fail_throws_assertion_failed_error_with_actual_and_expected_not_defined() {
@@ -27,5 +32,21 @@ class FailureTest {
         assertNull(error.actual)
         assertFalse(error.isExpectedDefined)
         assertFalse(error.isActualDefined)
+        assertNull(error.cause)
+    }
+
+    @Test fun fail_cause_nonnull() {
+        val cause = RuntimeException()
+        val error = assertFailsWith<AssertionFailedError> {
+            fail("message", cause = cause)
+        }
+        assertSame(cause, error.cause)
+    }
+
+    @Test fun fail_cause_null() {
+        val error = assertFailsWith<AssertionFailedError> {
+            fail("message", cause = null)
+        }
+        assertNull(error.cause)
     }
 }

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/support/SupportTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/support/SupportTest.kt
@@ -1,6 +1,11 @@
 package test.assertk.assertions.support
 
 import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.isSuccess
+import assertk.assertions.message
 import assertk.assertions.support.expected
 import assertk.assertions.support.fail
 import assertk.assertions.support.show
@@ -157,6 +162,7 @@ class SupportTest {
         assertEquals("actual" as Any?, error.actual?.value)
         assertTrue(error.isExpectedDefined)
         assertTrue(error.isActualDefined)
+        assertNull(error.cause)
     }
 
     @Test fun expected_throws_assertion_failed_error_with_actual_and_expected_not_defined() {
@@ -170,6 +176,56 @@ class SupportTest {
         assertNull(error.actual)
         assertFalse(error.isExpectedDefined)
         assertFalse(error.isActualDefined)
+        assertNull(error.cause)
+    }
+
+    @Test fun expected_throwable_included_as_cause() {
+        val subject = RuntimeException()
+        val error = assertFailsWith<AssertionFailedError> {
+            assertThat(subject).expected("message")
+        }
+        assertSame(subject, error.cause)
+    }
+
+    @Test fun expected_failure_result_included_as_cause() {
+        val subject = RuntimeException()
+        val error = assertFailsWith<AssertionFailedError> {
+            assertThat(Result.failure<String>(subject)).expected("message")
+        }
+        assertSame(subject, error.cause)
+    }
+
+    @Test fun expected_success_result_not_included_as_cause() {
+        val error = assertFailsWith<AssertionFailedError> {
+            assertThat(Result.success("hey")).expected("message")
+        }
+        assertNull(error.cause)
+    }
+
+    @Test fun expected_originating_throwable_included_as_cause() {
+        val subject = RuntimeException()
+        val assert = assertThat(subject).message()
+        val error = assertFailsWith<AssertionFailedError> {
+            assert.expected("message")
+        }
+        assertSame(subject, error.cause)
+    }
+
+    @Test fun expected_originating_failure_result_included_as_cause() {
+        val subject = RuntimeException()
+        val assert = assertThat(Result.failure<String>(subject)).isFailure().message()
+        val error = assertFailsWith<AssertionFailedError> {
+            assert.expected("message")
+        }
+        assertSame(subject, error.cause)
+    }
+
+    @Test fun expected_originating_success_result_not_included_as_cause() {
+        val assert = assertThat(Result.success("hey")).isSuccess()
+        val error = assertFailsWith<AssertionFailedError> {
+            assert.expected("message")
+        }
+        assertNull(error.cause)
     }
     //endregion
 }


### PR DESCRIPTION
This ensures that the full stacktrace can be seen to help identify the underlying source of a mismatch.

Consider the following two tests:
```kotlin
@Test fun demo1() {
  assertThat { someFunction() }
    .isFailure()
    .isInstanceOf(IllegalStateException::class)
}
@Test fun demo2() {
  assertThat { someFunction() }
    .isFailure()
    .hasMessage("failure!")
}
fun someFunction() {
  deepFunction()
}
fun deepFunction() {
  throw AssertionError("oh no!!!!!")
}
```
Demo 1's failure before:

    org.opentest4j.AssertionFailedError: expected to be instance of:<class java.lang.IllegalStateException> but had class:<class java.lang.AssertionError> (Failure(java.lang.AssertionError: oh no!!!!!))
    	at app//test.assertk.FailureTest.demo1(FailureTest.kt:56)
    	... 43 more

Demo 1's failure after:

    org.opentest4j.AssertionFailedError: expected to be instance of:<class java.lang.IllegalStateException> but had class:<class java.lang.AssertionError> (Failure(java.lang.AssertionError: oh no!!!!!))
    	at app//test.assertk.FailureTest.demo1(FailureTest.kt:56)
    	... 43 more
    Caused by: java.lang.AssertionError: oh no!!!!!
    	at test.assertk.FailureTest.deepFunction(FailureTest.kt:70)
    	at test.assertk.FailureTest.someFunction(FailureTest.kt:66)
    	at test.assertk.FailureTest.demo1(FailureTest.kt:54)
    	... 43 more

Demo 2's failure before:

    org.opentest4j.AssertionFailedError: expected [message]:<"[failure]!"> but was:<"[oh no!!!!]!"> (Failure(java.lang.AssertionError: oh no!!!!!))
    	at app//test.assertk.FailureTest.demo2(FailureTest.kt:61)
    	... 43 more

Demo 2's failure after:

    org.opentest4j.AssertionFailedError: expected [message]:<"[failure]!"> but was:<"[oh no!!!!]!"> (Failure(java.lang.AssertionError: oh no!!!!!))
    	at app//test.assertk.FailureTest.demo2(FailureTest.kt:62)
    	... 43 more
    Caused by: java.lang.AssertionError: oh no!!!!!
    	at test.assertk.FailureTest.deepFunction(FailureTest.kt:70)
    	at test.assertk.FailureTest.someFunction(FailureTest.kt:66)
    	at test.assertk.FailureTest.demo2(FailureTest.kt:60)
    	... 43 more

With the causes attached it's much easier to locate the source of the underlying problem.

Closes #456 