### PR TITLE
add map assertion doesNotContainKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added `doesNotContainKey` assertion for `Map`
 
 ## [0.27.0] 2023-09-13
 

--- a/assertk/src/commonMain/kotlin/assertk/assertions/map.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/map.kt
@@ -116,6 +116,14 @@ fun <K, V> Assert<Map<K, V>>.doesNotContain(element: Pair<K, V>) {
 }
 
 /**
+ * Asserts the map does not contain the expected key.
+ */
+fun <K, V> Assert<Map<K, V>>.doesNotContainKey(key: K) = given {
+    if (!it.containsKey(key)) return
+    expected("to not contain key:${show(key)} but had value: ${show(it[key])}")
+}
+
+/**
  * Asserts the map does not contain any of the expected elements.
  * @see [containsAtLeast]
  */

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/MapTest.kt
@@ -42,6 +42,18 @@ class MapTest {
         }
         assertEquals("expected to not contain:<{\"two\"=2}> but was:<{\"one\"=1, \"two\"=2}>", error.message)
     }
+
+    @Test fun doesNotContainKey_key_missing_passes() {
+        assertThat(emptyMap<String, Int>()).doesNotContainKey("one")
+    }
+
+    @Test fun doesNotContainKey_key_present_fails() {
+        val error = assertFailsWith<AssertionError> {
+            assertThat(mapOf("one" to 1)).doesNotContainKey("one")
+        }
+        assertEquals("expected to not contain key:<\"one\"> but had value: <1>", error.message)
+    }
+
     //endregion
 
     //region containsNone


### PR DESCRIPTION
Just adding a convenience assertion `Map::doesNotContainKey`. While existing assertions on `Map` can achieve the same functionality, having to pass an arbitrary value in addition to the key to be checked is overhead this PR endeavors to eliminate.