### PR TITLE
Fix `isDataClassEqualTo` not working with `data object`s

### DIFF
--- a/assertk/src/jvmMain/kotlin/assertk/assertions/any.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/any.kt
@@ -83,7 +83,7 @@ fun <T : Any> Assert<T>.isDataClassEqualTo(expected: T) = given { actual ->
 private fun <T> Assert<T>.isDataClassEqualToImpl(expected: T, kclass: KClass<*>?): Unit = given { actual ->
     if (actual == expected) return
     val compareProps = actual != null && expected != null
-    if (compareProps && kclass != null && kclass.isData) {
+    if (compareProps && kclass != null && kclass.isData && kclass.objectInstance == null) {
         for (memberProp in kclass.memberProperties) {
             @Suppress("UNCHECKED_CAST")
             val force = memberProp as KProperty1<T, Any?>

--- a/assertk/src/jvmMain/kotlin/assertk/assertions/any.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/any.kt
@@ -82,8 +82,8 @@ fun <T : Any> Assert<T>.isDataClassEqualTo(expected: T) = given { actual ->
 
 private fun <T> Assert<T>.isDataClassEqualToImpl(expected: T, kclass: KClass<*>?): Unit = given { actual ->
     if (actual == expected) return
-    val compareProps = actual != null && expected != null
-    if (compareProps && kclass != null && kclass.isData && kclass.objectInstance == null) {
+    val compareProps = actual != null && expected?.let { it::class } == kclass
+    if (compareProps && kclass != null && kclass.isData) {
         for (memberProp in kclass.memberProperties) {
             @Suppress("UNCHECKED_CAST")
             val force = memberProp as KProperty1<T, Any?>

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -112,6 +112,11 @@ class JavaAnyTest {
     }
 
     @Test
+    fun isDataClassEqualTo_equal_data_objects_passes() {
+        assertThat(DataObject).isDataClassEqualTo(DataObject)
+    }
+
+    @Test
     fun isDataClassEqualTo_reports_all_properties_that_differ_on_failure() {
         val error = assertFailsWith<AssertionError> {
             assertThat(DataClass(InnerDataClass("test"), 1, 'a'))
@@ -150,6 +155,17 @@ class JavaAnyTest {
             |${"\t"}${opentestPackageName}AssertionFailedError: expected [one]:<null> but was:<InnerDataClass(inner=test)> (DataClass(one=InnerDataClass(inner=test), two=1, three=a))
             |${"\t"}${opentestPackageName}AssertionFailedError: expected [three]:<'[b]'> but was:<'[a]'> (DataClass(one=InnerDataClass(inner=test), two=1, three=a))
         """.trimMargin().lines(), error.message!!.lines()
+        )
+    }
+
+    @Test
+    fun isDataClassEqualTo_fails_different_data_objects() {
+        val error = assertFailsWith<AssertionError> {
+            assertThat(DataObject).isDataClassEqualTo(OtherDataObject)
+        }
+        assertEquals(
+            "expected:<[Other]DataObject> but was:<[]DataObject>"
+                .lines(), error.message!!.lines()
         )
     }
     //endregion
@@ -217,5 +233,9 @@ class JavaAnyTest {
     data class DataClass(val one: InnerDataClass?, val two: Int, val three: Char)
 
     data class InnerDataClass(val inner: String)
+
+    data object DataObject
+
+    data object OtherDataObject
 }
 


### PR DESCRIPTION
This fixes #551 by going right to `isEqualTo` if the passed value is a `data object`.