### PR TITLE
Adding new assertFailureWith

### DIFF
--- a/assertk/src/commonMain/kotlin/assertk/assert.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assert.kt
@@ -190,3 +190,17 @@ inline fun assertFailure(f: () -> Unit): Assert<Throwable> {
     }
     fail("expected failure but lambda completed successfully")
 }
+
+/**
+ * Asserts that the given block will throw an exception with expected type rather than complete successfully.
+ */
+inline fun <reified T: Throwable> assertFailureWith(f: () -> Unit): Assert<T> {
+    @Suppress("TooGenericExceptionCaught") // Intentionally capturing all exceptions.
+    try {
+        f()
+    } catch (t: Throwable) {
+        if (t !is T) fail("2expected failure to be type of ${T::class}")
+        return assertThat(t)
+    }
+    fail("expected failure but lambda completed successfully")
+}

--- a/assertk/src/commonMain/kotlin/assertk/assert.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assert.kt
@@ -199,7 +199,7 @@ inline fun <reified T: Throwable> assertFailureWith(f: () -> Unit): Assert<T> {
     try {
         f()
     } catch (t: Throwable) {
-        if (t !is T) fail("2expected failure to be type of ${T::class}")
+        if (t !is T) fail("expected failure to be type of ${T::class}")
         return assertThat(t)
     }
     fail("expected failure but lambda completed successfully")

--- a/assertk/src/commonMain/kotlin/assertk/assertions/throwable.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/throwable.kt
@@ -1,8 +1,8 @@
 package assertk.assertions
 
 import assertk.Assert
-import assertk.ValueAssert
 import assertk.all
+import kotlin.reflect.KProperty1
 
 /**
  * Returns an assert on the throwable's message.
@@ -59,6 +59,17 @@ fun Assert<Throwable>.hasRootCause(cause: Throwable) {
     rootCause().all {
         kClass().isEqualTo(cause::class)
         hasMessage(cause.message)
+    }
+}
+
+/**
+ * Asserts the throwable with a specific type have the expected properties for it.
+ */
+fun <T: Throwable> Assert<T>.hasProperties(vararg pairs: Pair<KProperty1<T, Any>, Any>) {
+    all {
+        pairs.forEach {
+            prop(it.first).isEqualTo(it.second)
+        }
     }
 }
 


### PR DESCRIPTION
Adding the new `assertFailureWith` to assert exception with a specific type and verify properties of this type.