### PR TITLE
Update CI to m1 resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
   build-macos:
     macos:
       xcode: "14.1.0"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     <<: *defaults
     steps:
       - checkout


### PR DESCRIPTION
Modify the resource on mac os according to [this](https://github.com/willowtreeapps/assertk/pull/542#pullrequestreview-2166894935) comment.

However, I've never used the Circle CI, so it might be the wrong fix. If that's the case, feel free to close this PR.