### PR TITLE
Remove lambda-accepting `assertThat` overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
+- Lambda-accepting `assertThat { }` entrypoint is now deprecated.
+  Use `assertThat(T)` for normal values or `assertFailure { }` for exception-throwing code.
 - Previous deprecations are now errors
 
 ### Added
+- Added `assertFailure { }` entrypoint which is a shorthand for `assertThat(runCatching { .. }).isFailure()`
 - Added `first` and `single` assertion for `Iterable`
 - Added sequence assertions to mirror iterable
 - Added array assertions for `UByteArray`, `UShortArray`, `UIntArray`, and `ULongArray`.

--- a/README.md
+++ b/README.md
@@ -165,20 +165,13 @@ assertThat(people)
 
 ### Exceptions
 
-If you expect an exception to be thrown, you can use the version of `assertThat` that takes a lambda.
+If you expect an exception to be thrown, you can use `assertFailure` which takes a lambda.
 
 ```kotlin
-assertThat {
+assertFailure {
     throw Exception("error")
-}.isFailure().hasMessage("wrong")
+}.hasMessage("wrong")
 // -> expected [message] to be:<["wrong"]> but was:<["error"]>
-```
-
-This method also allows you to assert on successfully returned values.
-
-```kotlin
-assertThat { 1 + 1 }.isSuccess().isNegative()
-// -> expected to be negative but was:<2>
 ```
 
 ### Table Assertions

--- a/assertk/src/commonMain/kotlin/assertk/assert.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assert.kt
@@ -187,7 +187,7 @@ fun <T> Assert<T>.all(body: Assert<T>.() -> Unit) {
  *
  * @see assertFailure
  */
-@Deprecated("Use assertThat or assertFailure", ReplaceWith("assertThat(runCatching(f))"))
+@Deprecated("Use assertThat(result) or assertFailure", ReplaceWith("assertThat(runCatching(f))"))
 inline fun <T> assertThat(f: () -> T): Assert<Result<T>> = assertThat(runCatching(f))
 
 /**

--- a/assertk/src/commonMain/kotlin/assertk/assert.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assert.kt
@@ -187,6 +187,7 @@ fun <T> Assert<T>.all(body: Assert<T>.() -> Unit) {
  *
  * @see assertFailure
  */
+@Deprecated("Use assertThat or assertFailure", ReplaceWith("assertThat(runCatching(f))"))
 inline fun <T> assertThat(f: () -> T): Assert<Result<T>> = assertThat(runCatching(f))
 
 /**

--- a/assertk/src/commonMain/kotlin/assertk/assertions/result.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/result.kt
@@ -6,10 +6,10 @@ import assertk.assertions.support.show
 import assertk.showError
 
 /**
- * Asserts the given [assertk.Result] successful returned a value, returning it's result if it did or failing if it didn't.
+ * Asserts the given [Result] successful returned a value, returning its result if it did or failing if it didn't.
  *
  * ```
- * assertThat { 1 + 1 }.isSuccess().isEqualTo(2)
+ * assertThat(runCatching { 1 + 1 }).isSuccess().isEqualTo(2)
  * ```
  */
 fun <T> Assert<Result<T>>.isSuccess(): Assert<T> = transform { actual ->
@@ -19,10 +19,10 @@ fun <T> Assert<Result<T>>.isSuccess(): Assert<T> = transform { actual ->
 }
 
 /**
- * Asserts the given [assertk.Result] threw an exception, returning that exception if it was or failing it if didn't.
+ * Asserts the given [Result] threw an exception, returning that exception if it was or failing it if didn't.
  *
  * ```
- * assertThat { throw Exception("error") }.isFailure().hasMessage("error")
+ * assertThat(runCatching { throw Exception("error") }).isFailure().hasMessage("error")
  * ```
  */
 fun <T> Assert<Result<T>>.isFailure(): Assert<Throwable> = transform { actual ->


### PR DESCRIPTION
Use `assertFailure` for always-failing things and `assertThat(value)` for always-successful or `Result`-returning things.

Closes #464