### PR TITLE
Add `assertFailure` entrypoint

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assert.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assert.kt
@@ -184,12 +184,22 @@ fun <T> Assert<T>.all(body: Assert<T>.() -> Unit) {
  *   throw Exception("error")
  * }.isFailure().hasMessage("error")
  * ```
+ *
+ * @see assertFailure
  */
-inline fun <T> assertThat(f: () -> T): Assert<Result<T>> = assertThat(Result.runCatching { f() })
+inline fun <T> assertThat(f: () -> T): Assert<Result<T>> = assertThat(runCatching(f))
 
 /**
  * Runs all assertions in the given lambda and reports any failures.
  */
 inline fun assertAll(f: () -> Unit) {
     Failure.soft().run { f() }
+}
+
+/**
+ * Asserts that the given block will throw an exception rather than complete successfully.
+ */
+fun assertFailure(f: () -> Unit): Assert<Throwable> {
+    runCatching(f).onFailure { return assertThat(it) }
+    fail("expected failure but lambda completed successfully")
 }

--- a/assertk/src/commonTest/kotlin/test/assertk/AssertFailureTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/AssertFailureTest.kt
@@ -1,0 +1,38 @@
+package test.assertk
+
+import assertk.assertFailure
+import assertk.assertions.isEqualTo
+import assertk.assertions.message
+import com.willowtreeapps.opentest4k.AssertionFailedError
+import test.assertk.assertions.valueOrFail
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class AssertFailureTest {
+
+    @Test fun failure_is_success() {
+        val expected = RuntimeException()
+        assertSame(expected, assertFailure { throw expected }.valueOrFail)
+    }
+
+    @Test fun failure_originating_subject_not_wrapped_in_result() {
+        val t = assertFailsWith<AssertionFailedError> {
+            assertFailure { throw RuntimeException("foo") }
+                .message()
+                .isEqualTo("bar")
+        }
+        assertTrue("RuntimeException" in t.message!!)
+        assertFalse("Failure(" in t.message!!)
+    }
+
+    @Test fun success_is_failure() {
+        val t = assertFailsWith<AssertionFailedError> {
+            assertFailure { }
+        }
+        assertEquals("expected failure but lambda completed successfully", t.message)
+    }
+}


### PR DESCRIPTION
This accepts a lambda which is expected to throw an exception which is wrapped into an `Assert<Throwable>`. Successful completion of the lambda block will result in a failure exception.

Closes #453. Pairs well with #460.