### PR TITLE
Rename isSameAs/isNotSameAs to isSameInstanceAs/isNotSameInstanceAs

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assertions/any.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/any.kt
@@ -28,7 +28,7 @@ fun Assert<Any>.hashCodeFun() = prop("hashCode", Any::hashCode)
 /**
  * Asserts the value is equal to the expected one, using `==`.
  * @see [isNotEqualTo]
- * @see [isSameAs]
+ * @see [isSameInstanceAs]
  */
 fun <T> Assert<T>.isEqualTo(expected: T) = given { actual ->
     if (actual == expected) return
@@ -38,7 +38,7 @@ fun <T> Assert<T>.isEqualTo(expected: T) = given { actual ->
 /**
  * Asserts the value is not equal to the expected one, using `!=`.
  * @see [isEqualTo]
- * @see [isNotSameAs]
+ * @see [isNotSameInstanceAs]
  */
 fun Assert<Any?>.isNotEqualTo(expected: Any?) = given { actual ->
     if (actual != expected) return
@@ -54,20 +54,36 @@ fun Assert<Any?>.isNotEqualTo(expected: Any?) = given { actual ->
 
 /**
  * Asserts the value is the same as the expected one, using `===`.
- * @see [isNotSameAs]
+ * @see [isNotSameInstanceAs]
  * @see [isEqualTo]
  */
-fun <T> Assert<T>.isSameAs(expected: T) = given { actual ->
+@Deprecated("renamed to isSameInstanceAs", replaceWith = ReplaceWith("isSameInstanceAs(expected)"))
+fun <T> Assert<T>.isSameAs(expected: T) = isSameInstanceAs(expected)
+
+/**
+ * Asserts the value is the same as the expected one, using `===`.
+ * @see [isNotSameInstanceAs]
+ * @see [isEqualTo]
+ */
+fun <T> Assert<T>.isSameInstanceAs(expected: T) = given { actual ->
     if (actual === expected) return
     expected(":${show(expected)} and:${show(actual)} to refer to the same object")
 }
 
 /**
  * Asserts the value is not the same as the expected one, using `!==`.
- * @see [isSameAs]
+ * @see [isSameInstanceAs]
  * @see [isNotEqualTo]
  */
-fun Assert<Any?>.isNotSameAs(expected: Any?) = given { actual ->
+@Deprecated("renamed to isNotSameInstanceAs", replaceWith = ReplaceWith("isNotSameInstanceAs(expected)"))
+fun Assert<Any?>.isNotSameAs(expected: Any?) = isNotSameInstanceAs(expected)
+
+/**
+ * Asserts the value is not the same as the expected one, using `!==`.
+ * @see [isSameInstanceAs]
+ * @see [isNotEqualTo]
+ */
+fun Assert<Any?>.isNotSameInstanceAs(expected: Any?) = given { actual ->
     if (actual !== expected) return
     expected(":${show(expected)} to not refer to the same object")
 }

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
@@ -62,26 +62,26 @@ class AnyTest {
         assertEquals("expected to not be equal to:<test>", error.message)
     }
 
-    @Test fun isSameAs_same_objects_passes() {
-        assertThat(subject).isSameAs(subject)
+    @Test fun isSameInstanceAs_same_objects_passes() {
+        assertThat(subject).isSameInstanceAs(subject)
     }
 
-    @Test fun isSameAs_different_objects_fails() {
+    @Test fun isSameInstanceAs_different_objects_fails() {
         val nonSame = BasicObject("test")
         val error = assertFails("") {
-            assertThat(subject).isSameAs(nonSame)
+            assertThat(subject).isSameInstanceAs(nonSame)
         }
         assertEquals("expected:<test> and:<test> to refer to the same object", error.message)
     }
 
-    @Test fun isNotSameAs_non_same_objects_passes() {
+    @Test fun isNotSameInstanceAs_non_same_objects_passes() {
         val nonSame = BasicObject("test")
-        assertThat(subject).isNotSameAs(nonSame)
+        assertThat(subject).isNotSameInstanceAs(nonSame)
     }
 
-    @Test fun isNotSameAs_same_objects_fails() {
+    @Test fun isNotSameInstanceAs_same_objects_fails() {
         val error = assertFailsWith<AssertionError> {
-            assertThat(subject).isNotSameAs(subject)
+            assertThat(subject).isNotSameInstanceAs(subject)
         }
         assertEquals("expected:<test> to not refer to the same object", error.message)
     }


### PR DESCRIPTION
This makes it more clear these functions are about instance identity see: https://truth.dev/comparison

#495 