### PR TITLE
Add File `doesNotExist` assertion

### DIFF
--- a/assertk/src/jvmMain/kotlin/assertk/assertions/file.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/file.kt
@@ -47,6 +47,14 @@ fun Assert<File>.exists() = given { actual ->
 }
 
 /**
+ * Asserts the file does not exists.
+ */
+fun Assert<File>.doesNotExist() = given { actual ->
+    if (!actual.exists()) return
+    expected("not to exist")
+}
+
+/**
  * Asserts the file is a directory.
  * @see [isFile]
  */

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
@@ -10,6 +10,9 @@ class FileTest {
 
     val file = File.createTempFile("exists", "txt")
     val directory = Files.createTempDirectory("isDirectory").toFile()
+    val missing = File("/this/is/not/a/real/file/and/should/not/exist.txt").also {
+        assertFalse(it.exists())
+    }
 
     //region exists
     @Test
@@ -19,12 +22,25 @@ class FileTest {
 
     @Test
     fun exists_with_nonexistent_file_fails() {
-        val tempFile = File.createTempFile("exists", "txt")
-        tempFile.delete()
         val error = assertFailsWith<AssertionError> {
-            assertThat(tempFile).exists()
+            assertThat(missing).exists()
         }
         assertEquals("expected to exist", error.message)
+    }
+    //endregion
+
+    //region does not exist
+    @Test
+    fun doesNotExist_with_missing_file_passes() {
+        assertThat(missing).doesNotExist()
+    }
+
+    @Test
+    fun doesNotExist_with_nonexistent_file_fails() {
+        val error = assertFailsWith<AssertionError> {
+            assertThat(file).doesNotExist()
+        }
+        assertEquals("expected not to exist", error.message)
     }
     //endregion
 


### PR DESCRIPTION
I know we're all waiting for #448 or #450 to utilize the existing (heh) `exists()` with some kind of negation, but I run into this missing assertion so much that I think it's probably safe enough to add for now.