### PR TITLE
Add `asAssert` extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Add `asAssert` extensions for simplifying `assertThat` usages.
+- Add `doesNotExist` assertions to `File` and `Path`.
+- Add assertions `isIn(Iterable<T>)` and `isNotIn(Iterable<T>)`
 
 ### Changed
 - renamed `prop` to `having` as part of effort to unify API naming, old name is deprecated.
 - renamed `suspendCall` to `having` as part of effort to unify API naming, old name is deprecated.
-- added `doesNotExist` assertions to `Path`.
 - the receiver types for `isTrue()`, `isFalse()`, and `isInstanceOf()` have been widened to operate on nullable values.
 - signature of `isIn` and `isNotIn` has been changed to ensure at least two items are supplied.
-- added assertions `isIn(Iterable<T>)` and `isNotIn(Iterable<T>)`
 
 ## [0.28.1] 2024-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add `asAssert` extensions for simplifying `assertThat` usages.
+
 ### Changed
 - renamed `prop` to `having` as part of effort to unify API naming, old name is deprecated.
 - renamed `suspendCall` to `having` as part of effort to unify API naming, old name is deprecated.

--- a/assertk/src/commonMain/kotlin/assertk/assert.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assert.kt
@@ -121,6 +121,25 @@ fun <T> assertThat(
 )
 
 /**
+ * Asserts on this with an optional name.
+ *
+ * ```
+ * assertThis(name = "true").isTrue()
+ * ```
+ *
+ * @see [assertThat]
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun <T> T.asAssert(
+    name: String? = null,
+    noinline displayActual: (T) -> String = { display(it) }
+): Assert<T> = assertThat(
+    actual = this,
+    name = name,
+    displayActual = displayActual,
+)
+
+/**
  * Asserts on the given property reference using its name, if no explicit name is specified. This method
  * should be preferred in cases, where property references can be used, as it uses the property's name
  * for the assertion automatically. The name may optionally be overridden, if needed.
@@ -135,6 +154,26 @@ fun <T> assertThat(
  */
 fun <T> assertThat(getter: KProperty0<T>, name: String? = null): Assert<T> =
     assertThat(getter.get(), name ?: getter.name)
+
+
+/**
+ * Asserts on this reference using its name, if no explicit name is specified. This method
+ * should be preferred in cases, where property references can be used, as it uses the property's name
+ * for the assertion automatically. The name may optionally be overridden, if needed.
+ *
+ * ```
+ * data class Person(val name: String)
+ *
+ * val p = Person("Hugo")
+ *
+ * p::name.assertThis().contains("u")
+ * ```
+ * @see [assertThat]
+ */
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <T> KProperty0<T>.asAssert(name: String? = null): Assert<T> =
+    assertThat(getter = this, name = name)
 
 /**
  * All assertions in the given lambda are run.

--- a/assertk/src/commonMain/kotlin/assertk/assertions/support/support.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/support/support.kt
@@ -18,6 +18,7 @@ private fun prefix(wrap: String): String = if (wrap.length > 0) wrap[0].toString
 private fun suffix(wrap: String): String = if (wrap.length > 1) wrap[1].toString() else ""
 
 @Suppress("ComplexMethod")
+@PublishedApi
 internal fun display(value: Any?): String {
     return when (value) {
         null -> "null"

--- a/assertk/src/commonTest/kotlin/test/assertk/NameTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/NameTest.kt
@@ -1,6 +1,7 @@
 package test.assertk
 
 import assertk.assertThat
+import assertk.asAssert
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,18 +10,28 @@ import kotlin.test.assertFailsWith
 class NameTest {
     @Test
     fun with_no_name_fails_with_default_error_message() {
-        val error = assertFailsWith<AssertionError> {
+        val error1 = assertFailsWith<AssertionError> {
             assertThat("yes").isEqualTo("no")
         }
-        assertEquals("expected:<\"[no]\"> but was:<\"[yes]\">", error.message)
+        val error2 = assertFailsWith<AssertionError> {
+            "yes".asAssert().isEqualTo("no")
+        }
+        val expected = "expected:<\"[no]\"> but was:<\"[yes]\">"
+        assertEquals(expected, error1.message)
+        assertEquals(expected, error2.message)
     }
 
     @Test
     fun with_name_fails_with_name_prefixing_message() {
-        val error = assertFailsWith<AssertionError> {
+        val error1 = assertFailsWith<AssertionError> {
             assertThat("yes", name = "test").isEqualTo("no")
         }
-        assertEquals("expected [test]:<\"[no]\"> but was:<\"[yes]\">", error.message)
+        val error2 = assertFailsWith<AssertionError> {
+            "yes".asAssert(name = "test").isEqualTo("no")
+        }
+        val expected = "expected [test]:<\"[no]\"> but was:<\"[yes]\">"
+        assertEquals(expected, error1.message)
+        assertEquals(expected, error2.message)
     }
 
     @Test
@@ -29,10 +40,15 @@ class NameTest {
 
         val p = Person("Yoda")
 
-        val error = assertFailsWith<AssertionError> {
+        val error1 = assertFailsWith<AssertionError> {
             assertThat(p::name).isEqualTo("Darth")
         }
-        assertEquals("expected [name]:<\"[Darth]\"> but was:<\"[Yoda]\">", error.message)
+        val error2 = assertFailsWith<AssertionError> {
+            p::name.asAssert().isEqualTo("Darth")
+        }
+        val expected = "expected [name]:<\"[Darth]\"> but was:<\"[Yoda]\">"
+        assertEquals(expected, error1.message)
+        assertEquals(expected, error2.message)
     }
 
     @Test
@@ -41,9 +57,14 @@ class NameTest {
 
         val p = Person("Yoda")
 
-        val error = assertFailsWith<AssertionError> {
+        val error1 = assertFailsWith<AssertionError> {
             assertThat(p::name, "test").isEqualTo("Darth")
         }
-        assertEquals("expected [test]:<\"[Darth]\"> but was:<\"[Yoda]\">", error.message)
+        val error2 = assertFailsWith<AssertionError> {
+            p::name.asAssert("test").isEqualTo("Darth")
+        }
+        val expected = "expected [test]:<\"[Darth]\"> but was:<\"[Yoda]\">"
+        assertEquals(expected, error1.message)
+        assertEquals(expected, error2.message)
     }
 }


### PR DESCRIPTION
This is handy for simplifying things in https://github.com/GradleUp/shadow/blob/6c1920568d4c9c98ed5bb86ebf106a92ff63ef01/src/funcTest/groovy/com/github/jengelman/gradle/plugins/shadow/util/file/TestFile.java#L280-L298

to

```kt
  fun assertExists(): TestFile = apply {
      asAssert().exists()
  }
```