### PR TITLE
Use testImplementation instead of testCompile

### DIFF
--- a/assertk-coroutines/README.md
+++ b/assertk-coroutines/README.md
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile("com.willowtreeapps.assertk:assertk-coroutines:0.28.0")
+  testImplementation("com.willowtreeapps.assertk:assertk-coroutines:0.28.0")
 }
 ```
 


### PR DESCRIPTION
The `testCompile` configuration has been deprecated for dependency declaration.