### PR TITLE
Force `isIn` and `isNotIn` callers to specify at least two elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - renamed `suspendCall` to `having` as part of effort to unify API naming, old name is deprecated.
 - added `doesNotExist` assertions to `Path`.
 - the receiver types for `isTrue()`, `isFalse()`, and `isInstanceOf()` have been widened to operate on nullable values.
+- signature of `isIn` and `isNotIn` has been changed to ensure at least two items are supplied.
 - added assertions `isIn(Iterable<T>)` and `isNotIn(Iterable<T>)`
 
 ## [0.28.1] 2024-04-17

--- a/assertk/src/commonMain/kotlin/assertk/assertions/any.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/any.kt
@@ -92,9 +92,30 @@ fun Assert<Any?>.isNotSameInstanceAs(expected: Any?) = given { actual ->
  * Asserts the value is in the expected values, using `in`.
  * @see [isNotIn]
  */
+fun <T> Assert<T>.isIn(first: T, second: T, vararg rest: T) = given { actual ->
+    val values = listOf(first, second, *rest)
+    if (actual in values) return
+    expected(":${show(values)} to contain:${show(actual)}")
+}
+
+@Deprecated("For binary compatibility", level = DeprecationLevel.HIDDEN)
 fun <T> Assert<T>.isIn(vararg values: T) = given { actual ->
     if (actual in values) return
     expected(":${show(values)} to contain:${show(actual)}")
+}
+
+@Deprecated("isIn with no values always fails", level = DeprecationLevel.ERROR)
+fun <T> Assert<T>.isIn() {
+    throw AssertionError() // Cannot be called.
+}
+
+@Deprecated(
+    "Use isEqualTo instead of isIn with a singed value",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("isEqualTo(first)", "assertk.assertions.isEqualTo"),
+)
+fun <T> Assert<T>.isIn(first: T) {
+    throw AssertionError() // Cannot be called.
 }
 
 /**
@@ -110,9 +131,30 @@ fun <T> Assert<T>.isIn(values: Iterable<T>) = given { actual ->
  * Asserts the value is not in the expected values, using `!in`.
  * @see [isIn]
  */
+fun <T> Assert<T>.isNotIn(first: T, second: T, vararg rest: T) = given { actual ->
+    val values = listOf(first, second, *rest)
+    if (actual !in values) return
+    expected(":${show(values)} to not contain:${show(actual)}")
+}
+
+@Deprecated("For binary compatibility", level = DeprecationLevel.HIDDEN)
 fun <T> Assert<T>.isNotIn(vararg values: T) = given { actual ->
     if (actual !in values) return
     expected(":${show(values)} to not contain:${show(actual)}")
+}
+
+@Deprecated("isNotIn with no values always succeeds", level = DeprecationLevel.ERROR)
+fun <T> Assert<T>.isNotIn() {
+    throw AssertionError() // Cannot be called.
+}
+
+@Deprecated(
+    "Use isNotEqualTo instead of isNotIn with a singed value",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("isNotEqualTo(first)", "assertk.assertions.isNotEqualTo"),
+)
+fun <T> Assert<T>.isNotIn(first: T) {
+    throw AssertionError() // Cannot be called.
 }
 
 /**

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
@@ -121,22 +121,7 @@ class AnyTest {
     }
 
     @Test
-    fun isIn_one_equal_item_passes() {
-        val isIn = BasicObject("test")
-        assertThat(subject).isIn(isIn)
-    }
-
-    @Test
-    fun isIn_one_non_equal_item_fails() {
-        val isOut1 = BasicObject("not test1")
-        val error = assertFailsWith<AssertionError> {
-            assertThat(subject).isIn(isOut1)
-        }
-        assertEquals("expected:<[not test1]> to contain:<test>", error.message)
-    }
-
-    @Test
-    fun isIn_one_equal_item_in_may_passes() {
+    fun isIn_one_equal_item_in_many_passes() {
         val isOut1 = BasicObject("not test1")
         val isIn = BasicObject("test")
         val isOut2 = BasicObject("not test2")
@@ -144,7 +129,7 @@ class AnyTest {
     }
 
     @Test
-    fun isIn_no_equal_items_in_may_fails() {
+    fun isIn_no_equal_items_in_many_fails() {
         val isOut1 = BasicObject("not test1")
         val isOut2 = BasicObject("not test2")
         val error = assertFailsWith<AssertionError> {
@@ -181,21 +166,6 @@ class AnyTest {
             assertThat(subject).isIn(list)
         }
         assertEquals("expected:<[not test1, not test2]> to contain:<test>", error.message)
-    }
-
-    @Test
-    fun isNotIn_one_non_equal_item_passes() {
-        val isOut1 = BasicObject("not test1")
-        assertThat(subject).isNotIn(isOut1)
-    }
-
-    @Test
-    fun isNotIn_one_equal_item_fails() {
-        val isIn = BasicObject("test")
-        val error = assertFailsWith<AssertionError> {
-            assertThat(subject).isNotIn(isIn)
-        }
-        assertEquals("expected:<[test]> to not contain:<test>", error.message)
     }
 
     @Test


### PR DESCRIPTION
From discussions in #555 