### PR TITLE
Make isEqualToIgnoringGivenProperties accept subtype properties

### DIFF
--- a/assertk/src/jvmMain/kotlin/assertk/assertions/any.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/any.kt
@@ -97,13 +97,13 @@ private fun <T> Assert<T>.isDataClassEqualToImpl(expected: T, kclass: KClass<*>?
 /**
  * Returns an assert that compares all accessible properties except the given properties on the calling class.
  * @param other Other value to compare to
- * @param properties properties of the type with which been ignored
+ * @param properties properties of the type which will be ignored during comparison
  *
  * ```
  * assertThat(person).isEqualToIgnoringGivenProperties(other, Person::name, Person::age)
  * ```
  */
-fun <T : Any> Assert<T>.isEqualToIgnoringGivenProperties(other: T, vararg properties: KProperty1<T, Any?>) {
+fun <T : Any> Assert<T>.isEqualToIgnoringGivenProperties(other: T, vararg properties: KProperty1<out T, Any?>) {
     all {
         for (prop in other::class.memberProperties) {
             if (!properties.contains(prop)) {

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -207,6 +207,22 @@ class JavaAnyTest {
             BasicObject::failing
         )
     }
+
+    @Test
+    fun isEqualToIgnoringGivenProperties_passes_subclass() {
+        fun testObject(): TestObject {
+            return BasicObject(str = "Rarity")
+        }
+
+        assertThat(
+            testObject()
+        ).isEqualToIgnoringGivenProperties(
+            BasicObject(str = "notRarity"),
+            BasicObject::str,
+            BasicObject::other,
+            BasicObject::failing
+        )
+    }
     //endregion
 
     open class TestObject


### PR DESCRIPTION
This change makes the properties parameter covariant on T, which allows passing properties of subtypes of T, eliminating the need to cast the test subject to its runtime type to access its properties.