### PR TITLE
Fix code samples in KDoc comments

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assertions/iterable.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/iterable.kt
@@ -224,7 +224,7 @@ fun <E> Assert<Iterable<E>>.none(f: (Assert<E>) -> Unit) =
  * The given lambda will be run for each item.
  *
  * ```
- * assert(listOf(-1, 1, 2)).atLeast(2) { it.isPositive() }
+ * assertThat(listOf(-1, 1, 2)).atLeast(2) { it.isPositive() }
  * ```
  */
 fun <E, T : Iterable<E>> Assert<T>.atLeast(times: Int, f: (Assert<E>) -> Unit) =
@@ -239,7 +239,7 @@ fun <E, T : Iterable<E>> Assert<T>.atLeast(times: Int, f: (Assert<E>) -> Unit) =
  * The given lambda will be run for each item.
  *
  * ```
- * assert(listOf(-2, -1, 1)).atMost(2) { it.isPositive() }
+ * assertThat(listOf(-2, -1, 1)).atMost(2) { it.isPositive() }
  * ```
  */
 fun <E, T : Iterable<E>> Assert<T>.atMost(times: Int, f: (Assert<E>) -> Unit) =
@@ -254,7 +254,7 @@ fun <E, T : Iterable<E>> Assert<T>.atMost(times: Int, f: (Assert<E>) -> Unit) =
  * The given lambda will be run for each item.
  *
  * ```
- * assert(listOf(-1, 1, 2)).exactly(2) { it.isPositive() }
+ * assertThat(listOf(-1, 1, 2)).exactly(2) { it.isPositive() }
  * ```
  */
 fun <E, T : Iterable<E>> Assert<T>.exactly(times: Int, f: (Assert<E>) -> Unit) =
@@ -269,7 +269,7 @@ fun <E, T : Iterable<E>> Assert<T>.exactly(times: Int, f: (Assert<E>) -> Unit) =
  * The given lambda will be run for each item.
  *
  * ```
- * assert(listOf(-1, -2, 1)).any { it.isPositive() }
+ * assertThat(listOf(-1, -2, 1)).any { it.isPositive() }
  * ```
  */
 fun <E, T : Iterable<E>> Assert<T>.any(f: (Assert<E>) -> Unit) =

--- a/assertk/src/commonMain/kotlin/assertk/assertions/predicate.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/predicate.kt
@@ -8,7 +8,7 @@ import assertk.assertions.support.expected
  *
  * ```
  * val divisibleBy5 : (Int) -> Boolean = { it % 5 == 0 }
- * assert(10).matchesPredicate(divisibleBy5)
+ * assertThat(10).matchesPredicate(divisibleBy5)
  * ```
  */
 fun <T> Assert<T>.matchesPredicate(f: (T) -> Boolean) = given { actual ->

--- a/assertk/src/commonMain/kotlin/assertk/assertions/sequence.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/sequence.kt
@@ -245,7 +245,7 @@ fun <E> Assert<Sequence<E>>.none(f: (Assert<E>) -> Unit) =
  * The given lambda will be run for each item.
  *
  * ```
- * assert(sequenceOf(-1, 1, 2)).atLeast(2) { it.isPositive() }
+ * assertThat(sequenceOf(-1, 1, 2)).atLeast(2) { it.isPositive() }
  * ```
  */
 fun <E, T : Sequence<E>> Assert<T>.atLeast(times: Int, f: (Assert<E>) -> Unit) =
@@ -260,7 +260,7 @@ fun <E, T : Sequence<E>> Assert<T>.atLeast(times: Int, f: (Assert<E>) -> Unit) =
  * The given lambda will be run for each item.
  *
  * ```
- * assert(sequenceOf(-2, -1, 1)).atMost(2) { it.isPositive() }
+ * assertThat(sequenceOf(-2, -1, 1)).atMost(2) { it.isPositive() }
  * ```
  */
 fun <E, T : Sequence<E>> Assert<T>.atMost(times: Int, f: (Assert<E>) -> Unit) =
@@ -275,7 +275,7 @@ fun <E, T : Sequence<E>> Assert<T>.atMost(times: Int, f: (Assert<E>) -> Unit) =
  * The given lambda will be run for each item.
  *
  * ```
- * assert(sequenceOf(-1, 1, 2)).exactly(2) { it.isPositive() }
+ * assertThat(sequenceOf(-1, 1, 2)).exactly(2) { it.isPositive() }
  * ```
  */
 fun <E, T : Sequence<E>> Assert<T>.exactly(times: Int, f: (Assert<E>) -> Unit) =
@@ -290,7 +290,7 @@ fun <E, T : Sequence<E>> Assert<T>.exactly(times: Int, f: (Assert<E>) -> Unit) =
  * The given lambda will be run for each item.
  *
  * ```
- * assert(sequenceOf(-1, -2, 1)).any { it.isPositive() }
+ * assertThat(sequenceOf(-1, -2, 1)).any { it.isPositive() }
  * ```
  */
 fun <E, T : Sequence<E>> Assert<T>.any(f: (Assert<E>) -> Unit) =


### PR DESCRIPTION
In some places `assert()` was still used instead of `assertThat()`.