### PR TITLE
Add Assert<StateFlow>.value()

### DIFF
--- a/assertk-coroutines/src/commonMain/kotlin/assertk/coroutines/assertions/flow.kt
+++ b/assertk-coroutines/src/commonMain/kotlin/assertk/coroutines/assertions/flow.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.flow.*
 
 suspend fun Assert<Flow<*>>.count(): Assert<Int> = having("count()", Flow<*>::count)
 
+fun <T> Assert<StateFlow<T>>.havingValue() = having(StateFlow<T>::value)
+
 /**
  * Asserts the flow is empty. Fails as soon as the flow delivers an element.
  * @see isNotEmpty


### PR DESCRIPTION
I write this function in most projects I touch to avoid having to repeat the generic parameter name every time I reference the `value` kprop via `prop`/`having`.

Not essential, but a handy convenience for a core bit of the Flow APIs.