### PR TITLE
Fix the build on Windows

### DIFF
--- a/buildSrc/src/main/kotlin/TemplateTask.kt
+++ b/buildSrc/src/main/kotlin/TemplateTask.kt
@@ -61,6 +61,7 @@ abstract class TemplateTask : DefaultTask() {
 
     @TaskAction
     fun run() {
+        val lineSeparator = System.lineSeparator()
         val inDir = inputDir.get().asFile
         val outDir = outputDir.get().asFile
 
@@ -72,7 +73,7 @@ abstract class TemplateTask : DefaultTask() {
             val content = template.readText()
 
             val tokensStart = content.indexOf('$')
-            val tokensStop = content.indexOf("\n\n", startIndex = tokensStart)
+            val tokensStop = content.indexOf("$lineSeparator$lineSeparator", startIndex = tokensStart)
             val tokenLine = content.substring(tokensStart until tokensStop)
             val tokens = tokenLine.substringBefore('=').split(':').cleanup()
             val replacements = tokenLine.substringAfter('=')


### PR DESCRIPTION
The project had been failing to build on my Windows PC with the following rather cryptic exception:
Caused by: java.lang.StringIndexOutOfBoundsException: begin 324, end -1, length 5122

I tracked this down to use of hard-coded Unix-style line separator "\n" in TemplateTask.kt. Using the system's line separator corrected the problem.

I don't think this is likely to have any impact on non-Windows builds, as these templates are evidently dependent on the build platform, but releases already work on Windows, and clearly the build infrastructure is not Windows.