### PR TITLE
Make tests 20s faster

### DIFF
--- a/assertk/src/jvmTest/kotlin/test/assertk/JVMAssertLambdaTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/JVMAssertLambdaTest.kt
@@ -25,12 +25,12 @@ class JVMAssertLambdaTest {
     }
 
     private suspend fun asyncReturnValue(): Int {
-        delay(10000)
+        delay(10)
         return 1
     }
 
     private suspend fun asyncThrows() {
-        delay(10000)
+        delay(10)
         throw  Exception("test")
     }
 }


### PR DESCRIPTION
Any non-zero value will trigger suspension. Let's do 10 milliseconds instead of 10 seconds to save 20 seconds from wall clock time.