### PR TITLE
prioritize exceptions thrown directly in soft assertion blocks

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/failure.kt
+++ b/assertk/src/commonMain/kotlin/assertk/failure.kt
@@ -25,7 +25,7 @@ internal object FailureContext {
     }
 
     fun fail(error: Throwable) {
-        if (error.isOutOfMemory()) throw error
+        if (error.isFatal()) throw error
         failureRef.value.last().fail(error)
     }
 }
@@ -83,7 +83,7 @@ internal inline fun <F: Failure, T> F.run(f: F.() -> T): T {
     try {
         return f()
     } catch (e: Throwable) {
-        if (e.isOutOfMemory()) {
+        if (e.isFatal()) {
             throw e
         }
         otherException = e
@@ -189,7 +189,7 @@ fun notifyFailure(e: Throwable) {
 }
 
 @PublishedApi
-internal expect inline fun Throwable.isOutOfMemory(): Boolean
+internal expect inline fun Throwable.isFatal(): Boolean
 
 internal expect inline fun failWithNotInStacktrace(error: Throwable): Nothing
 

--- a/assertk/src/commonTest/kotlin/test/assertk/AssertAllTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/AssertAllTest.kt
@@ -1,11 +1,19 @@
 package test.assertk
 
-import assertk.*
-import assertk.assertions.*
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.endsWith
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.isSuccess
+import assertk.assertions.startsWith
 import assertk.assertions.support.show
+import assertk.fail
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class AssertAllTest {
@@ -44,6 +52,16 @@ class AssertAllTest {
             """.trimMargin().lines(),
             error.message!!.lines()
         )
+    }
+
+    @Test fun all_prioritizes_exceptions_thrown_in_block_over_soft_assertions() {
+        val error = assertFailsWith<IllegalStateException> {
+            assertThat(1).all {
+                isEqualTo(2)
+                throw IllegalStateException("Test")
+            }
+        }
+        assertEquals("Test", error.message)
     }
     //endregion
 
@@ -144,6 +162,17 @@ class AssertAllTest {
         assertTrue(error.message!!.contains("\t${opentestPackageName}AssertionFailedError: expected success but was failure:${show(Exception("error1"))}"))
         assertTrue(error.message!!.contains("\t${opentestPackageName}AssertionFailedError: expected success but was failure:${show(Exception("error2"))}"))
     }
-    //endregion
 
+    @Test
+    fun assertAll_prioritizes_exceptions_thrown_in_block_over_soft_assertions() {
+        val error = assertFailsWith<IllegalStateException> {
+            assertAll {
+                assertThat(1).isEqualTo(2)
+                throw IllegalStateException("Test")
+            }
+        }
+        assertEquals("Test", error.message)
+        assertIs<AssertionError>(error.suppressedExceptions.first())
+    }
+    //endregion
 }

--- a/assertk/src/jsMain/kotlin/assertk/failure.kt
+++ b/assertk/src/jsMain/kotlin/assertk/failure.kt
@@ -7,4 +7,4 @@ internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
 }
 
 @PublishedApi
-internal actual inline fun Throwable.isOutOfMemory(): Boolean = false
+internal actual inline fun Throwable.isFatal(): Boolean = false

--- a/assertk/src/jsMain/kotlin/assertk/failure.kt
+++ b/assertk/src/jsMain/kotlin/assertk/failure.kt
@@ -6,8 +6,5 @@ internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
     throw error
 }
 
-internal actual inline fun Throwable.addSuppressed(error: Throwable) {
-    // ignore
-}
-
+@PublishedApi
 internal actual inline fun Throwable.isOutOfMemory(): Boolean = false

--- a/assertk/src/jvmMain/kotlin/assertk/failure.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/failure.kt
@@ -12,9 +12,5 @@ internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
     throw error
 }
 
-@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-internal actual inline fun Throwable.addSuppressed(error: Throwable) {
-    throw NotImplementedError()
-}
-
+@PublishedApi
 internal actual inline fun Throwable.isOutOfMemory(): Boolean = this is OutOfMemoryError

--- a/assertk/src/jvmMain/kotlin/assertk/failure.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/failure.kt
@@ -5,12 +5,14 @@ package assertk
 
 internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
     val filtered = error.stackTrace
-            .dropWhile { it.className.startsWith("assertk") }
-            .toTypedArray()
+        .dropWhile { it.className.startsWith("assertk") }
+        .toTypedArray()
     @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UnsafeCast")
     error.stackTrace = filtered
     throw error
 }
 
 @PublishedApi
-internal actual inline fun Throwable.isOutOfMemory(): Boolean = this is OutOfMemoryError
+internal actual inline fun Throwable.isFatal(): Boolean =
+    // https://github.com/ReactiveX/RxJava/blob/6a44e5d0543a48f1c378dc833a155f3f71333bc2/src/main/java/io/reactivex/exceptions/Exceptions.java#L66
+    this is VirtualMachineError || this is ThreadDeath || this is LinkageError

--- a/assertk/src/jvmTest/kotlin/test/assertk/JVMAssertAllTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/JVMAssertAllTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 
 class JVMAssertAllTest {
-    @Test fun assert_all_is_thread_safe() {
+    @Test fun assertAll_is_thread_safe() {
         runOnMultipleThreads {
             assertAll {
                 assertThat("one").isEqualTo("one")
@@ -30,7 +30,7 @@ class JVMAssertAllTest {
         }
     }
 
-    @Test fun assert_all_includes_exceptions_as_suppressed() {
+    @Test fun assertAll_includes_exceptions_as_suppressed() {
         val error = assertFailsWith<AssertionError> {
             assertAll {
                 assertThat(1).isEqualTo(2)
@@ -42,7 +42,15 @@ class JVMAssertAllTest {
         assertEquals("expected:<[1]> but was:<[2]>", error.suppressed[1].message)
     }
 
-    @Test fun assert_all_does_not_catch_out_of_memory_errors() {
+    @Test fun assertAll_does_not_catch_out_of_memory_errors() {
+        assertFailsWith<OutOfMemoryError> {
+            assertAll {
+                throw OutOfMemoryError()
+            }
+        }
+    }
+
+    @Test fun assertAll_does_not_catch_out_of_memory_errors_in_nested_assert() {
         var runs = false
         assertFailsWith<OutOfMemoryError> {
             assertAll {

--- a/assertk/src/nativeMain/kotlin/assertk/failure.kt
+++ b/assertk/src/nativeMain/kotlin/assertk/failure.kt
@@ -6,8 +6,5 @@ internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
     throw error
 }
 
-internal actual inline fun Throwable.addSuppressed(error: Throwable) {
-    // ignore
-}
-
+@PublishedApi
 internal actual inline fun Throwable.isOutOfMemory(): Boolean = this is OutOfMemoryError

--- a/assertk/src/nativeMain/kotlin/assertk/failure.kt
+++ b/assertk/src/nativeMain/kotlin/assertk/failure.kt
@@ -7,4 +7,4 @@ internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
 }
 
 @PublishedApi
-internal actual inline fun Throwable.isOutOfMemory(): Boolean = this is OutOfMemoryError
+internal actual inline fun Throwable.isFatal(): Boolean = this is OutOfMemoryError

--- a/assertk/src/nativeTest/kotlin/test/assertk/NativeAssertAllTest.kt
+++ b/assertk/src/nativeTest/kotlin/test/assertk/NativeAssertAllTest.kt
@@ -8,9 +8,11 @@ import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
 import kotlin.native.concurrent.Worker
 import kotlin.native.concurrent.Future
+import kotlin.native.concurrent.ObsoleteWorkersApi
 import kotlin.native.concurrent.TransferMode
 import kotlin.test.*
 
+@ObsoleteWorkersApi
 class NativeAssertAllTest {
 
     @Test fun assert_all_is_thread_safe() {
@@ -35,7 +37,15 @@ class NativeAssertAllTest {
         }
     }
 
-    @Test fun assert_all_does_not_catch_out_of_memory_errors() {
+    @Test fun assertAll_does_not_catch_out_of_memory_errors() {
+        assertFailsWith<OutOfMemoryError> {
+            assertAll {
+                throw OutOfMemoryError()
+            }
+        }
+    }
+
+    @Test fun assertAll_does_not_catch_out_of_memory_errors_in_nested_assert() {
         var runs = false
         assertFailsWith<OutOfMemoryError> {
             assertAll {

--- a/assertk/src/wasmJsMain/kotlin/assertk/failure.kt
+++ b/assertk/src/wasmJsMain/kotlin/assertk/failure.kt
@@ -7,4 +7,4 @@ internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
 }
 
 @PublishedApi
-internal actual inline fun Throwable.isOutOfMemory(): Boolean = false
+internal actual inline fun Throwable.isFatal(): Boolean = false

--- a/assertk/src/wasmJsMain/kotlin/assertk/failure.kt
+++ b/assertk/src/wasmJsMain/kotlin/assertk/failure.kt
@@ -6,8 +6,5 @@ internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
     throw error
 }
 
-internal actual inline fun Throwable.addSuppressed(error: Throwable) {
-    // ignore
-}
-
+@PublishedApi
 internal actual inline fun Throwable.isOutOfMemory(): Boolean = false


### PR DESCRIPTION
If you had
```kotlin
assertAll {
  assertThat(1).isEqualTo(2)
  throw IllegalStateException("Broken!")
}
```
the `IllegalStateException` would be swallowed. It'll now be the primary exception you see. This more closely matches the mental model where soft assertions are thrown at the end of the block.

For convenience the assertion failure is added as a suppressed exception. Kotlin has mixed support for this (jvm shows the suppressed exception trace and error message, native just shows the trace, and js doesn't show it at all). This is acceptable as the inline exception is likely the one you care about fixing anyway.

Fixes #475