### PR TITLE
Add Path `doesNotExist` assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - renamed `prop` to `having` as part of effort to unify API naming, old name is deprecated.
 - renamed `suspendCall` to `having` as part of effort to unify API naming, old name is deprecated.
+- added `doesNotExist` assertions to `Path`.
 
 ## [0.28.1] 2024-04-17
 

--- a/assertk/src/jvmMain/kotlin/assertk/assertions/path.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/path.kt
@@ -99,3 +99,15 @@ fun Assert<Path>.exists(vararg options: LinkOption) = given { actual ->
         expected("${show(actual)} to exist, but it does not")
     }
 }
+
+/**
+ * Assert that the path does not exists.
+ *
+ * @param options indicating how symbolic links are handled
+ */
+@Suppress("SpreadOperator") // https://github.com/arturbosch/detekt/issues/391
+fun Assert<Path>.doesNotExist(vararg options: LinkOption) = given { actual ->
+    if (!Files.notExists(actual, *options)) {
+        expected("${show(actual)} does not exist, but it exists")
+    }
+}

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/PathTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/PathTest.kt
@@ -1,26 +1,11 @@
 package test.assertk.assertions
 
 import assertk.assertThat
-import assertk.assertions.bytes
-import assertk.assertions.containsExactly
-import assertk.assertions.doesNotExist
-import assertk.assertions.exists
-import assertk.assertions.isDirectory
-import assertk.assertions.isHidden
-import assertk.assertions.isReadable
-import assertk.assertions.isRegularFile
-import assertk.assertions.isSameFileAs
-import assertk.assertions.isSymbolicLink
-import assertk.assertions.isWritable
-import assertk.assertions.lines
+import assertk.assertions.*
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import kotlin.test.*
 
 private var regularFile: Path? = null
 private var directory: Path? = null

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/PathTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/PathTest.kt
@@ -1,11 +1,26 @@
 package test.assertk.assertions
 
 import assertk.assertThat
-import assertk.assertions.*
+import assertk.assertions.bytes
+import assertk.assertions.containsExactly
+import assertk.assertions.doesNotExist
+import assertk.assertions.exists
+import assertk.assertions.isDirectory
+import assertk.assertions.isHidden
+import assertk.assertions.isReadable
+import assertk.assertions.isRegularFile
+import assertk.assertions.isSameFileAs
+import assertk.assertions.isSymbolicLink
+import assertk.assertions.isWritable
+import assertk.assertions.lines
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.test.*
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 private var regularFile: Path? = null
 private var directory: Path? = null
@@ -158,6 +173,29 @@ class PathTest {
             assertThat(doesNotExist!!).exists()
         }
         assertEquals("expected <$doesNotExist> to exist, but it does not", error.message)
+    }
+    //endregion
+
+    //region exists
+    @Test
+    fun doesNotExist_value_regularFile_fails() {
+        val error = assertFailsWith<AssertionError> {
+            assertThat(regularFile!!).doesNotExist()
+        }
+        assertEquals("expected <$regularFile> does not exist, but it exists", error.message)
+    }
+
+    @Test
+    fun doesNotExist_value_directory_fails() {
+        val error = assertFailsWith<AssertionError> {
+            assertThat(directory!!).doesNotExist()
+        }
+        assertEquals("expected <$directory> does not exist, but it exists", error.message)
+    }
+
+    @Test
+    fun doesNotExist_value_not_exists_passes() {
+        assertThat(doesNotExist!!).doesNotExist()
     }
     //endregion
 


### PR DESCRIPTION
`Assert<Path>.exists()` exists, but its negation, `Assert<Path>.doesNotExist()`, does not. Add `doesNotExist()` to Path for clean negation assertions.