### PR TITLE
Check the Gradle distribution checksum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
It is generally a good idea to ensure the integrity of the Gradle distribution to prevent MITM attacks when downloading. (See https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification)

Keep in mind that this has to be updated alongside the distribution link.